### PR TITLE
Remove Obsolete Config Entry

### DIFF
--- a/trust-center-agent/src/main/resources/application.yaml
+++ b/trust-center-agent/src/main/resources/application.yaml
@@ -29,7 +29,3 @@ consent:
   gics:
     fhir:
       baseUrl: http://gics:8080/ttp-fhir/fhir/gics
-
-spring:
-  codec:
-    max-in-memory-size: 10MB


### PR DESCRIPTION
`spring.codec.max-in-memory-size` is not needed anymore.