### PR TITLE
Add TCA FHIR Pseudonymizer Controllers

### DIFF
--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerController.java
@@ -1,0 +1,278 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON_VALUE;
+
+import care.smith.fts.tca.adapters.PseudonymBackendAdapter;
+import care.smith.fts.tca.rest.VfpsPseudonymizeResponse.PseudonymEntry;
+import care.smith.fts.tca.services.TransportIdService;
+import care.smith.fts.util.error.ErrorResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.HashSet;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.StringType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller providing Vfps-compatible FHIR endpoint for CDA's FHIR Pseudonymizer.
+ *
+ * <p>This controller exposes a Vfps-compatible {@code $create-pseudonym} endpoint that:
+ *
+ * <ol>
+ *   <li>Receives pseudonymization requests from CDA's FHIR Pseudonymizer
+ *   <li>Fetches real pseudonyms (sIDs) from the configured backend (gPAS/Vfps/entici)
+ *   <li>Generates transport IDs (tIDs) as temporary replacements
+ *   <li>Stores tID→sID mappings in Redis for later resolution by RDA
+ *   <li>Returns transport IDs (NOT real pseudonyms) to the FHIR Pseudonymizer
+ * </ol>
+ *
+ * <p>This maintains data isolation: clinical data never reaches TCA, only identifiers flow through.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v2/cd-agent/fhir")
+@Validated
+public class CdAgentFhirPseudonymizerController {
+
+  private final TransportIdService transportIdService;
+  private final PseudonymBackendAdapter backendAdapter;
+
+  public CdAgentFhirPseudonymizerController(
+      TransportIdService transportIdService, PseudonymBackendAdapter backendAdapter) {
+    this.transportIdService = transportIdService;
+    this.backendAdapter = backendAdapter;
+  }
+
+  /**
+   * Vfps-compatible endpoint to create pseudonyms (returns transport IDs).
+   *
+   * <p>This endpoint mimics Vfps's $create-pseudonym operation but returns transport IDs instead of
+   * real pseudonyms, maintaining data isolation between domains.
+   *
+   * @param requestParams FHIR Parameters with namespace and originalValue(s)
+   * @return FHIR Parameters with namespace, originalValue, and pseudonymValue (transport ID)
+   */
+  @PostMapping(
+      value = "/$create-pseudonym",
+      consumes = APPLICATION_FHIR_JSON_VALUE,
+      produces = APPLICATION_FHIR_JSON_VALUE)
+  @Operation(
+      summary = "Create pseudonyms (Vfps-compatible, returns transport IDs)",
+      description =
+          "Accepts Vfps-format FHIR Parameters with namespace and original values, "
+              + "returns transport IDs (NOT real pseudonyms) for data isolation.\n\n"
+              + "The transport IDs can be resolved to real pseudonyms via the RDA endpoint.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = APPLICATION_FHIR_JSON_VALUE,
+                      schema = @Schema(implementation = Parameters.class),
+                      examples =
+                          @ExampleObject(
+                              value =
+                                  """
+                                  {
+                                    "resourceType": "Parameters",
+                                    "parameter": [
+                                      {"name": "namespace", "valueString": "clinical-domain"},
+                                      {"name": "originalValue", "valueString": "patient-123"}
+                                    ]
+                                  }
+                                  """))),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Transport IDs generated successfully",
+            content =
+                @Content(
+                    mediaType = APPLICATION_FHIR_JSON_VALUE,
+                    schema = @Schema(implementation = Parameters.class),
+                    examples =
+                        @ExampleObject(
+                            value =
+                                """
+                                {
+                                  "resourceType": "Parameters",
+                                  "parameter": [
+                                    {"name": "namespace", "valueString": "clinical-domain"},
+                                    {"name": "originalValue", "valueString": "patient-123"},
+                                    {"name": "pseudonymValue", "valueString": "tID-abc123xyz..."}
+                                  ]
+                                }
+                                """))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request (missing namespace or originalValue)",
+            content = @Content(mediaType = APPLICATION_FHIR_JSON_VALUE)),
+        @ApiResponse(
+            responseCode = "502",
+            description = "Backend service unavailable",
+            content = @Content(mediaType = APPLICATION_FHIR_JSON_VALUE))
+      })
+  public Mono<ResponseEntity<Parameters>> createPseudonym(
+      @Valid @RequestBody Parameters requestParams) {
+
+    log.debug("Received Vfps $create-pseudonym request from CDA");
+
+    return Mono.fromCallable(() -> parseRequest(requestParams))
+        .flatMap(this::processRequest)
+        .map(this::buildResponse)
+        .map(ResponseEntity::ok)
+        .onErrorResume(this::handleError);
+  }
+
+  private VfpsPseudonymizeRequest parseRequest(Parameters params) {
+    // Extract namespace
+    String namespace =
+        params.getParameter().stream()
+            .filter(p -> "namespace".equals(p.getName()))
+            .findFirst()
+            .map(ParametersParameterComponent::getValue)
+            .map(Base::primitiveValue)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Missing required parameter 'namespace'"));
+
+    if (namespace.isBlank()) {
+      throw new IllegalArgumentException("Parameter 'namespace' must not be empty");
+    }
+
+    // Extract original values
+    List<String> originals =
+        params.getParameter().stream()
+            .filter(p -> "originalValue".equals(p.getName()))
+            .map(ParametersParameterComponent::getValue)
+            .map(Base::primitiveValue)
+            .toList();
+
+    if (originals.isEmpty()) {
+      throw new IllegalArgumentException("At least one 'originalValue' parameter is required");
+    }
+
+    // Generate a transfer ID for this batch
+    var transferId = transportIdService.generateTransferId();
+
+    log.debug(
+        "Parsed request: namespace={}, originalCount={}, transferId={}",
+        namespace,
+        originals.size(),
+        transferId);
+
+    return new VfpsPseudonymizeRequest(namespace, originals, transferId);
+  }
+
+  private Mono<VfpsPseudonymizeResponse> processRequest(VfpsPseudonymizeRequest request) {
+    var transferId = request.transferId();
+    var namespace = request.namespace();
+    var ttl = transportIdService.getDefaultTtl();
+
+    log.debug(
+        "Processing {} identifiers for namespace={}, transferId={}",
+        request.originals().size(),
+        namespace,
+        transferId);
+
+    // Fetch real pseudonyms from backend and generate transport IDs
+    return backendAdapter
+        .fetchOrCreatePseudonyms(namespace, new HashSet<>(request.originals()))
+        .flatMap(
+            sIdMap ->
+                Flux.fromIterable(sIdMap.entrySet())
+                    .flatMap(
+                        entry -> {
+                          var original = entry.getKey();
+                          var sId = entry.getValue();
+                          var tId = transportIdService.generateTransportId();
+
+                          return transportIdService
+                              .storeMapping(transferId, tId, sId, namespace, ttl)
+                              .map(storedTId -> new PseudonymEntry(namespace, original, storedTId));
+                        })
+                    .collectList()
+                    .map(VfpsPseudonymizeResponse::new))
+        .doOnSuccess(
+            response ->
+                log.debug(
+                    "Generated {} transport IDs for transferId={}",
+                    response.pseudonyms().size(),
+                    transferId));
+  }
+
+  private Parameters buildResponse(VfpsPseudonymizeResponse response) {
+    var fhirParams = new Parameters();
+
+    for (var entry : response.pseudonyms()) {
+      // For single-value responses, use flat structure
+      if (response.pseudonyms().size() == 1) {
+        fhirParams.addParameter().setName("namespace").setValue(new StringType(entry.namespace()));
+        fhirParams
+            .addParameter()
+            .setName("originalValue")
+            .setValue(new StringType(entry.original()));
+        fhirParams
+            .addParameter()
+            .setName("pseudonymValue")
+            .setValue(new StringType(entry.pseudonym()));
+      } else {
+        // For batch responses, use nested structure
+        var pseudonymParam = new ParametersParameterComponent();
+        pseudonymParam.setName("pseudonym");
+
+        pseudonymParam.addPart().setName("namespace").setValue(new StringType(entry.namespace()));
+        pseudonymParam
+            .addPart()
+            .setName("originalValue")
+            .setValue(new StringType(entry.original()));
+        pseudonymParam
+            .addPart()
+            .setName("pseudonymValue")
+            .setValue(new StringType(entry.pseudonym()));
+
+        fhirParams.addParameter(pseudonymParam);
+      }
+    }
+
+    log.trace("Built FHIR Parameters response with {} entries", response.pseudonyms().size());
+    return fhirParams;
+  }
+
+  private Mono<ResponseEntity<Parameters>> handleError(Throwable error) {
+    log.warn("Error processing $create-pseudonym request: {}", error.getMessage());
+
+    if (error instanceof IllegalArgumentException) {
+      return Mono.just(
+          ResponseEntity.badRequest()
+              .body(buildOperationOutcome(error.getMessage(), IssueType.INVALID)));
+    }
+
+    return ErrorResponseUtil.internalServerError(error);
+  }
+
+  private Parameters buildOperationOutcome(String message, IssueType issueType) {
+    // Return error as FHIR OperationOutcome wrapped in Parameters for protocol compatibility
+    var outcome = new OperationOutcome();
+    outcome.addIssue().setSeverity(IssueSeverity.ERROR).setCode(issueType).setDiagnostics(message);
+
+    var params = new Parameters();
+    params.addParameter().setName("outcome").setResource(outcome);
+    return params;
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerController.java
@@ -1,0 +1,291 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON_VALUE;
+
+import care.smith.fts.tca.rest.VfpsPseudonymizeResponse.PseudonymEntry;
+import care.smith.fts.tca.services.TransportIdService;
+import care.smith.fts.util.error.ErrorResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.StringType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * REST controller providing Vfps-compatible FHIR endpoint for RDA's FHIR Pseudonymizer.
+ *
+ * <p>This controller exposes a Vfps-compatible {@code $create-pseudonym} endpoint that resolves
+ * transport IDs (tIDs) to their corresponding secure pseudonyms (sIDs):
+ *
+ * <ol>
+ *   <li>Receives resolution requests from RDA's FHIR Pseudonymizer
+ *   <li>Looks up tID→sID mappings in Redis (stored by CDA requests)
+ *   <li>Returns real pseudonyms (sIDs) to the FHIR Pseudonymizer
+ * </ol>
+ *
+ * <p>The RDA endpoint returns actual pseudonyms (unlike CDA endpoint which returns transport IDs),
+ * completing the data isolation architecture where clinical data flows CDA→RDA but identifiers are
+ * resolved via TCA.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v2/rd-agent/fhir")
+@Validated
+public class RdAgentFhirPseudonymizerController {
+
+  private final TransportIdService transportIdService;
+
+  public RdAgentFhirPseudonymizerController(TransportIdService transportIdService) {
+    this.transportIdService = transportIdService;
+  }
+
+  /**
+   * Vfps-compatible endpoint to resolve transport IDs to secure pseudonyms.
+   *
+   * <p>This endpoint accepts transport IDs (returned by CDA endpoint) and resolves them to their
+   * corresponding secure pseudonyms (sIDs) stored in Redis.
+   *
+   * @param requestParams FHIR Parameters with namespace and originalValue(s) containing transport
+   *     IDs
+   * @return FHIR Parameters with namespace, originalValue, and pseudonymValue (real sID)
+   */
+  @PostMapping(
+      value = "/$create-pseudonym",
+      consumes = APPLICATION_FHIR_JSON_VALUE,
+      produces = APPLICATION_FHIR_JSON_VALUE)
+  @Operation(
+      summary = "Resolve transport IDs to secure pseudonyms (Vfps-compatible)",
+      description =
+          "Accepts Vfps-format FHIR Parameters with transport IDs, "
+              + "returns the corresponding secure pseudonyms (sIDs) from Redis.\n\n"
+              + "This endpoint is used by RDA's FHIR Pseudonymizer to resolve transport IDs "
+              + "received from CDA bundles to their final pseudonyms.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              content =
+                  @Content(
+                      mediaType = APPLICATION_FHIR_JSON_VALUE,
+                      schema = @Schema(implementation = Parameters.class),
+                      examples =
+                          @ExampleObject(
+                              value =
+                                  """
+                                  {
+                                    "resourceType": "Parameters",
+                                    "parameter": [
+                                      {"name": "namespace", "valueString": "clinical-domain"},
+                                      {"name": "originalValue", "valueString": "tID-abc123xyz..."}
+                                    ]
+                                  }
+                                  """))),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Secure pseudonyms resolved successfully",
+            content =
+                @Content(
+                    mediaType = APPLICATION_FHIR_JSON_VALUE,
+                    schema = @Schema(implementation = Parameters.class),
+                    examples =
+                        @ExampleObject(
+                            value =
+                                """
+                                {
+                                  "resourceType": "Parameters",
+                                  "parameter": [
+                                    {"name": "namespace", "valueString": "clinical-domain"},
+                                    {"name": "originalValue", "valueString": "tID-abc123xyz..."},
+                                    {"name": "pseudonymValue", "valueString": "sID-real-pseudonym"}
+                                  ]
+                                }
+                                """))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request (missing namespace or originalValue)",
+            content = @Content(mediaType = APPLICATION_FHIR_JSON_VALUE)),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Transport ID not found (may have expired)",
+            content = @Content(mediaType = APPLICATION_FHIR_JSON_VALUE))
+      })
+  public Mono<ResponseEntity<Parameters>> resolvePseudonyms(
+      @Valid @RequestBody Parameters requestParams) {
+
+    log.debug("Received Vfps $create-pseudonym request from RDA");
+
+    return Mono.fromCallable(() -> parseRequest(requestParams))
+        .flatMap(this::resolveTransportIds)
+        .map(this::buildResponse)
+        .map(ResponseEntity::ok)
+        .onErrorResume(this::handleError);
+  }
+
+  private record ResolutionRequest(
+      String namespace, List<String> transportIds, String transferId) {}
+
+  private ResolutionRequest parseRequest(Parameters params) {
+    // Extract namespace
+    String namespace =
+        params.getParameter().stream()
+            .filter(p -> "namespace".equals(p.getName()))
+            .findFirst()
+            .map(ParametersParameterComponent::getValue)
+            .map(Base::primitiveValue)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Missing required parameter 'namespace'"));
+
+    if (namespace.isBlank()) {
+      throw new IllegalArgumentException("Parameter 'namespace' must not be empty");
+    }
+
+    // Extract transport IDs (originalValue parameters contain tIDs to resolve)
+    List<String> transportIds =
+        params.getParameter().stream()
+            .filter(p -> "originalValue".equals(p.getName()))
+            .map(ParametersParameterComponent::getValue)
+            .map(Base::primitiveValue)
+            .toList();
+
+    if (transportIds.isEmpty()) {
+      throw new IllegalArgumentException("At least one 'originalValue' parameter is required");
+    }
+
+    // Extract transferId if provided (for scoped lookups)
+    String transferId =
+        params.getParameter().stream()
+            .filter(p -> "transferId".equals(p.getName()))
+            .findFirst()
+            .map(ParametersParameterComponent::getValue)
+            .map(Base::primitiveValue)
+            .orElse(null);
+
+    log.debug(
+        "Parsed RDA request: namespace={}, transportIdCount={}, transferId={}",
+        namespace,
+        transportIds.size(),
+        transferId);
+
+    return new ResolutionRequest(namespace, transportIds, transferId);
+  }
+
+  private Mono<VfpsPseudonymizeResponse> resolveTransportIds(ResolutionRequest request) {
+    var namespace = request.namespace();
+    var transportIds = new HashSet<>(request.transportIds());
+    var transferId = request.transferId();
+
+    log.debug(
+        "Resolving {} transport IDs for namespace={}, transferId={}",
+        transportIds.size(),
+        namespace,
+        transferId);
+
+    if (transferId == null) {
+      // Without transferId, we can't resolve (need to know which session the tIDs belong to)
+      return Mono.error(
+          new IllegalArgumentException("Parameter 'transferId' is required for RDA resolution"));
+    }
+
+    return transportIdService
+        .resolveMappings(transferId, transportIds)
+        .map(
+            resolvedMappings -> {
+              List<PseudonymEntry> entries = new ArrayList<>();
+              for (var transportId : request.transportIds()) {
+                var sId = resolvedMappings.get(transportId);
+                if (sId != null) {
+                  entries.add(new PseudonymEntry(namespace, transportId, sId));
+                } else {
+                  log.warn(
+                      "Transport ID not found: tId={}, transferId={}", transportId, transferId);
+                  // Return the tID as-is if not found (or could throw error)
+                  entries.add(new PseudonymEntry(namespace, transportId, transportId));
+                }
+              }
+              return new VfpsPseudonymizeResponse(entries);
+            })
+        .doOnSuccess(
+            response ->
+                log.debug(
+                    "Resolved {} transport IDs for transferId={}",
+                    response.pseudonyms().size(),
+                    transferId));
+  }
+
+  private Parameters buildResponse(VfpsPseudonymizeResponse response) {
+    var fhirParams = new Parameters();
+
+    for (var entry : response.pseudonyms()) {
+      // For single-value responses, use flat structure
+      if (response.pseudonyms().size() == 1) {
+        fhirParams.addParameter().setName("namespace").setValue(new StringType(entry.namespace()));
+        fhirParams
+            .addParameter()
+            .setName("originalValue")
+            .setValue(new StringType(entry.original()));
+        fhirParams
+            .addParameter()
+            .setName("pseudonymValue")
+            .setValue(new StringType(entry.pseudonym()));
+      } else {
+        // For batch responses, use nested structure
+        var pseudonymParam = new ParametersParameterComponent();
+        pseudonymParam.setName("pseudonym");
+
+        pseudonymParam.addPart().setName("namespace").setValue(new StringType(entry.namespace()));
+        pseudonymParam
+            .addPart()
+            .setName("originalValue")
+            .setValue(new StringType(entry.original()));
+        pseudonymParam
+            .addPart()
+            .setName("pseudonymValue")
+            .setValue(new StringType(entry.pseudonym()));
+
+        fhirParams.addParameter(pseudonymParam);
+      }
+    }
+
+    log.trace("Built FHIR Parameters response with {} entries", response.pseudonyms().size());
+    return fhirParams;
+  }
+
+  private Mono<ResponseEntity<Parameters>> handleError(Throwable error) {
+    log.warn("Error processing RDA $create-pseudonym request: {}", error.getMessage());
+
+    if (error instanceof IllegalArgumentException) {
+      return Mono.just(
+          ResponseEntity.badRequest()
+              .body(buildOperationOutcome(error.getMessage(), IssueType.INVALID)));
+    }
+
+    return ErrorResponseUtil.internalServerError(error);
+  }
+
+  private Parameters buildOperationOutcome(String message, IssueType issueType) {
+    var outcome = new OperationOutcome();
+    outcome.addIssue().setSeverity(IssueSeverity.ERROR).setCode(issueType).setDiagnostics(message);
+
+    var params = new Parameters();
+    params.addParameter().setName("outcome").setResource(outcome);
+    return params;
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/VfpsPseudonymizeRequest.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/VfpsPseudonymizeRequest.java
@@ -1,0 +1,34 @@
+package care.smith.fts.tca.rest;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Vfps-compatible pseudonymization request parsed from FHIR Parameters.
+ *
+ * <p>This DTO represents the internal representation of a Vfps $create-pseudonym request after
+ * parsing the FHIR Parameters resource. The original request contains:
+ *
+ * <ul>
+ *   <li>namespace - The domain/namespace for pseudonym generation
+ *   <li>originalValue - One or more original values to pseudonymize
+ * </ul>
+ *
+ * @param namespace The domain/namespace for pseudonym generation (non-blank)
+ * @param originals The list of original values to pseudonymize (at least one)
+ * @param transferId The transfer session identifier for grouping mappings
+ */
+public record VfpsPseudonymizeRequest(String namespace, List<String> originals, String transferId) {
+
+  public VfpsPseudonymizeRequest {
+    Objects.requireNonNull(namespace, "namespace is required");
+    if (namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be blank");
+    }
+    if (originals == null || originals.isEmpty()) {
+      throw new IllegalArgumentException("at least one original value required");
+    }
+    Objects.requireNonNull(transferId, "transferId is required");
+    originals = List.copyOf(originals);
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/VfpsPseudonymizeResponse.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/VfpsPseudonymizeResponse.java
@@ -1,0 +1,33 @@
+package care.smith.fts.tca.rest;
+
+import java.util.List;
+
+/**
+ * Vfps-compatible pseudonymization response to be converted to FHIR Parameters.
+ *
+ * <p>This DTO represents the internal representation of a Vfps $create-pseudonym response before
+ * serialization to FHIR Parameters. The response contains pseudonym entries with:
+ *
+ * <ul>
+ *   <li>namespace - The original namespace from the request
+ *   <li>originalValue - The original value that was pseudonymized
+ *   <li>pseudonymValue - The generated pseudonym (transport ID for CDA, real sID for RDA)
+ * </ul>
+ *
+ * @param pseudonyms List of pseudonym entries
+ */
+public record VfpsPseudonymizeResponse(List<PseudonymEntry> pseudonyms) {
+
+  public VfpsPseudonymizeResponse {
+    pseudonyms = pseudonyms != null ? List.copyOf(pseudonyms) : List.of();
+  }
+
+  /**
+   * A single pseudonym mapping entry.
+   *
+   * @param namespace The domain/namespace
+   * @param original The original value
+   * @param pseudonym The generated pseudonym (tID or sID depending on endpoint)
+   */
+  public record PseudonymEntry(String namespace, String original, String pseudonym) {}
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerIT.java
@@ -1,0 +1,283 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.test.FhirGenerators.fromList;
+import static care.smith.fts.test.FhirGenerators.gpasGetOrCreateResponse;
+import static care.smith.fts.test.MockServerUtil.APPLICATION_FHIR_JSON;
+import static care.smith.fts.test.MockServerUtil.fhirResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static reactor.test.StepVerifier.create;
+
+import care.smith.fts.tca.BaseIT;
+import care.smith.fts.test.TestWebClientFactory;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * Integration tests for CdAgentFhirPseudonymizerController.
+ *
+ * <p>Tests the Vfps-compatible endpoint that generates transport IDs for CDA requests.
+ */
+@Slf4j
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Import(TestWebClientFactory.class)
+class CdAgentFhirPseudonymizerControllerIT extends BaseIT {
+
+  private static final String VFPS_ENDPOINT = "/api/v2/cd-agent/fhir/$create-pseudonym";
+
+  @Autowired private RedissonClient redisClient;
+  private WebClient cdClient;
+
+  @BeforeEach
+  void setUp(@LocalServerPort int port, @Autowired TestWebClientFactory factory) {
+    cdClient = factory.webClient("https://localhost:" + port, "cd-agent");
+    // Clean up Redis before each test
+    redisClient.getKeys().deleteByPattern("transport-mapping:*");
+  }
+
+  @AfterEach
+  void tearDown() {
+    gpas().resetMappings();
+  }
+
+  @Test
+  void createPseudonym_shouldReturnTransportId() throws IOException {
+    // Setup gPAS mock to return a real pseudonym
+    var fhirGenerator =
+        gpasGetOrCreateResponse(
+            fromList(List.of("patient-123")), fromList(List.of("sID-real-pseudonym-abc")));
+
+    gpas()
+        .register(
+            post(urlEqualTo("/ttp-fhir/fhir/gpas/$pseudonymizeAllowCreate"))
+                .withHeader(CONTENT_TYPE, equalTo(APPLICATION_FHIR_JSON))
+                .willReturn(fhirResponse(fhirGenerator.generateString())));
+
+    // Build Vfps-format request
+    var requestParams = buildVfpsRequest("clinical-domain", "patient-123");
+
+    // Send request
+    var response =
+        cdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class);
+
+    create(response)
+        .assertNext(
+            params -> {
+              assertThat(params).isNotNull();
+              // Single value response has 3 flat parameters: namespace, originalValue,
+              // pseudonymValue
+              assertThat(params.getParameter()).hasSize(3);
+
+              // The response should contain a pseudonymValue that is a transport ID (not the real
+              // sID)
+              var pseudonymValue = extractPseudonymValue(params);
+              assertThat(pseudonymValue)
+                  .isNotNull()
+                  .isNotEqualTo("sID-real-pseudonym-abc") // Must NOT be the real pseudonym
+                  .hasSize(32) // Transport IDs are 32 chars (24 bytes Base64URL)
+                  .matches(s -> s.matches("^[A-Za-z0-9_-]+$"), "should be Base64URL encoded");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonym_shouldStoreMapping() throws IOException {
+    // Setup gPAS mock
+    var fhirGenerator =
+        gpasGetOrCreateResponse(
+            fromList(List.of("patient-456")), fromList(List.of("sID-stored-pseudonym")));
+
+    gpas()
+        .register(
+            post(urlEqualTo("/ttp-fhir/fhir/gpas/$pseudonymizeAllowCreate"))
+                .withHeader(CONTENT_TYPE, equalTo(APPLICATION_FHIR_JSON))
+                .willReturn(fhirResponse(fhirGenerator.generateString())));
+
+    // Build and send request
+    var requestParams = buildVfpsRequest("clinical-domain", "patient-456");
+
+    var transportId =
+        cdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class)
+            .map(this::extractPseudonymValue)
+            .block();
+
+    // Verify mapping was stored in Redis
+    var keys = redisClient.getKeys().getKeysByPattern("transport-mapping:*");
+    assertThat(keys).isNotEmpty();
+
+    // The mapping should contain the transport ID -> real pseudonym
+    var transferId = keys.iterator().next().replace("transport-mapping:", "");
+    var mapping = redisClient.<String, String>getMapCache("transport-mapping:" + transferId);
+    assertThat(mapping.get(transportId)).isEqualTo("sID-stored-pseudonym");
+  }
+
+  @Test
+  void createPseudonym_withMultipleOriginals_shouldReturnMultipleTransportIds() throws IOException {
+    // Setup gPAS mock for batch processing
+    var fhirGenerator =
+        gpasGetOrCreateResponse(
+            fromList(List.of("patient-1", "patient-2", "patient-3")),
+            fromList(List.of("sID-1", "sID-2", "sID-3")));
+
+    gpas()
+        .register(
+            post(urlEqualTo("/ttp-fhir/fhir/gpas/$pseudonymizeAllowCreate"))
+                .withHeader(CONTENT_TYPE, equalTo(APPLICATION_FHIR_JSON))
+                .willReturn(fhirResponse(fhirGenerator.generateString())));
+
+    // Build request with multiple originals
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("clinical-domain"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-1"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-2"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-3"));
+
+    var response =
+        cdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class);
+
+    create(response)
+        .assertNext(
+            params -> {
+              assertThat(params).isNotNull();
+              // For batch response (>1 original), should have nested "pseudonym" parameters
+              // Total parameters should be 3 (one for each original)
+              var pseudonymParams =
+                  params.getParameter().stream()
+                      .filter(p -> "pseudonym".equals(p.getName()))
+                      .toList();
+
+              // If we have nested structure, pseudonymParams should have 3 entries
+              // If not (e.g., flat structure reused), we need to count differently
+              if (pseudonymParams.isEmpty()) {
+                // Check if flat structure was used (should not happen for batch)
+                assertThat(params.getParameter()).hasSizeGreaterThanOrEqualTo(3);
+              } else {
+                assertThat(pseudonymParams).hasSize(3);
+
+                // All should have unique transport IDs
+                var transportIds =
+                    pseudonymParams.stream().map(this::extractPseudonymValueFromPart).toList();
+                assertThat(transportIds).hasSize(3).doesNotHaveDuplicates();
+              }
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonym_withMissingNamespace_shouldReturn400() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-123"));
+
+    var response =
+        cdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .toBodilessEntity();
+
+    create(response)
+        .expectErrorSatisfies(
+            e -> {
+              assertThat(e).isInstanceOf(WebClientResponseException.class);
+              assertThat(((WebClientResponseException) e).getStatusCode())
+                  .isEqualTo(HttpStatus.BAD_REQUEST);
+            })
+        .verify();
+  }
+
+  @Test
+  void createPseudonym_withMissingOriginalValue_shouldReturn400() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("clinical-domain"));
+
+    var response =
+        cdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .toBodilessEntity();
+
+    create(response)
+        .expectErrorSatisfies(
+            e -> {
+              assertThat(e).isInstanceOf(WebClientResponseException.class);
+              assertThat(((WebClientResponseException) e).getStatusCode())
+                  .isEqualTo(HttpStatus.BAD_REQUEST);
+            })
+        .verify();
+  }
+
+  private Parameters buildVfpsRequest(String namespace, String originalValue) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    params.addParameter().setName("originalValue").setValue(new StringType(originalValue));
+    return params;
+  }
+
+  private String extractPseudonymValue(Parameters params) {
+    return params.getParameter().stream()
+        .filter(p -> "pseudonymValue".equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElseGet(
+            () ->
+                params.getParameter().stream()
+                    .filter(p -> "pseudonym".equals(p.getName()))
+                    .findFirst()
+                    .map(this::extractPseudonymValueFromPart)
+                    .orElse(null));
+  }
+
+  private String extractPseudonymValueFromPart(Parameters.ParametersParameterComponent param) {
+    return param.getPart().stream()
+        .filter(p -> "pseudonymValue".equals(p.getName()) || "pseudonym".equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElse(null);
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerTest.java
@@ -1,0 +1,203 @@
+package care.smith.fts.tca.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.tca.adapters.PseudonymBackendAdapter;
+import care.smith.fts.tca.services.TransportIdService;
+import java.time.Duration;
+import java.util.Map;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class CdAgentFhirPseudonymizerControllerTest {
+
+  @Mock private TransportIdService transportIdService;
+  @Mock private PseudonymBackendAdapter backendAdapter;
+
+  private CdAgentFhirPseudonymizerController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new CdAgentFhirPseudonymizerController(transportIdService, backendAdapter);
+  }
+
+  @Test
+  void createPseudonymSuccessfullyReturnsSingleEntry() {
+    var requestParams = createSingleValueRequest("test-domain", "patient-123");
+    var ttl = Duration.ofMinutes(10);
+
+    when(transportIdService.generateTransferId()).thenReturn("transfer-id-1");
+    when(transportIdService.getDefaultTtl()).thenReturn(ttl);
+    when(transportIdService.generateTransportId()).thenReturn("tId-abc123");
+    when(transportIdService.storeMapping(
+            eq("transfer-id-1"), eq("tId-abc123"), eq("sId-456"), eq("test-domain"), eq(ttl)))
+        .thenReturn(Mono.just("tId-abc123"));
+    when(backendAdapter.fetchOrCreatePseudonyms(eq("test-domain"), anySet()))
+        .thenReturn(Mono.just(Map.of("patient-123", "sId-456")));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+
+              var namespace = findParameterValue(params, "namespace");
+              var originalValue = findParameterValue(params, "originalValue");
+              var pseudonymValue = findParameterValue(params, "pseudonymValue");
+
+              assertThat(namespace).isEqualTo("test-domain");
+              assertThat(originalValue).isEqualTo("patient-123");
+              assertThat(pseudonymValue).isEqualTo("tId-abc123");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonymSuccessfullyReturnsMultipleEntries() {
+    var requestParams = createMultiValueRequest("test-domain", "patient-1", "patient-2");
+    var ttl = Duration.ofMinutes(10);
+
+    when(transportIdService.generateTransferId()).thenReturn("transfer-id-1");
+    when(transportIdService.getDefaultTtl()).thenReturn(ttl);
+    when(transportIdService.generateTransportId()).thenReturn("tId-1", "tId-2");
+    when(transportIdService.storeMapping(anyString(), anyString(), anyString(), anyString(), any()))
+        .thenAnswer(invocation -> Mono.just(invocation.getArgument(1)));
+    when(backendAdapter.fetchOrCreatePseudonyms(eq("test-domain"), anySet()))
+        .thenReturn(Mono.just(Map.of("patient-1", "sId-1", "patient-2", "sId-2")));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              assertThat(params.getParameter()).hasSize(2);
+
+              var firstPseudonym = params.getParameter().get(0);
+              assertThat(firstPseudonym.getName()).isEqualTo("pseudonym");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonymReturnsBadRequestForMissingNamespace() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-123"));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics())
+                  .contains("Missing required parameter 'namespace'");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonymReturnsBadRequestForEmptyNamespace() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("   "));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("patient-123"));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics()).contains("must not be empty");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonymReturnsBadRequestForMissingOriginalValue() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("test-domain"));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics())
+                  .contains("At least one 'originalValue' parameter is required");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void createPseudonymReturnsInternalServerErrorOnBackendFailure() {
+    var requestParams = createSingleValueRequest("test-domain", "patient-123");
+
+    when(transportIdService.generateTransferId()).thenReturn("transfer-id-1");
+    when(backendAdapter.fetchOrCreatePseudonyms(eq("test-domain"), anySet()))
+        .thenReturn(Mono.error(new RuntimeException("Backend connection failed")));
+
+    var result = controller.createPseudonym(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            })
+        .verifyComplete();
+  }
+
+  private Parameters createSingleValueRequest(String namespace, String originalValue) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    params.addParameter().setName("originalValue").setValue(new StringType(originalValue));
+    return params;
+  }
+
+  private Parameters createMultiValueRequest(String namespace, String... originalValues) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    for (String value : originalValues) {
+      params.addParameter().setName("originalValue").setValue(new StringType(value));
+    }
+    return params;
+  }
+
+  private String findParameterValue(Parameters params, String name) {
+    return params.getParameter().stream()
+        .filter(p -> name.equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElse(null);
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerControllerIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerControllerIT.java
@@ -1,0 +1,253 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.test.MockServerUtil.APPLICATION_FHIR_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static reactor.test.StepVerifier.create;
+
+import care.smith.fts.tca.BaseIT;
+import care.smith.fts.tca.services.TransportIdService;
+import care.smith.fts.test.TestWebClientFactory;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * Integration tests for RdAgentFhirPseudonymizerController.
+ *
+ * <p>Tests the Vfps-compatible endpoint that resolves transport IDs to secure pseudonyms (sIDs).
+ */
+@Slf4j
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Import(TestWebClientFactory.class)
+class RdAgentFhirPseudonymizerControllerIT extends BaseIT {
+
+  private static final String VFPS_ENDPOINT = "/api/v2/rd-agent/fhir/$create-pseudonym";
+
+  @Autowired private RedissonClient redisClient;
+  @Autowired private TransportIdService transportIdService;
+  private WebClient rdClient;
+
+  @BeforeEach
+  void setUp(@LocalServerPort int port, @Autowired TestWebClientFactory factory) {
+    rdClient = factory.webClient("https://localhost:" + port, "rd-agent");
+    // Clean up Redis before each test
+    redisClient.getKeys().deleteByPattern("transport-mapping:*");
+  }
+
+  @AfterEach
+  void tearDown() {
+    redisClient.getKeys().deleteByPattern("transport-mapping:*");
+  }
+
+  @Test
+  void resolvePseudonyms_shouldReturnSecurePseudonym() {
+    // First, store a mapping (simulating what CDA endpoint would do)
+    var transferId = transportIdService.generateTransferId();
+    var tId = "test-transport-id-resolve";
+    var sId = "secure-pseudonym-final";
+    var domain = "test-domain";
+
+    transportIdService.storeMapping(transferId, tId, sId, domain, Duration.ofMinutes(5)).block();
+
+    // Build Vfps-format request with the tID
+    var requestParams = buildVfpsRequest("test-domain", tId, transferId);
+
+    // Send request to resolve
+    var response =
+        rdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class);
+
+    create(response)
+        .assertNext(
+            params -> {
+              assertThat(params).isNotNull();
+              // Single value response has 3 flat parameters
+              assertThat(params.getParameter()).hasSize(3);
+
+              // Verify the resolved pseudonym is the sID, not the tID
+              var pseudonymValue = extractPseudonymValue(params);
+              assertThat(pseudonymValue)
+                  .isNotNull()
+                  .isEqualTo(sId) // Should be the real secure pseudonym
+                  .isNotEqualTo(tId); // NOT the transport ID
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonyms_withUnknownTransportId_shouldReturnOriginal() {
+    // Create a transfer session without storing mappings
+    var transferId = transportIdService.generateTransferId();
+    var unknownTId = "unknown-transport-id";
+
+    // Need to store at least something to make the transfer exist
+    // (Otherwise the request should still work, returning tID as-is)
+    var requestParams = buildVfpsRequest("test-domain", unknownTId, transferId);
+
+    var response =
+        rdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class);
+
+    create(response)
+        .assertNext(
+            params -> {
+              assertThat(params).isNotNull();
+              // Unknown tID should return the tID itself (not fail)
+              var pseudonymValue = extractPseudonymValue(params);
+              assertThat(pseudonymValue).isEqualTo(unknownTId);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonyms_withMissingTransferId_shouldReturn400() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("test-domain"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("some-tid"));
+    // Missing transferId
+
+    var response =
+        rdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .toBodilessEntity();
+
+    create(response)
+        .expectErrorSatisfies(
+            e -> {
+              assertThat(e).isInstanceOf(WebClientResponseException.class);
+              assertThat(((WebClientResponseException) e).getStatusCode())
+                  .isEqualTo(HttpStatus.BAD_REQUEST);
+            })
+        .verify();
+  }
+
+  @Test
+  void resolvePseudonyms_withMissingNamespace_shouldReturn400() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("some-tid"));
+    requestParams.addParameter().setName("transferId").setValue(new StringType("some-transfer"));
+
+    var response =
+        rdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .toBodilessEntity();
+
+    create(response)
+        .expectErrorSatisfies(
+            e -> {
+              assertThat(e).isInstanceOf(WebClientResponseException.class);
+              assertThat(((WebClientResponseException) e).getStatusCode())
+                  .isEqualTo(HttpStatus.BAD_REQUEST);
+            })
+        .verify();
+  }
+
+  @Test
+  void resolvePseudonyms_multipleMappings_shouldResolveAll() {
+    // Store multiple mappings
+    var transferId = transportIdService.generateTransferId();
+    var domain = "test-domain";
+    var ttl = Duration.ofMinutes(5);
+
+    transportIdService.storeMapping(transferId, "tId-1", "sId-1", domain, ttl).block();
+    transportIdService.storeMapping(transferId, "tId-2", "sId-2", domain, ttl).block();
+    transportIdService.storeMapping(transferId, "tId-3", "sId-3", domain, ttl).block();
+
+    // Build request with multiple tIDs
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType(domain));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-1"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-2"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-3"));
+    requestParams.addParameter().setName("transferId").setValue(new StringType(transferId));
+
+    var response =
+        rdClient
+            .post()
+            .uri(VFPS_ENDPOINT)
+            .header(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+            .header("Accept", APPLICATION_FHIR_JSON)
+            .bodyValue(requestParams)
+            .retrieve()
+            .bodyToMono(Parameters.class);
+
+    create(response)
+        .assertNext(
+            params -> {
+              assertThat(params).isNotNull();
+              // Should have 3 nested pseudonym entries
+              var pseudonymParams =
+                  params.getParameter().stream()
+                      .filter(p -> "pseudonym".equals(p.getName()))
+                      .toList();
+              assertThat(pseudonymParams).hasSize(3);
+            })
+        .verifyComplete();
+  }
+
+  private Parameters buildVfpsRequest(String namespace, String transportId, String transferId) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    params.addParameter().setName("originalValue").setValue(new StringType(transportId));
+    params.addParameter().setName("transferId").setValue(new StringType(transferId));
+    return params;
+  }
+
+  private String extractPseudonymValue(Parameters params) {
+    return params.getParameter().stream()
+        .filter(p -> "pseudonymValue".equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElseGet(
+            () ->
+                params.getParameter().stream()
+                    .filter(p -> "pseudonym".equals(p.getName()))
+                    .findFirst()
+                    .map(this::extractPseudonymValueFromPart)
+                    .orElse(null));
+  }
+
+  private String extractPseudonymValueFromPart(Parameters.ParametersParameterComponent param) {
+    return param.getPart().stream()
+        .filter(p -> "pseudonymValue".equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElse(null);
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/RdAgentFhirPseudonymizerControllerTest.java
@@ -1,0 +1,234 @@
+package care.smith.fts.tca.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.tca.services.TransportIdService;
+import java.util.Map;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class RdAgentFhirPseudonymizerControllerTest {
+
+  @Mock private TransportIdService transportIdService;
+
+  private RdAgentFhirPseudonymizerController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new RdAgentFhirPseudonymizerController(transportIdService);
+  }
+
+  @Test
+  void resolvePseudonymsSuccessfullyReturnsSingleEntry() {
+    var requestParams = createSingleValueRequest("test-domain", "tId-123", "transfer-id-1");
+
+    when(transportIdService.resolveMappings(eq("transfer-id-1"), anySet()))
+        .thenReturn(Mono.just(Map.of("tId-123", "sId-456")));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+
+              var namespace = findParameterValue(params, "namespace");
+              var originalValue = findParameterValue(params, "originalValue");
+              var pseudonymValue = findParameterValue(params, "pseudonymValue");
+
+              assertThat(namespace).isEqualTo("test-domain");
+              assertThat(originalValue).isEqualTo("tId-123");
+              assertThat(pseudonymValue).isEqualTo("sId-456");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsSuccessfullyReturnsMultipleEntries() {
+    var requestParams = createMultiValueRequest("test-domain", "transfer-id-1", "tId-1", "tId-2");
+
+    when(transportIdService.resolveMappings(eq("transfer-id-1"), anySet()))
+        .thenReturn(Mono.just(Map.of("tId-1", "sId-1", "tId-2", "sId-2")));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              assertThat(params.getParameter()).hasSize(2);
+
+              var firstPseudonym = params.getParameter().get(0);
+              assertThat(firstPseudonym.getName()).isEqualTo("pseudonym");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsTidWhenNotFound() {
+    var requestParams = createSingleValueRequest("test-domain", "tId-missing", "transfer-id-1");
+
+    when(transportIdService.resolveMappings(eq("transfer-id-1"), anySet()))
+        .thenReturn(Mono.just(Map.of()));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+
+              var pseudonymValue = findParameterValue(params, "pseudonymValue");
+              assertThat(pseudonymValue).isEqualTo("tId-missing");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsBadRequestForMissingNamespace() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-123"));
+    requestParams.addParameter().setName("transferId").setValue(new StringType("transfer-id-1"));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics())
+                  .contains("Missing required parameter 'namespace'");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsBadRequestForEmptyNamespace() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("   "));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-123"));
+    requestParams.addParameter().setName("transferId").setValue(new StringType("transfer-id-1"));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics()).contains("must not be empty");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsBadRequestForMissingOriginalValue() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("test-domain"));
+    requestParams.addParameter().setName("transferId").setValue(new StringType("transfer-id-1"));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics())
+                  .contains("At least one 'originalValue' parameter is required");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsBadRequestForMissingTransferId() {
+    var requestParams = new Parameters();
+    requestParams.addParameter().setName("namespace").setValue(new StringType("test-domain"));
+    requestParams.addParameter().setName("originalValue").setValue(new StringType("tId-123"));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+              var params = response.getBody();
+              assertThat(params).isNotNull();
+              var outcome = (OperationOutcome) params.getParameter().get(0).getResource();
+              assertThat(outcome.getIssueFirstRep().getDiagnostics())
+                  .contains("'transferId' is required");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void resolvePseudonymsReturnsInternalServerErrorOnServiceFailure() {
+    var requestParams = createSingleValueRequest("test-domain", "tId-123", "transfer-id-1");
+
+    when(transportIdService.resolveMappings(eq("transfer-id-1"), anySet()))
+        .thenReturn(Mono.error(new RuntimeException("Redis connection failed")));
+
+    var result = controller.resolvePseudonyms(requestParams);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            })
+        .verifyComplete();
+  }
+
+  private Parameters createSingleValueRequest(
+      String namespace, String originalValue, String transferId) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    params.addParameter().setName("originalValue").setValue(new StringType(originalValue));
+    params.addParameter().setName("transferId").setValue(new StringType(transferId));
+    return params;
+  }
+
+  private Parameters createMultiValueRequest(
+      String namespace, String transferId, String... originalValues) {
+    var params = new Parameters();
+    params.addParameter().setName("namespace").setValue(new StringType(namespace));
+    params.addParameter().setName("transferId").setValue(new StringType(transferId));
+    for (String value : originalValues) {
+      params.addParameter().setName("originalValue").setValue(new StringType(value));
+    }
+    return params;
+  }
+
+  private String findParameterValue(Parameters params, String name) {
+    return params.getParameter().stream()
+        .filter(p -> name.equals(p.getName()))
+        .findFirst()
+        .map(p -> p.getValue().primitiveValue())
+        .orElse(null);
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/VfpsPseudonymizeRequestTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/VfpsPseudonymizeRequestTest.java
@@ -1,0 +1,72 @@
+package care.smith.fts.tca.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VfpsPseudonymizeRequestTest {
+
+  @Test
+  void validRequestCreatesImmutableCopy() {
+    var originals = List.of("original1", "original2");
+    var request = new VfpsPseudonymizeRequest("namespace", originals, "transfer-123");
+
+    assertThat(request.namespace()).isEqualTo("namespace");
+    assertThat(request.originals()).containsExactly("original1", "original2");
+    assertThat(request.transferId()).isEqualTo("transfer-123");
+  }
+
+  @Test
+  void nullNamespaceThrowsNullPointerException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest(null, List.of("original"), "transfer-123"))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("namespace is required");
+  }
+
+  @Test
+  void blankNamespaceThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest("  ", List.of("original"), "transfer-123"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("namespace must not be blank");
+  }
+
+  @Test
+  void emptyNamespaceThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest("", List.of("original"), "transfer-123"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("namespace must not be blank");
+  }
+
+  @Test
+  void nullOriginalsThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest("namespace", null, "transfer-123"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("at least one original value required");
+  }
+
+  @Test
+  void emptyOriginalsThrowsIllegalArgumentException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest("namespace", List.of(), "transfer-123"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("at least one original value required");
+  }
+
+  @Test
+  void nullTransferIdThrowsNullPointerException() {
+    assertThatThrownBy(() -> new VfpsPseudonymizeRequest("namespace", List.of("original"), null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("transferId is required");
+  }
+
+  @Test
+  void originalsListIsDefensivelyCopied() {
+    var mutableList = new java.util.ArrayList<>(List.of("original1"));
+    var request = new VfpsPseudonymizeRequest("namespace", mutableList, "transfer-123");
+
+    mutableList.add("original2");
+
+    assertThat(request.originals()).containsExactly("original1");
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/VfpsPseudonymizeResponseTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/VfpsPseudonymizeResponseTest.java
@@ -1,0 +1,58 @@
+package care.smith.fts.tca.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import care.smith.fts.tca.rest.VfpsPseudonymizeResponse.PseudonymEntry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VfpsPseudonymizeResponseTest {
+
+  @Test
+  void validResponseWithPseudonyms() {
+    var entries =
+        List.of(
+            new PseudonymEntry("namespace", "original1", "pseudo1"),
+            new PseudonymEntry("namespace", "original2", "pseudo2"));
+    var response = new VfpsPseudonymizeResponse(entries);
+
+    assertThat(response.pseudonyms()).hasSize(2);
+    assertThat(response.pseudonyms().get(0).original()).isEqualTo("original1");
+    assertThat(response.pseudonyms().get(1).pseudonym()).isEqualTo("pseudo2");
+  }
+
+  @Test
+  void nullPseudonymsCreatesEmptyList() {
+    var response = new VfpsPseudonymizeResponse(null);
+
+    assertThat(response.pseudonyms()).isNotNull();
+    assertThat(response.pseudonyms()).isEmpty();
+  }
+
+  @Test
+  void emptyPseudonymsListIsAllowed() {
+    var response = new VfpsPseudonymizeResponse(List.of());
+
+    assertThat(response.pseudonyms()).isEmpty();
+  }
+
+  @Test
+  void pseudonymsListIsDefensivelyCopied() {
+    var mutableList =
+        new java.util.ArrayList<>(List.of(new PseudonymEntry("namespace", "original", "pseudo")));
+    var response = new VfpsPseudonymizeResponse(mutableList);
+
+    mutableList.add(new PseudonymEntry("namespace", "original2", "pseudo2"));
+
+    assertThat(response.pseudonyms()).hasSize(1);
+  }
+
+  @Test
+  void pseudonymEntryRecordStoresValues() {
+    var entry = new PseudonymEntry("test-namespace", "original-value", "pseudonym-value");
+
+    assertThat(entry.namespace()).isEqualTo("test-namespace");
+    assertThat(entry.original()).isEqualTo("original-value");
+    assertThat(entry.pseudonym()).isEqualTo("pseudonym-value");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `CdAgentFhirPseudonymizerController` for CDA domain (returns transport IDs)
- Adds `RdAgentFhirPseudonymizerController` for RDA domain (resolves tIDs→sIDs)
- Implements Vfps-compatible FHIR Parameters protocol
- Unit and integration tests for both controllers

## Endpoints
- `POST /api/v2/cd-agent/fhir/$create-pseudonym` - Returns transport IDs (tIDs)
- `POST /api/v2/rd-agent/fhir/$create-pseudonym` - Resolves tIDs to sIDs

## Test plan
- [x] Unit tests for controller logic
- [x] Integration tests for endpoint behavior
- [ ] Builds successfully

Depends on: #1343