### PR TITLE
Use `patientIdentifierSystem` to Filter Identifiers

### DIFF
--- a/.github/test/cd-agent/projects/external-consent-example.yaml
+++ b/.github/test/cd-agent/projects/external-consent-example.yaml
@@ -5,7 +5,8 @@
 ##! Specify which cohort selection implementation should be used.
 ##! https://medizininformatik-initiative.github.io/fts-next/cd-agent/cohort-selector
 cohortSelector:
-  external: { }
+  external:
+    patientIdentifierSystem: http://fts.smith.care
 
 ### Data Selection Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/cd-agent/data-selector

--- a/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
+++ b/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
@@ -21,15 +21,16 @@ import java.util.*;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-public record ConsentedPatient(String id, ConsentedPolicies consentedPolicies) {
+public record ConsentedPatient(
+    String id, String patientIdentifierSystem, ConsentedPolicies consentedPolicies) {
 
   public ConsentedPatient {
     requireNonNull(id, "Patient's id cannot be null");
     requireNonNull(consentedPolicies, "Consented policies cannot be null");
   }
 
-  public ConsentedPatient(String id) {
-    this(id, new ConsentedPolicies());
+  public ConsentedPatient(String id, String patientIdentifierSystem) {
+    this(id, patientIdentifierSystem, new ConsentedPolicies());
   }
 
   public Optional<Period> maxConsentedPeriod() {

--- a/api/src/test/java/care/smith/fts/api/ConsentedPatientTest.java
+++ b/api/src/test/java/care/smith/fts/api/ConsentedPatientTest.java
@@ -15,7 +15,7 @@ class ConsentedPatientTest {
 
   @Test
   void emptyConsentYieldsEmptyMaxPeriod() {
-    ConsentedPatient patient = new ConsentedPatient("patient-122522");
+    ConsentedPatient patient = new ConsentedPatient("patient-122522", "http://fts.smith.care");
     assertThat(patient.maxConsentedPeriod()).isEmpty();
   }
 
@@ -119,7 +119,8 @@ class ConsentedPatientTest {
 
     Period period = Period.parse("1234-03-01T00:00:00+00:00", "1234-03-03T00:00:00+00:00");
     consentedPolicies.put("a", period);
-    ConsentedPatient consentedPatient = new ConsentedPatient("patient", consentedPolicies);
+    ConsentedPatient consentedPatient =
+        new ConsentedPatient("patient", "http://fts.smith.care", consentedPolicies);
 
     String des = om.writeValueAsString(consentedPatient);
     ConsentedPatient ser = om.readValue(des, ConsentedPatient.class);

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
@@ -3,6 +3,7 @@ package care.smith.fts.cda.impl;
 import static care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils.generateRegistry;
 import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 
+import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.ConsentedPatientBundle;
 import care.smith.fts.api.DateShiftPreserve;
 import care.smith.fts.api.TransportBundle;
@@ -56,7 +57,7 @@ class DeidentifhirStep implements Deidentificator {
     var ids = idatScraper.gatherIDs(bundle.bundle());
 
     return !ids.isEmpty()
-        ? fetchTransportMapping(patient.id(), ids)
+        ? fetchTransportMapping(patient, ids)
             .map(
                 response -> {
                   var transportMapping = response.transportMapping();
@@ -74,8 +75,11 @@ class DeidentifhirStep implements Deidentificator {
         : Mono.empty();
   }
 
-  private Mono<TransportMappingResponse> fetchTransportMapping(String patientId, Set<String> ids) {
-    var request = new TransportMappingRequest(patientId, ids, domains, maxDateShift, preserve);
+  private Mono<TransportMappingResponse> fetchTransportMapping(
+      ConsentedPatient patient, Set<String> ids) {
+    var request =
+        new TransportMappingRequest(
+            patient.id(), patient.patientIdentifierSystem(), ids, domains, maxDateShift, preserve);
 
     log.trace("Fetch transport mapping for {} IDs", ids.size());
     return tcaClient

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/ExternalCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/ExternalCohortSelector.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class ExternalCohortSelector
     implements CohortSelector.Factory<ExternalCohortSelector.Config> {
 
-  public record Config() {}
+  public record Config(String patientIdentifierSystem) {}
 
   public ExternalCohortSelector() {}
 
@@ -25,7 +25,8 @@ public class ExternalCohortSelector
   public CohortSelector create(CohortSelector.Config ignored, Config config) {
     return pids -> {
       log.debug("pids: {}", pids);
-      return fromStream(pids.stream().map(ConsentedPatient::new));
+      return fromStream(
+          pids.stream().map(id -> new ConsentedPatient(id, config.patientIdentifierSystem())));
     };
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -23,7 +23,7 @@ import reactor.core.publisher.Mono;
 class DefaultTransferProcessRunnerTest {
 
   private static final String PATIENT_ID = "patient-150622";
-  private static final ConsentedPatient PATIENT = new ConsentedPatient(PATIENT_ID);
+  private static final ConsentedPatient PATIENT = new ConsentedPatient(PATIENT_ID, "system");
 
   private DefaultTransferProcessRunner runner;
 
@@ -66,7 +66,7 @@ class DefaultTransferProcessRunnerTest {
   @Test
   void runMockTestWithSkippedBundles() {
     var first = new AtomicBoolean(true);
-    var patient2 = new ConsentedPatient(PATIENT_ID);
+    var patient2 = new ConsentedPatient(PATIENT_ID, "system");
     var process =
         new TransferProcessDefinition(
             "test",

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepIT.java
@@ -61,7 +61,7 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
     step = new DeidentifhirStep(client, domains, ofDays(14), NONE, deiConf, scrConf, meterRegistry);
 
     var bundle = generateOnePatient("id1", "2024", "identifierSystem");
-    var consentedPatient = new ConsentedPatient("id1");
+    var consentedPatient = new ConsentedPatient("id1", "system");
     consentedPatientBundle = new ConsentedPatientBundle(bundle, consentedPatient);
   }
 
@@ -142,7 +142,9 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
 
   @Test
   void emptyIdsYieldEmptyMono() {
-    create(step.deidentify(new ConsentedPatientBundle(new Bundle(), new ConsentedPatient("id1"))))
+    create(
+            step.deidentify(
+                new ConsentedPatientBundle(new Bundle(), new ConsentedPatient("id1", "system"))))
         .expectNextCount(0)
         .verifyComplete();
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorIT.java
@@ -68,7 +68,7 @@ class EverythingDataSelectorIT extends AbstractConnectionScenarioIT {
 
     var consentedPolicies = new ConsentedPolicies();
     consentedPolicies.put("pol", new Period(ZonedDateTime.now(), ZonedDateTime.now().plusYears(5)));
-    consentedPatient = new ConsentedPatient(PATIENT_ID, consentedPolicies);
+    consentedPatient = new ConsentedPatient(PATIENT_ID, "system", consentedPolicies);
   }
 
   private static MappingBuilder fhirStoreRequestWithoutConsent() {
@@ -107,7 +107,7 @@ class EverythingDataSelectorIT extends AbstractConnectionScenarioIT {
 
   @Test
   void noConsentErrors() {
-    create(dataSelector.select(new ConsentedPatient(PATIENT_ID))).expectError().verify();
+    create(dataSelector.select(new ConsentedPatient(PATIENT_ID, "system"))).expectError().verify();
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/ExternalCohortSelectorTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/ExternalCohortSelectorTest.java
@@ -17,7 +17,7 @@ class ExternalCohortSelectorTest {
   void setUp() {
     selector =
         new ExternalCohortSelector()
-            .create(new CohortSelector.Config(), new ExternalCohortSelector.Config());
+            .create(new CohortSelector.Config(), new ExternalCohortSelector.Config("system"));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
@@ -24,7 +24,7 @@ class DeidentifhirUtilsTest {
 
   @Test
   void deidentifySucceeds() throws IOException {
-    ConsentedPatient patient = new ConsentedPatient("id1");
+    ConsentedPatient patient = new ConsentedPatient("id1", "system");
 
     Map<String, String> transportIDs =
         Map.of(

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/IDATScraperTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/IDATScraperTest.java
@@ -14,7 +14,7 @@ class IDATScraperTest {
 
   @BeforeEach
   void setUp() {
-    ConsentedPatient patient = new ConsentedPatient("id1");
+    ConsentedPatient patient = new ConsentedPatient("id1", "system");
     var config = parseResources(IDATScraperTest.class, "IDScraper.profile");
     scraper = new IDATScraper(config, patient);
   }

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerTest.java
@@ -48,7 +48,12 @@ class DeIdentificationControllerTest {
     var mapName = "transferId";
     var request =
         new TransportMappingRequest(
-            "patientId1", ids, DEFAULT_DOMAINS, ofDays(14), DateShiftPreserve.NONE);
+            "patientId1",
+            "patientIdentifierSystem",
+            ids,
+            DEFAULT_DOMAINS,
+            ofDays(14),
+            DateShiftPreserve.NONE);
     given(mappingProvider.generateTransportMapping(request))
         .willReturn(
             Mono.just(
@@ -73,7 +78,12 @@ class DeIdentificationControllerTest {
     var domains = new TCADomains("unknown domain", "unknown domain", "unknown domain");
     var request =
         new TransportMappingRequest(
-            "id1", Set.of("id1"), domains, ofDays(14), DateShiftPreserve.NONE);
+            "id1",
+            "patientIdentifierSystem",
+            Set.of("id1"),
+            domains,
+            ofDays(14),
+            DateShiftPreserve.NONE);
     given(mappingProvider.generateTransportMapping(request))
         .willReturn(Mono.error(new UnknownDomainException("unknown domain")));
 
@@ -89,7 +99,12 @@ class DeIdentificationControllerTest {
   void transportMappingIllegalArgumentException() {
     var request =
         new TransportMappingRequest(
-            "id1", Set.of("id1"), DEFAULT_DOMAINS, ofDays(14), DateShiftPreserve.NONE);
+            "id1",
+            "patientIdentifierSystem",
+            Set.of("id1"),
+            DEFAULT_DOMAINS,
+            ofDays(14),
+            DateShiftPreserve.NONE);
 
     given(mappingProvider.generateTransportMapping(request))
         .willReturn(Mono.error(new IllegalArgumentException("Illegal argument")));
@@ -107,7 +122,12 @@ class DeIdentificationControllerTest {
     var mapName = "transferId";
     var request =
         new TransportMappingRequest(
-            "patientId1", Set.of(), DEFAULT_DOMAINS, ofDays(14), DateShiftPreserve.NONE);
+            "patientId1",
+            "patientIdentifierSystem",
+            Set.of(),
+            DEFAULT_DOMAINS,
+            ofDays(14),
+            DateShiftPreserve.NONE);
     given(mappingProvider.generateTransportMapping(request))
         .willReturn(Mono.just(new TransportMappingResponse(mapName, Map.of(), ofDays(1))));
 
@@ -127,7 +147,12 @@ class DeIdentificationControllerTest {
     var ids = Set.of("id1", "id2");
     var request =
         new TransportMappingRequest(
-            "id1", ids, DEFAULT_DOMAINS, ofDays(14), DateShiftPreserve.NONE);
+            "id1",
+            "patientIdentifierSystem",
+            ids,
+            DEFAULT_DOMAINS,
+            ofDays(14),
+            DateShiftPreserve.NONE);
     given(mappingProvider.generateTransportMapping(request))
         .willReturn(Mono.error(new ResponseStatusException(INTERNAL_SERVER_ERROR)));
 

--- a/util/src/main/java/care/smith/fts/util/ConsentedPatientExtractor.java
+++ b/util/src/main/java/care/smith/fts/util/ConsentedPatientExtractor.java
@@ -73,7 +73,8 @@ public interface ConsentedPatientExtractor {
             pid -> {
               var consentedPolicies = getConsentedPolicies(policySystem, bundle, policiesToCheck);
               if (consentedPolicies.hasAllPolicies(policiesToCheck)) {
-                return Optional.of(new ConsentedPatient(pid, consentedPolicies));
+                return Optional.of(
+                    new ConsentedPatient(pid, patientIdentifierSystem, consentedPolicies));
               } else {
                 return Optional.empty();
               }

--- a/util/src/main/java/care/smith/fts/util/tca/TransportMappingRequest.java
+++ b/util/src/main/java/care/smith/fts/util/tca/TransportMappingRequest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 public record TransportMappingRequest(
     @NotNull(groups = TransportMappingRequest.class) String patientId,
+    @NotNull(groups = TransportMappingRequest.class) String patientIdentifierSystem,
     @NotNull(groups = TransportMappingRequest.class) Set<String> resourceIds,
     @NotNull(groups = TransportMappingRequest.class) TCADomains tcaDomains,
     @NotNull(groups = TransportMappingRequest.class) Duration maxDateShift,

--- a/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
@@ -36,6 +36,7 @@ class WebClientDefaultsTest {
                     """
                     {
                       "id": "patient",
+                      "patientIdentifierSystem": "system",
                       "consentedPolicies": {
                         "policies":{
                           "a":[
@@ -55,6 +56,7 @@ class WebClientDefaultsTest {
         .assertNext(
             b -> {
               assertThat(b.id()).isEqualTo("patient");
+              assertThat(b.patientIdentifierSystem()).isEqualTo("system");
               assertThat(b.consentedPolicies().policyNames()).isNotEmpty();
             })
         .verifyComplete();

--- a/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
@@ -20,6 +20,7 @@ class TransportMappingRequestTest {
     var request =
         new TransportMappingRequest(
             "patient123",
+            "patientIdentifierSystem",
             Set.of("id1", "id2"),
             new TCADomains("pDomain", "sDomain", "dDomain"),
             Duration.ofDays(30),
@@ -29,6 +30,7 @@ class TransportMappingRequestTest {
 
     assertThat(jsonString)
         .contains("patient123")
+        .contains("patientIdentifierSystem")
         .contains("id1")
         .contains("id2")
         .contains("pDomain")
@@ -43,6 +45,7 @@ class TransportMappingRequestTest {
         """
         {
           "patientId": "patient123",
+          "patientIdentifierSystem": "patientIdentifierSystem",
           "resourceIds": ["id1", "id2"],
           "tcaDomains": {
             "pseudonym" : "pDomain",


### PR DESCRIPTION
- Add `patientIdentifierSystem` to ConsentedPatient
- Add `patientIdentifierSystem` to TransportMappingRequest
- Add `patientIdentifierSystem` to ExternalCohortSelector.Config
- Use NamespacingReplacementProvider to construct Identifier Name