### PR TITLE
Correctly Set Default Value for `dateShiftPreserve`

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStepConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStepConfig.java
@@ -5,6 +5,7 @@ import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.tca.TcaDomains;
 import java.io.File;
 import java.time.Duration;
+import java.util.Optional;
 
 public record DeidentifhirStepConfig(
     TCAConfig trustCenterAgent,
@@ -17,8 +18,13 @@ public record DeidentifhirStepConfig(
       TCAConfig trustCenterAgent,
       Duration maxDateShift,
       File deidentifhirConfig,
-      File scraperConfig) {
-    this(trustCenterAgent, maxDateShift, deidentifhirConfig, scraperConfig, DateShiftPreserve.NONE);
+      File scraperConfig,
+      DateShiftPreserve dateShiftPreserve) {
+    this.trustCenterAgent = trustCenterAgent;
+    this.maxDateShift = maxDateShift;
+    this.deidentifhirConfig = deidentifhirConfig;
+    this.scraperConfig = scraperConfig;
+    this.dateShiftPreserve = Optional.ofNullable(dateShiftPreserve).orElse(DateShiftPreserve.NONE);
   }
 
   public record TCAConfig(HttpClientConfig server, TcaDomains domains) {}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepConfigTest.java
@@ -1,0 +1,15 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import care.smith.fts.api.DateShiftPreserve;
+import org.junit.jupiter.api.Test;
+
+public class DeidentifhirStepConfigTest {
+
+  @Test
+  void missingDateShiftPreserveDefaultsToNone() {
+    var config = new DeidentifhirStepConfig(null, null, null, null, null);
+    assertThat(config.dateShiftPreserve()).isEqualTo(DateShiftPreserve.NONE);
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepFactoryIT.java
@@ -44,7 +44,8 @@ class DeidentifhirStepFactoryIT {
                         new TcaDomains("domain", "domain", "domain")),
                     ofDays(14),
                     new File("deidentifhirConfig"),
-                    new File("scraperConfig"))))
+                    new File("scraperConfig"),
+                    null)))
         .isNotNull();
   }
 }


### PR DESCRIPTION
- Remove constructor that was only used in tests