### PR TITLE
Use fixed PIS to Extract ConsentedPatient

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
@@ -8,7 +8,7 @@ import static org.springframework.web.util.UriComponentsBuilder.*;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.cda.CohortSelector;
-import care.smith.fts.util.ConsentedPatientExtractor;
+import care.smith.fts.util.GicsConsentedPatientExtractor;
 import care.smith.fts.util.error.TransferProcessException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -80,7 +80,7 @@ class FhirCohortSelector implements CohortSelector {
 
   private Flux<ConsentedPatient> extractConsentedPatients(Bundle bundle) {
     return Flux.fromStream(
-        ConsentedPatientExtractor.getConsentedPatients(
+        GicsConsentedPatientExtractor.getConsentedPatients(
             config.patientIdentifierSystem(),
             config.policySystem(),
             groupPatientsAndConsents(bundle),

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TCACohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TCACohortSelector.java
@@ -7,7 +7,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.cda.CohortSelector;
-import care.smith.fts.util.ConsentedPatientExtractor;
+import care.smith.fts.util.GicsConsentedPatientExtractor;
 import care.smith.fts.util.error.TransferProcessException;
 import care.smith.fts.util.error.fhir.FhirException;
 import com.google.common.collect.ImmutableMap;
@@ -91,7 +91,7 @@ class TCACohortSelector implements CohortSelector {
 
   private Flux<ConsentedPatient> extractConsentedPatients(Bundle outerBundle) {
     return Flux.fromStream(
-        ConsentedPatientExtractor.extractConsentedPatients(
+        GicsConsentedPatientExtractor.extractConsentedPatients(
             config.patientIdentifierSystem(),
             config.policySystem(),
             outerBundle,

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirUtil.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirUtil.java
@@ -1,6 +1,6 @@
 package care.smith.fts.tca.consent;
 
-import static care.smith.fts.util.ConsentedPatientExtractor.hasAllPolicies;
+import static care.smith.fts.util.GicsConsentedPatientExtractor.hasAllPolicies;
 import static care.smith.fts.util.fhir.FhirClientUtils.fetchCapabilityStatementOperations;
 import static care.smith.fts.util.fhir.FhirClientUtils.requireOperations;
 import static care.smith.fts.util.fhir.FhirUtils.resourceStream;


### PR DESCRIPTION
We use the hard-coded
"https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym" to extract the Patient's identifier from the gICS response.