### PR TITLE
Improve Transfer Process Status

### DIFF
--- a/.github/scripts/await-transfer.sh
+++ b/.github/scripts/await-transfer.sh
@@ -8,8 +8,8 @@ fi
 
 function printStatus() {
   phase="$(echo "${1}" | jq -r '.phase')"
-  sent="$(echo "${1}" | jq -r '.bundlesSentCount')"
-  skipped="$(echo "${1}" | jq -r '.bundlesSkippedCount')"
+  sent="$(echo "${1}" | jq -r '.sentBundles')"
+  skipped="$(echo "${1}" | jq -r '.skippedBundles')"
   printf "· %-14s transferred: %-5d skipped: %-5d\n" "${phase}" "${sent}" "${skipped}"
 }
 
@@ -21,6 +21,6 @@ done
 
 printStatus "${response}"
 
-if [ "$(echo "${response}" | jq -r '.phase')" == "ERROR" ]; then
+if [ "$(echo "${response}" | jq -r '.phase')" == "FATAL" ]; then
   exit 1
 fi

--- a/.github/scripts/check-status.sh
+++ b/.github/scripts/check-status.sh
@@ -13,5 +13,6 @@ status="$(curl -sf "${1}")"
 
 echo "Check Transfer Result Status"
 assert "phase" "$(echo "${status}" | jq -r .phase)" "COMPLETED"
-assert-ge "number of bundles sent" "$(echo "${status}" | jq -r .bundlesSentCount)" "$(jq -r .bundlesSentCount <"results/${2:-100}.json")"
-assert "number of patients skipped" "$(echo "${status}" | jq -r .bundlesSkippedCount)" "$(jq -r .bundlesSkippedCount <"results/${2:-100}.json")"
+echo "${status}"
+assert-ge "number of bundles sent" "$(echo "${status}" | jq -r .sentBundles)" "$(jq -r .sentBundles <"results/${2:-100}.json")"
+assert "number of patients skipped" "$(echo "${status}" | jq -r .skippedBundles)" "$(jq -r .skippedBundles <"results/${2:-100}.json")"

--- a/.github/test/results/100.json
+++ b/.github/test/results/100.json
@@ -1,6 +1,6 @@
 {
-  "bundlesSentCount": 100,
-  "bundlesSkippedCount": 0,
+  "sentBundles": 100,
+  "skippedBundles": 0,
   "count": {
     "total": 21,
     "Patient": 100,

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
@@ -7,14 +7,13 @@ import reactor.core.publisher.Mono;
 public interface TransferProcessRunner {
   String start(TransferProcessDefinition process, @NotNull List<String> pids);
 
-  Mono<Status> status(String processId);
-
-  record Status(String processId, Phase phase, long bundlesSentCount, long bundlesSkippedCount) {}
+  Mono<TransferProcessStatus> status(String processId);
 
   enum Phase {
     QUEUED,
     RUNNING,
     COMPLETED,
-    ERROR
+    COMPLETED_WITH_ERROR,
+    FATAL
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
@@ -1,0 +1,40 @@
+package care.smith.fts.cda;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PUBLIC;
+
+import care.smith.fts.cda.TransferProcessRunner.Phase;
+import lombok.With;
+
+public record TransferProcessStatus(
+    String processId,
+    @With(PUBLIC) Phase phase,
+    @With(PRIVATE) long totalPatients,
+    @With(PRIVATE) long totalBundles,
+    @With(PRIVATE) long deidentifiedBundles,
+    @With(PRIVATE) long sentBundles,
+    @With(PRIVATE) long skippedBundles) {
+  public static TransferProcessStatus create(String processId) {
+    return new TransferProcessStatus(processId, Phase.QUEUED, 0, 0, 0, 0, 0);
+  }
+
+  public TransferProcessStatus incTotalPatients() {
+    return withTotalPatients(totalPatients() + 1);
+  }
+
+  public TransferProcessStatus incTotalBundles() {
+    return withTotalBundles(totalBundles() + 1);
+  }
+
+  public TransferProcessStatus incDeidentifiedBundles() {
+    return withDeidentifiedBundles(deidentifiedBundles() + 1);
+  }
+
+  public TransferProcessStatus incSentBundles() {
+    return withSentBundles(sentBundles() + 1);
+  }
+
+  public TransferProcessStatus incSkippedBundles() {
+    return withSkippedBundles(skippedBundles() + 1);
+  }
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TCACohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TCACohortSelector.java
@@ -52,7 +52,7 @@ class TCACohortSelector implements CohortSelector {
         .timeout(Duration.ofSeconds(30))
         .doOnNext(b -> log.debug("Found {} consented patient bundles", b.getEntry().size()))
         .doOnError(e -> log.error("Error fetching cohort: {}", e.getMessage()))
-        .onErrorResume(WebClientException.class, TCACohortSelector::handleError)
+        .onErrorResume(WebClientException.class, TCACohortSelector::handleWebClientException)
         .flatMap(this::extractConsentedPatients);
   }
 
@@ -119,7 +119,7 @@ class TCACohortSelector implements CohortSelector {
             config.policies()));
   }
 
-  private static Mono<Bundle> handleError(WebClientException e) {
+  private static Mono<Bundle> handleWebClientException(WebClientException e) {
     return Mono.error(
         new TransferProcessException("Error communicating with trust center agent", e));
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepTest.java
@@ -16,6 +16,7 @@ import care.smith.fts.test.MockServerUtil;
 import care.smith.fts.util.tca.TCADomains;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import org.hl7.fhir.r4.model.Bundle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,13 @@ class DeidentifhirStepTest {
     var consentedPatientBundle = new ConsentedPatientBundle(bundle, consentedPatient);
 
     create(step.deidentify(consentedPatientBundle)).expectNextCount(1).verifyComplete();
+  }
+
+  @Test
+  void emptyIdsYieldEmptyMono() {
+    create(step.deidentify(new ConsentedPatientBundle(new Bundle(), new ConsentedPatient("id1"))))
+        .expectNextCount(0)
+        .verifyComplete();
   }
 
   @AfterEach

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
@@ -3,10 +3,10 @@ package care.smith.fts.cda.rest;
 import static java.util.List.of;
 import static reactor.test.StepVerifier.create;
 
+import care.smith.fts.cda.TransferProcessStatus;
 import care.smith.fts.cda.TransferProcessDefinition;
 import care.smith.fts.cda.TransferProcessRunner;
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import care.smith.fts.cda.TransferProcessRunner.Status;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,8 @@ import reactor.core.publisher.Mono;
 class TransferProcessControllerTest {
 
   private static final String processId = "processId";
-  private static final Status PATIENT_SUMMARY_RESULT = new Status(processId, Phase.RUNNING, 0, 0);
+  private static final TransferProcessStatus PATIENT_SUMMARY_RESULT =
+      TransferProcessStatus.create(processId).withPhase(Phase.RUNNING);
   private TransferProcessController api;
 
   @BeforeEach
@@ -33,7 +34,7 @@ class TransferProcessControllerTest {
               }
 
               @Override
-              public Mono<Status> status(String processId) {
+              public Mono<TransferProcessStatus> status(String processId) {
                 return Mono.just(PATIENT_SUMMARY_RESULT);
               }
             },

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/CohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/CohortSelectorIT.java
@@ -2,12 +2,12 @@ package care.smith.fts.cda.rest.it;
 
 import static care.smith.fts.test.TestPatientGenerator.generateNPatients;
 
-import care.smith.fts.cda.TransferProcessRunner.Phase;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import org.hl7.fhir.r4.model.Bundle;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError;
 
 public class CohortSelectorIT extends TransferProcessControllerIT {
 
@@ -15,48 +15,40 @@ public class CohortSelectorIT extends TransferProcessControllerIT {
   void tcaDown() {
     mockCohortSelector.isDown();
 
-    startProcess(Duration.ofSeconds(3))
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+    startProcess(Duration.ofSeconds(3)).expectError(InternalServerError.class).verify();
     startProcessForIds(Duration.ofSeconds(3), List.of())
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+        .expectError(InternalServerError.class)
+        .verify();
   }
 
   @Test
   void tcaTimeoutConsentedPatientsRequest() {
     mockCohortSelector.timeout();
 
-    startProcess(Duration.ofMinutes(1))
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+    startProcess(Duration.ofMinutes(1)).expectError(InternalServerError.class).verify();
     startProcessForIds(Duration.ofMinutes(1), List.of())
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+        .expectError(InternalServerError.class)
+        .verify();
   }
 
   @Test
   void tcaSendsWrongContentType() throws IOException {
     mockCohortSelector.wrongContentType();
 
-    startProcess(Duration.ofSeconds(3))
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+    startProcess(Duration.ofSeconds(3)).expectError(InternalServerError.class).verify();
     startProcessForIds(Duration.ofSeconds(3), List.of())
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+        .expectError(InternalServerError.class)
+        .verify();
   }
 
   @Test
   void unknownDomain() {
     mockCohortSelector.unknownDomain(om);
 
-    startProcess(Duration.ofSeconds(3))
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+    startProcess(Duration.ofSeconds(3)).expectError(InternalServerError.class).verify();
     startProcessForIds(Duration.ofSeconds(3), List.of())
-        .assertNext(r -> expectPhase(r, Phase.ERROR))
-        .verifyComplete();
+        .expectError(InternalServerError.class)
+        .verify();
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/GeneralIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/GeneralIT.java
@@ -3,7 +3,7 @@ package care.smith.fts.cda.rest.it;
 import static care.smith.fts.test.TestPatientGenerator.generateNPatients;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import care.smith.fts.cda.TransferProcessRunner.Status;
+import care.smith.fts.cda.TransferProcessStatus;
 import java.io.IOException;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
@@ -157,7 +157,7 @@ public class GeneralIT extends TransferProcessControllerIT {
         .flatMap(
             r -> {
               var uri = r.getFirst().concat("-unknown-process-id");
-              return client.get().uri(uri).retrieve().bodyToMono(Status.class);
+              return client.get().uri(uri).retrieve().bodyToMono(TransferProcessStatus.class);
             })
         .as(
             response ->

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/TransferProcessControllerIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/TransferProcessControllerIT.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import care.smith.fts.cda.ClinicalDomainAgent;
+import care.smith.fts.cda.TransferProcessStatus;
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import care.smith.fts.cda.TransferProcessRunner.Status;
 import care.smith.fts.cda.rest.it.mock.MockBundleSender;
 import care.smith.fts.cda.rest.it.mock.MockCohortSelector;
 import care.smith.fts.cda.rest.it.mock.MockDataSelector;
@@ -97,11 +97,11 @@ public class TransferProcessControllerIT extends BaseIT {
 
 
 
-  protected FirstStep<Status> startProcess(Duration timeout) {
+  protected FirstStep<TransferProcessStatus> startProcess(Duration timeout) {
     return startProcess(timeout, s -> s.phase() != RUNNING);
   }
 
-  protected FirstStep<Status> startProcess(Duration timeout, Predicate<Status> until) {
+  protected FirstStep<TransferProcessStatus> startProcess(Duration timeout, Predicate<TransferProcessStatus> until) {
     return client
         .post()
         .uri("/api/v2/process/test/start")
@@ -120,12 +120,12 @@ public class TransferProcessControllerIT extends BaseIT {
         .as(StepVerifier::create);
   }
 
-  protected FirstStep<Status> startProcessForIds(Duration timeout, List<String> ids) {
+  protected FirstStep<TransferProcessStatus> startProcessForIds(Duration timeout, List<String> ids) {
     return startProcessForIds(timeout, s -> s.phase() != RUNNING, ids);
   }
 
-  protected FirstStep<Status> startProcessForIds(
-      Duration timeout, Predicate<Status> until, List<String> ids) {
+  protected FirstStep<TransferProcessStatus> startProcessForIds(
+      Duration timeout, Predicate<TransferProcessStatus> until, List<String> ids) {
     return client
         .post()
         .uri("/api/v2/process/test/start")
@@ -145,21 +145,21 @@ public class TransferProcessControllerIT extends BaseIT {
         .as(StepVerifier::create);
   }
 
-  private Mono<Status> retrieveStatus(List<String> r) {
-    return client.get().uri(r.getFirst()).retrieve().bodyToMono(Status.class);
+  private Mono<TransferProcessStatus> retrieveStatus(List<String> r) {
+    return client.get().uri(r.getFirst()).retrieve().bodyToMono(TransferProcessStatus.class);
   }
 
-  protected static void completedWithBundles(int expectedBundlesSent, Status r) {
+  protected static void completedWithBundles(int expectedBundlesSent, TransferProcessStatus r) {
     expectPhase(r, Phase.COMPLETED);
-    assertThat(r.bundlesSentCount()).isEqualTo(expectedBundlesSent);
+    assertThat(r.sentBundles()).isEqualTo(expectedBundlesSent);
   }
 
-  protected static void errored(Status r) {
-    expectPhase(r, Phase.ERROR);
-    assertThat(r.bundlesSkippedCount()).isEqualTo(1);
+  protected static void errored(TransferProcessStatus r) {
+    expectPhase(r, Phase.COMPLETED_WITH_ERROR);
+    assertThat(r.skippedBundles()).isEqualTo(1);
   }
 
-  protected static void expectPhase(Status r, Phase phase) {
+  protected static void expectPhase(TransferProcessStatus r, Phase phase) {
     assertThat(r.phase()).isEqualTo(phase);
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/mock/MockFetchData.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/it/mock/MockFetchData.java
@@ -70,6 +70,6 @@ public class MockFetchData {
   }
 
   public void respondWithEmptyBundle() {
-    hds.when(mockRequestSpec).respond(successResponse(200, new Bundle()));
+    hds.when(mockRequestSpec).respond(response().withStatusCode(404));
   }
 }

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/DeIdentificationController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/DeIdentificationController.java
@@ -35,7 +35,6 @@ public class DeIdentificationController {
   public Mono<ResponseEntity<TransportMappingResponse>> transportMapping(
       @Valid @RequestBody Mono<TransportMappingRequest> requestData) {
     return requestData
-        .filter(r -> !r.resourceIds().isEmpty())
         .flatMap(mappingProvider::generateTransportMapping)
         .map(ResponseEntity::ok)
         .onErrorResume(DeIdentificationController::handleGenerateError);

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerTest.java
@@ -94,9 +94,20 @@ class DeIdentificationControllerTest {
 
   @Test
   void transportMappingEmptyIds() {
-    var body = new TransportMappingRequest("id1", Set.of(), DEFAULT_DOMAINS, ofDays(14));
+    var mapName = "transferId";
+    var request = new TransportMappingRequest("patientId1", Set.of(), DEFAULT_DOMAINS, ofDays(14));
+    given(mappingProvider.generateTransportMapping(request))
+        .willReturn(Mono.just(new TransportMappingResponse(mapName, Map.of(), ofDays(1))));
 
-    create(controller.transportMapping(Mono.just(body))).verifyComplete();
+    create(controller.transportMapping(Mono.just(request)))
+        .assertNext(
+            r -> {
+              assertThat(r.getStatusCode().is2xxSuccessful()).isTrue();
+              assertThat(r.getBody().dateShiftValue()).isEqualTo(Duration.ofSeconds(86400));
+              assertThat(r.getBody().transportMapping()).isEmpty();
+              assertThat(r.getBody().transferId()).isEqualTo("transferId");
+            })
+        .verifyComplete();
   }
 
   @Test


### PR DESCRIPTION
- Track `totalPatients`, `totalBundles`, `deidentifiedBundles`, `bundlesSent`, and `bundlesSkipped`.
- Introduce `Phase.FATAL` that is set, if CohortSelector fails.