### PR TITLE
Make SignerIDType Configurable

### DIFF
--- a/.github/test/cd-agent/projects/gics-consent-example.yaml
+++ b/.github/test/cd-agent/projects/gics-consent-example.yaml
@@ -20,6 +20,7 @@ cohortSelector:
     domain: MII
     # Identifier system filter. Only patients with identifiers from this system will be included in the cohort.
     patientIdentifierSystem: "https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym"
+    signerIdType: "Pseudonym"
     # Policy system filter. Only policies with identifiers from this system will be considered valid.
     # see e.g.: https://simplifier.net/medizininformatikinitiative-modulconsent/2.16.840.1.113883.3.1937.777.24.5.3--20210423105554
     policySystem: "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3" # MII CS Consent Policy

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelector.java
@@ -29,8 +29,6 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 class TcaCohortSelector implements CohortSelector {
-  String GICS_PATIENT_IDENTIFIER_SYSTEM =
-      "https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym";
   private final TcaCohortSelectorConfig config;
   private final WebClient tcaClient;
   private final MeterRegistry meterRegistry;
@@ -40,6 +38,10 @@ class TcaCohortSelector implements CohortSelector {
     this.config = config;
     this.tcaClient = tcaClient;
     this.meterRegistry = meterRegistry;
+  }
+
+  private String getGicsIdentifierSystem() {
+    return "https://ths-greifswald.de/fhir/gics/identifiers/" + config.signerIdType();
   }
 
   @Override
@@ -101,7 +103,7 @@ class TcaCohortSelector implements CohortSelector {
             config.policySystem(),
             resources,
             config.policies(),
-            b -> getPatientIdentifier(GICS_PATIENT_IDENTIFIER_SYSTEM, b)));
+            b -> getPatientIdentifier(getGicsIdentifierSystem(), b)));
   }
 
   private static Mono<Bundle> handleWebClientException(WebClientException e) {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelectorConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelectorConfig.java
@@ -3,6 +3,7 @@ package care.smith.fts.cda.impl;
 import care.smith.fts.util.HttpClientConfig;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
 import java.util.Set;
 
 @JsonClassDescription("")
@@ -18,4 +19,23 @@ public record TcaCohortSelectorConfig(
     Set<String> policies,
 
     /* */
-    String domain) {}
+    String domain,
+
+    /* */
+    String signerIdType) {
+
+  public TcaCohortSelectorConfig(
+      HttpClientConfig server,
+      String patientIdentifierSystem,
+      String policySystem,
+      Set<String> policies,
+      String domain,
+      String signerIdType) {
+    this.server = server;
+    this.patientIdentifierSystem = patientIdentifierSystem;
+    this.policySystem = policySystem;
+    this.policies = policies;
+    this.domain = domain;
+    this.signerIdType = Optional.ofNullable(signerIdType).orElse("Pseudonym");
+  }
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -232,7 +232,7 @@ public class TransferProcessController {
                           value =
 """
 {
-  "cohortSelector":{"trustCenterAgent":{"server":{"baseUrl":"http://tc-agent:8080"},"domain":"MII","patientIdentifierSystem":"https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym","policySystem":"https://ths-greifswald.de/fhir/CodeSystem/gics/Policy","policies":["IDAT_erheben","IDAT_speichern_verarbeiten","MDAT_erheben","MDAT_speichern_verarbeiten"]}},
+  "cohortSelector":{"trustCenterAgent":{"server":{"baseUrl":"http://tc-agent:8080"},"domain":"MII","patientIdentifierSystem":"https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym","policySystem":"https://ths-greifswald.de/fhir/CodeSystem/gics/Policy","policies":["IDAT_erheben","IDAT_speichern_verarbeiten","MDAT_erheben","MDAT_speichern_verarbeiten"],"signerIdType":"Pseudonym"}},
   "dataSelector":{"everything":{"fhirServer":{"baseUrl":"http://cd-hds:8080/fhir"},"resolve":{"patientIdentifierSystem":"http://fts.smith.care"}}},
   "deidentificator":{"deidentifhir":{"trustCenterAgent":{"server":{"baseUrl":"http://tc-agent:8080"},"domains":{"pseudonym":"MII","salt":"MII","dateShift":"MII"}},"maxDateShift":"P14D","deidentifhirConfig":"/app/projects/example/deidentifhir/CDtoTransport.profile","scraperConfig":"/app/projects/example/deidentifhir/IDScraper.profile"}},
   "bundleSender":{"researchDomainAgent":{"server":{"baseUrl":"http://rd-agent:8080"},"project":"example"}}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorFactoryIT.java
@@ -34,7 +34,12 @@ class TcaCohortSelectorFactoryIT {
             factory.create(
                 null,
                 new TcaCohortSelectorConfig(
-                    new HttpClientConfig("http://dummy.example.com"), null, null, null, null)))
+                    new HttpClientConfig("http://dummy.example.com"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null)))
         .isNotNull();
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/mock/MockCohortSelector.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/mock/MockCohortSelector.java
@@ -40,15 +40,15 @@ public class MockCohortSelector {
   private final WireMock tca;
   private final String basePath;
 
-  public static MockCohortSelector fetchAll(WireMock tca, String policySystem) {
-    return new MockCohortSelector(tca, policySystem, "/api/v2/cd/consented-patients/fetch-all");
+  public static MockCohortSelector fetchAll(WireMock tca) {
+    return new MockCohortSelector(tca, "/api/v2/cd/consented-patients/fetch-all");
   }
 
-  public static MockCohortSelector fetch(WireMock tca, String policySystem) {
-    return new MockCohortSelector(tca, policySystem, "/api/v2/cd/consented-patients/fetch");
+  public static MockCohortSelector fetch(WireMock tca) {
+    return new MockCohortSelector(tca, "/api/v2/cd/consented-patients/fetch");
   }
 
-  public MockCohortSelector(WireMock tca, String policy_system, String basePath) {
+  public MockCohortSelector(WireMock tca, String basePath) {
     this.tca = tca;
     this.basePath = basePath;
   }

--- a/clinical-domain-agent/src/test/resources/care/smith/fts/cda/rest/it/project-template.yaml
+++ b/clinical-domain-agent/src/test/resources/care/smith/fts/cda/rest/it/project-template.yaml
@@ -6,6 +6,7 @@ cohortSelector:
     patientIdentifierSystem: "https://ths-greifswald.de/fhir/gics/identifiers/Pseudonym"
     policySystem: "https://ths-greifswald.de/fhir/CodeSystem/gics/Policy"
     policies: [ "IDAT_erheben", "IDAT_speichern_verarbeiten", "MDAT_erheben", "MDAT_speichern_verarbeiten" ]
+    signerIdType: "Pseudonym"
 
 dataSelector:
   everything:


### PR DESCRIPTION
TcaCohortSelectorConfig now requires signerIdType parameter. This replaces the hardcoded "Pseudonym" identifier system to support dynamic gICS identifier systems based on configured SignerIDType.

Fixes #1138