### PR TITLE
Improve HTTP Call Observability

### DIFF
--- a/.github/scripts/check-consent.sh
+++ b/.github/scripts/check-consent.sh
@@ -9,7 +9,7 @@ if ! gics_base_url="http://$(docker compose port gics 8080)/ttp-fhir/fhir/gics";
   exit 2
 fi
 
-summary="$(curl -XPOST -sf -H "Content-Type: application/fhir+json" \
+summary="$(curl -XPOST -sSf -H "Content-Type: application/fhir+json" \
   --data '{"resourceType": "Parameters", "parameter": [{"name": "domain", "valueString": "MII"}]}' \
   "${gics_base_url}/\$allConsentsForDomain?_summary=count")"
 

--- a/.github/scripts/download-test-data-checksums.sh
+++ b/.github/scripts/download-test-data-checksums.sh
@@ -7,4 +7,4 @@ share="${1}"
 # Create directory based on share ID to avoid file collisions
 data_dir="./test-data/${share}"
 mkdir -p "${data_dir}"
-curl -sLf -u "${share}:" "${base_url}/kds/checksums.sha256" >"${data_dir}/checksums.sha256"
+curl -sSfL --retry 3 -u "${share}:" "${base_url}/kds/checksums.sha256" >"${data_dir}/checksums.sha256"

--- a/.github/scripts/list-projects.sh
+++ b/.github/scripts/list-projects.sh
@@ -5,9 +5,11 @@ if ! cd_base_url="http://$(docker compose port cd-agent 8080)"; then
   >&2 echo "Unable to find clinical domain agent"
   exit 2
 fi
-cd_projetcs="$(curl -sSf "${cd_base_url}/api/v2/projects")"
+
+cd_projects="$(curl -sSf "${cd_base_url}/api/v2/projects")"
+
 echo
-echo "CD Projects: ${cd_projetcs}"
+echo "CD Projects: ${cd_projects}"
 echo
 
 if ! rd_base_url="http://$(docker compose port rd-agent 8080)"; then

--- a/.github/scripts/show-project.sh
+++ b/.github/scripts/show-project.sh
@@ -5,9 +5,10 @@ if ! cd_base_url="http://$(docker compose port cd-agent 8080)"; then
   >&2 echo "Unable to find clinical domain agent"
   exit 2
 fi
-cd_projetcs="$(curl -sSf "${cd_base_url}/api/v2/projects/{$1}")"
+cd_projects="$(curl -sSf "${cd_base_url}/api/v2/projects/{$1}")"
+
 echo
-echo "CD Projects: ${cd_projetcs}"
+echo "CD Projects: ${cd_projects}"
 echo
 
 if ! rd_base_url="http://$(docker compose port rd-agent 8080)"; then

--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -56,7 +56,7 @@ check-resources:
 	../scripts/check-resources.sh ${RESULTS_FILE}
 
 show-status:
-	curl -s "$(shell cat process.url)"
+	curl -sSf "$(shell cat process.url)"
 
 list-projects:
 	../scripts/list-projects.sh

--- a/.github/test/compose.yaml
+++ b/.github/test/compose.yaml
@@ -23,7 +23,7 @@ services:
     environment:
       BASE_URL: "http://cd-hds:8080"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/health" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -38,7 +38,7 @@ services:
       BASE_URL: "http://rd-hds:8080"
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/health" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -53,7 +53,7 @@ services:
       gics-db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/gics/gicsService?wsdl" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/gics/gicsService?wsdl" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -83,7 +83,7 @@ services:
       gpas-db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/gpas/gpasService?wsdl" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/gpas/gpasService?wsdl" ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/.github/test/oauth2/compose.yaml
+++ b/.github/test/oauth2/compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       KC_HEALTH_ENABLED: true
     healthcheck:
-      test: [ "CMD-SHELL", "curl -v -sf http://localhost:9000/health > /tmp/health.json && cat /tmp/health.json | jq -e '.status == \"UP\"'" ]
+      test: [ "CMD-SHELL", "curl -sSf http://localhost:9000/health > /tmp/health.json && cat /tmp/health.json | jq -e '.status == \"UP\"'" ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/usage/execution.md
+++ b/docs/usage/execution.md
@@ -21,7 +21,7 @@ and all patients with consent are transferred.
 For example, to start the transfer of the template's example project run:
 
 ```shell
-curl -X POST https://cd-agent:8080/api/v2/process/example/start
+curl -sSfX POST "https://cd-agent:8080/api/v2/process/example/start"
 ```
 
 ### Manual Cohort
@@ -29,8 +29,8 @@ curl -X POST https://cd-agent:8080/api/v2/process/example/start
 The other option is to have a list of IDs as payload with the start request, e.g.
 
 ```shell
-curl -X POST --data '["id1", "id2", "id3"]' -H "Content-Type: application/json" \
-  https://cd-agent:8080/api/v2/process/example/start
+curl -sSf --data '["id1", "id2", "id3"]' -H "Content-Type: application/json" \
+  "https://cd-agent:8080/api/v2/process/example/start"
 ```
 
 [API Reference for Start Endpoint](/open-api/cd-openapi.html#post-/api/v2/process/-project-/start)
@@ -40,7 +40,7 @@ curl -X POST --data '["id1", "id2", "id3"]' -H "Content-Type: application/json" 
 The response's Content-Location header contains a URL with the transfer status, e.g.
 
 ```shell
-curl "https://cd-agent:8080/api/v2/process/status/52792219-b966-44bf-bc1b-c0eafbe8ead0"
+curl -sSf "https://cd-agent:8080/api/v2/process/status/52792219-b966-44bf-bc1b-c0eafbe8ead0"
 ```
 
 The status response looks like this:


### PR DESCRIPTION
by using -S flag, where applicable. Errors are shown when they occur. -s alone would suppress them.