### PR TITLE
Use Undocumented Token for Trivy GHCR Auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,8 @@ jobs:
         output: trivy-results.sarif
         severity: 'CRITICAL,HIGH'
         timeout: '15m0s'
+      env:
+        ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload Trivy Scan Results to GitHub Security Tab
       uses: github/codeql-action/upload-sarif@294a9d92911152fe08befb9ec03e240add280cb3 # v3


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2368662097