### PR TITLE
Let Renovate Update Binary Digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
     - name: Install CycloneDX CLI
       env:
         # Check the cyclonedx binary against a pinned checksum here, it must be updated accordingly
-        # renovate: datasource=github-releases depName=CycloneDX/cyclonedx-cli
+        # renovate: datasource=github-release-attachments depName=CycloneDX/cyclonedx-cli
         CDX_CLI_VERSION: v0.29.0
         CDX_CLI_CHECKSUM: 411bd30d28ca705500f0b5a7f4a896749cad1b082deb5245ece7b386e496c48c
       run: .github/scripts/install-cyclonedx.sh

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,6 @@
     ':automergeMinor',
     ':automergeDigest',
     ':maintainLockFilesWeekly',
-    'customManagers:githubActionsVersions',
   ],
   description: [
     "We use `ignorePaths` to mitigate :ignoreModulesAndTests, which would ignore java test classes",
@@ -126,5 +125,18 @@
         '// renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\n[^\\n]+[A-Za-z0-9_]+?_VERSION\\s*=\\s*"(?<currentValue>[^@;]+?)(@(?<currentDigest>sha256:.+?))?";',
       ],
     },
+    {
+      description: [
+        "Like customManagers:githubActionsVersions, but also finds the digest."
+      ],
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+?) depName=(?<depName>\\S+?)(?: (?:lookupName|packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: extractVersion=(?<extractVersion>\\S+?))?\\s+\\w+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s+(\\w+?_CHECKSUM\\s*:\\s*[\"']?(?<currentDigest>\\w+)[\"']?)?"
+      ]
+    }
   ],
 }


### PR DESCRIPTION
where digests are attached to github actions assets.