### PR TITLE
Add RDA FhirPseudonymizerStep

### DIFF
--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerConfig.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerConfig.java
@@ -1,0 +1,51 @@
+package care.smith.fts.rda.impl;
+
+import care.smith.fts.util.HttpClientConfig;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Configuration for FHIR Pseudonymizer service integration in Research Domain Agent.
+ *
+ * <p>This configuration enables deidentification via an external FHIR Pseudonymizer service, which
+ * delegates pseudonym resolution to the Trust Center Agent's Vfps-compatible FHIR operations.
+ *
+ * <p>In the RDA context, the FHIR Pseudonymizer resolves transport IDs (tIDs) in the incoming
+ * bundle to their corresponding secure pseudonyms (sIDs) via TCA's /rd-agent/fhir endpoint.
+ *
+ * <p>Configuration example:
+ *
+ * <pre>{@code
+ * deidentificator:
+ *   fhir-pseudonymizer:
+ *     server:
+ *       baseUrl: "https://fhir-pseudonymizer.research.example.com"
+ *       auth:
+ *         type: oauth2
+ *         clientId: "rda-client"
+ *         clientSecret: "${FHIR_PSEUDONYMIZER_SECRET}"
+ *     timeout: 60s
+ *     maxRetries: 3
+ * }</pre>
+ *
+ * @param server HTTP client configuration for the FHIR Pseudonymizer service
+ * @param timeout Request timeout (default: 60 seconds)
+ * @param maxRetries Maximum retry attempts (default: 3)
+ */
+public record FhirPseudonymizerConfig(
+    @NotNull HttpClientConfig server, Duration timeout, Integer maxRetries) {
+
+  public FhirPseudonymizerConfig(HttpClientConfig server, Duration timeout, Integer maxRetries) {
+    this.server = server;
+    this.timeout = Optional.ofNullable(timeout).orElse(Duration.ofSeconds(60));
+    this.maxRetries = Optional.ofNullable(maxRetries).orElse(3);
+
+    if (this.timeout.isNegative() || this.timeout.isZero()) {
+      throw new IllegalArgumentException("Timeout must be positive");
+    }
+    if (this.maxRetries < 0) {
+      throw new IllegalArgumentException("Max retries must be non-negative");
+    }
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerStep.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerStep.java
@@ -1,0 +1,106 @@
+package care.smith.fts.rda.impl;
+
+import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
+import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.api.TransportBundle;
+import care.smith.fts.api.rda.Deidentificator;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * RDA Deidentificator implementation that delegates deidentification to an external FHIR
+ * Pseudonymizer service.
+ *
+ * <p>This implementation provides an alternative to DeidentifhirStep in the Research Domain Agent.
+ * It sends bundles containing transport IDs to a local FHIR Pseudonymizer service, which resolves
+ * the tIDs to secure pseudonyms (sIDs) via TCA's /rd-agent/fhir endpoint.
+ *
+ * <p>Architecture:
+ *
+ * <pre>
+ * TransportBundle (with transport IDs)
+ *     ↓
+ * FhirPseudonymizerStep (this class)
+ *     ↓ [HTTP POST /fhir with FHIR Bundle]
+ * FHIR Pseudonymizer Service (external, research domain)
+ *     ↓ [POST /$create-pseudonym]
+ * TCA RdAgentFhirPseudonymizerController
+ *     ↓ [tID→sID resolution from Redis]
+ * Bundle (with final sIDs)
+ * </pre>
+ *
+ * <p>The returned bundle contains real secure pseudonyms (sIDs) ready for storage in the research
+ * FHIR store.
+ */
+@Slf4j
+public class FhirPseudonymizerStep implements Deidentificator {
+
+  private static final String FHIR_ENDPOINT = "/fhir";
+
+  private final WebClient fhirPseudonymizerClient;
+  private final FhirPseudonymizerConfig config;
+  private final MeterRegistry meterRegistry;
+  private final FhirContext fhirContext;
+
+  public FhirPseudonymizerStep(
+      WebClient fhirPseudonymizerClient,
+      FhirPseudonymizerConfig config,
+      MeterRegistry meterRegistry,
+      FhirContext fhirContext) {
+    this.fhirPseudonymizerClient = fhirPseudonymizerClient;
+    this.config = config;
+    this.meterRegistry = meterRegistry;
+    this.fhirContext = fhirContext;
+  }
+
+  /**
+   * Deidentifies a FHIR Bundle via external FHIR Pseudonymizer service.
+   *
+   * <p>Sends the TransportBundle to the FHIR Pseudonymizer service, which resolves transport IDs to
+   * secure pseudonyms via TCA and returns the final deidentified bundle.
+   *
+   * @param bundle TransportBundle containing data with transport IDs
+   * @return Mono of Bundle with resolved secure pseudonyms (sIDs)
+   */
+  @Override
+  public Mono<Bundle> deidentify(TransportBundle bundle) {
+    log.debug(
+        "Resolving transport IDs in bundle via FHIR Pseudonymizer, transfer ID: {}",
+        bundle.transferId());
+
+    String bundleJson = fhirContext.newJsonParser().encodeResourceToString(bundle.bundle());
+
+    return fhirPseudonymizerClient
+        .post()
+        .uri(FHIR_ENDPOINT)
+        .contentType(APPLICATION_FHIR_JSON)
+        .accept(APPLICATION_FHIR_JSON)
+        .bodyValue(bundleJson)
+        .retrieve()
+        .bodyToMono(String.class)
+        .map(this::parseDeidentifiedBundle)
+        .timeout(config.timeout())
+        .retryWhen(defaultRetryStrategy(meterRegistry, "rdaFhirPseudonymizerDeidentification"))
+        .doOnSuccess(
+            result ->
+                log.debug(
+                    "Successfully resolved transport IDs for transfer ID: {}, bundle entries: {}",
+                    bundle.transferId(),
+                    result.getEntry().size()))
+        .doOnError(
+            error ->
+                log.error(
+                    "Failed to resolve transport IDs for transfer ID {}: {}",
+                    bundle.transferId(),
+                    error.getMessage()));
+  }
+
+  private Bundle parseDeidentifiedBundle(String bundleJson) {
+    return fhirContext.newJsonParser().parseResource(Bundle.class, bundleJson);
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerStepFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirPseudonymizerStepFactory.java
@@ -1,0 +1,66 @@
+package care.smith.fts.rda.impl;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.util.WebClientFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Factory for creating FhirPseudonymizerStep instances in the Research Domain Agent.
+ *
+ * <p>This factory implements the transfer process step factory pattern, enabling
+ * configuration-based instantiation of FHIR Pseudonymizer deidentificators for tID→sID resolution.
+ *
+ * <p>Configuration example:
+ *
+ * <pre>{@code
+ * deidentificator:
+ *   fhir-pseudonymizer:
+ *     server:
+ *       baseUrl: "https://fhir-pseudonymizer.research.example.com"
+ *       auth:
+ *         type: oauth2
+ *         clientId: "rda-client"
+ *         clientSecret: "${FHIR_PSEUDONYMIZER_SECRET}"
+ *     timeout: 60s
+ *     maxRetries: 3
+ * }</pre>
+ *
+ * <p>The factory is registered as a Spring bean with name "fhir-pseudonymizerDeidentificator" to
+ * enable configuration-based selection between deidentification methods (deidentifhir vs
+ * fhir-pseudonymizer).
+ */
+@Slf4j
+@Component("fhir-pseudonymizerDeidentificator")
+public class FhirPseudonymizerStepFactory
+    implements Deidentificator.Factory<FhirPseudonymizerConfig> {
+
+  private final WebClientFactory clientFactory;
+  private final MeterRegistry meterRegistry;
+  private final FhirContext fhirContext;
+
+  public FhirPseudonymizerStepFactory(
+      WebClientFactory clientFactory, MeterRegistry meterRegistry, FhirContext fhirContext) {
+    this.clientFactory = clientFactory;
+    this.meterRegistry = meterRegistry;
+    this.fhirContext = fhirContext;
+  }
+
+  @Override
+  public Class<FhirPseudonymizerConfig> getConfigType() {
+    return FhirPseudonymizerConfig.class;
+  }
+
+  @Override
+  public Deidentificator create(
+      Deidentificator.Config commonConfig, FhirPseudonymizerConfig implConfig) {
+    var httpClient = clientFactory.create(implConfig.server());
+
+    log.info(
+        "Created RDA FhirPseudonymizerStep with service URL: {}", implConfig.server().baseUrl());
+
+    return new FhirPseudonymizerStep(httpClient, implConfig, meterRegistry, fhirContext);
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerConfigTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerConfigTest.java
@@ -1,0 +1,88 @@
+package care.smith.fts.rda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import care.smith.fts.util.HttpClientConfig;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class FhirPseudonymizerConfigTest {
+
+  @Test
+  void createWithAllParametersExplicit() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+    var timeout = Duration.ofSeconds(30);
+    var maxRetries = 5;
+
+    var config = new FhirPseudonymizerConfig(server, timeout, maxRetries);
+
+    assertThat(config.server()).isEqualTo(server);
+    assertThat(config.timeout()).isEqualTo(timeout);
+    assertThat(config.maxRetries()).isEqualTo(5);
+  }
+
+  @Test
+  void createWithDefaultTimeout() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    var config = new FhirPseudonymizerConfig(server, null, 5);
+
+    assertThat(config.timeout()).isEqualTo(Duration.ofSeconds(60));
+  }
+
+  @Test
+  void createWithDefaultMaxRetries() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    var config = new FhirPseudonymizerConfig(server, Duration.ofSeconds(30), null);
+
+    assertThat(config.maxRetries()).isEqualTo(3);
+  }
+
+  @Test
+  void createWithAllDefaults() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    var config = new FhirPseudonymizerConfig(server, null, null);
+
+    assertThat(config.timeout()).isEqualTo(Duration.ofSeconds(60));
+    assertThat(config.maxRetries()).isEqualTo(3);
+  }
+
+  @Test
+  void negativeTimeoutThrowsException() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    assertThatThrownBy(() -> new FhirPseudonymizerConfig(server, Duration.ofSeconds(-1), 3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Timeout must be positive");
+  }
+
+  @Test
+  void zeroTimeoutThrowsException() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    assertThatThrownBy(() -> new FhirPseudonymizerConfig(server, Duration.ZERO, 3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Timeout must be positive");
+  }
+
+  @Test
+  void negativeMaxRetriesThrowsException() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    assertThatThrownBy(() -> new FhirPseudonymizerConfig(server, Duration.ofSeconds(30), -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Max retries must be non-negative");
+  }
+
+  @Test
+  void zeroMaxRetriesIsAllowed() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+
+    var config = new FhirPseudonymizerConfig(server, Duration.ofSeconds(30), 0);
+
+    assertThat(config.maxRetries()).isZero();
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerStepFactoryTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerStepFactoryTest.java
@@ -1,0 +1,70 @@
+package care.smith.fts.rda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class FhirPseudonymizerStepFactoryTest {
+
+  @Mock private WebClientFactory clientFactory;
+  @Mock private WebClient webClient;
+
+  private MeterRegistry meterRegistry;
+  private FhirContext fhirContext;
+  private FhirPseudonymizerStepFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    fhirContext = FhirContext.forR4();
+    factory = new FhirPseudonymizerStepFactory(clientFactory, meterRegistry, fhirContext);
+  }
+
+  @Test
+  void getConfigTypeReturnsFhirPseudonymizerConfigClass() {
+    assertThat(factory.getConfigType()).isEqualTo(FhirPseudonymizerConfig.class);
+  }
+
+  @Test
+  void createReturnsDeidentificator() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+    var implConfig = new FhirPseudonymizerConfig(server, Duration.ofSeconds(30), 3);
+    var commonConfig = new Deidentificator.Config();
+
+    when(clientFactory.create(any(HttpClientConfig.class))).thenReturn(webClient);
+
+    var result = factory.create(commonConfig, implConfig);
+
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(FhirPseudonymizerStep.class);
+  }
+
+  @Test
+  void createWithDefaultConfigValues() {
+    var server = new HttpClientConfig("http://fhir-pseudonymizer:8080");
+    var implConfig = new FhirPseudonymizerConfig(server, null, null);
+    var commonConfig = new Deidentificator.Config();
+
+    when(clientFactory.create(any(HttpClientConfig.class))).thenReturn(webClient);
+
+    var result = factory.create(commonConfig, implConfig);
+
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(FhirPseudonymizerStep.class);
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerStepIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirPseudonymizerStepIT.java
@@ -1,0 +1,193 @@
+package care.smith.fts.rda.impl;
+
+import static care.smith.fts.test.MockServerUtil.APPLICATION_FHIR_JSON;
+import static care.smith.fts.test.MockServerUtil.clientConfig;
+import static care.smith.fts.test.TestPatientGenerator.generateOnePatient;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static reactor.test.StepVerifier.create;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.api.TransportBundle;
+import care.smith.fts.rda.ResearchDomainAgent;
+import care.smith.fts.util.WebClientFactory;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Integration tests for FhirPseudonymizerStep in Research Domain Agent.
+ *
+ * <p>These tests verify:
+ *
+ * <ul>
+ *   <li>Transport ID resolution to secure pseudonyms via external FHIR Pseudonymizer service
+ *   <li>Retry behavior on service unavailability
+ *   <li>Timeout handling
+ *   <li>Bundle transformation from transport IDs to secure IDs
+ * </ul>
+ */
+@Slf4j
+@SpringBootTest(classes = ResearchDomainAgent.class)
+@WireMockTest
+class FhirPseudonymizerStepIT {
+
+  private static final String FHIR_PSEUDONYMIZER_ENDPOINT = "/fhir";
+
+  private FhirPseudonymizerStep step;
+  private WireMock wireMock;
+  private TransportBundle testBundle;
+  private FhirContext fhirContext;
+
+  @BeforeEach
+  void setUp(
+      WireMockRuntimeInfo wireMockRuntime,
+      @Autowired WebClientFactory clientFactory,
+      @Autowired MeterRegistry meterRegistry)
+      throws IOException {
+    var config =
+        new FhirPseudonymizerConfig(clientConfig(wireMockRuntime), Duration.ofSeconds(30), 3);
+
+    var client = clientFactory.create(clientConfig(wireMockRuntime));
+    wireMock = wireMockRuntime.getWireMock();
+    fhirContext = FhirContext.forR4();
+
+    step = new FhirPseudonymizerStep(client, config, meterRegistry, fhirContext);
+
+    var bundle =
+        generateOnePatient("transport-id-123", "2024", "http://test.example.com", "test-tid");
+    testBundle = new TransportBundle(bundle, "transfer-session-123");
+  }
+
+  @Test
+  void testDeidentifyWithFhirPseudonymizer() {
+    var deidentifiedBundle = new Bundle();
+    deidentifiedBundle.setType(Bundle.BundleType.COLLECTION);
+    deidentifiedBundle.setId("resolved-bundle-123");
+
+    var deidentifiedBundleJson =
+        fhirContext.newJsonParser().encodeResourceToString(deidentifiedBundle);
+
+    wireMock.register(
+        post(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT))
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_FHIR_JSON))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+                    .withBody(deidentifiedBundleJson)));
+
+    var result = step.deidentify(testBundle);
+
+    create(result)
+        .assertNext(
+            bundle -> {
+              assertThat(bundle).isNotNull();
+              assertThat(bundle.getIdPart()).isEqualTo("resolved-bundle-123");
+              assertThat(bundle.getType()).isEqualTo(Bundle.BundleType.COLLECTION);
+            })
+        .verifyComplete();
+
+    wireMock.verifyThat(1, postRequestedFor(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT)));
+  }
+
+  @Test
+  void testDeidentifyServiceUnavailableRetry() {
+    wireMock.register(
+        post(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT))
+            .willReturn(
+                aResponse()
+                    .withStatus(SERVICE_UNAVAILABLE.value())
+                    .withBody("Service temporarily unavailable")));
+
+    var result = step.deidentify(testBundle);
+
+    create(result)
+        .expectErrorSatisfies(
+            error -> {
+              assertThat(error).isNotNull();
+              assertThat(error.getMessage())
+                  .satisfiesAnyOf(
+                      msg -> assertThat(msg).contains("Service temporarily unavailable"),
+                      msg -> assertThat(msg).contains("503"),
+                      msg -> assertThat(msg).contains("SERVICE_UNAVAILABLE"),
+                      msg -> assertThat(msg).contains("Retries exhausted"));
+            })
+        .verify();
+
+    wireMock.verifyThat(4, postRequestedFor(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT)));
+  }
+
+  @Test
+  void testDeidentifySuccessAfterRetry() {
+    var deidentifiedBundle = new Bundle();
+    deidentifiedBundle.setType(Bundle.BundleType.COLLECTION);
+    deidentifiedBundle.setId("resolved-bundle-retry-success");
+
+    var deidentifiedBundleJson =
+        fhirContext.newJsonParser().encodeResourceToString(deidentifiedBundle);
+
+    wireMock.register(
+        post(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT))
+            .inScenario("Retry Scenario")
+            .whenScenarioStateIs("Started")
+            .willReturn(aResponse().withStatus(SERVICE_UNAVAILABLE.value()))
+            .willSetStateTo("First Failure"));
+
+    wireMock.register(
+        post(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT))
+            .inScenario("Retry Scenario")
+            .whenScenarioStateIs("First Failure")
+            .willReturn(aResponse().withStatus(SERVICE_UNAVAILABLE.value()))
+            .willSetStateTo("Second Failure"));
+
+    wireMock.register(
+        post(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT))
+            .inScenario("Retry Scenario")
+            .whenScenarioStateIs("Second Failure")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(CONTENT_TYPE, APPLICATION_FHIR_JSON)
+                    .withBody(deidentifiedBundleJson)));
+
+    var result = step.deidentify(testBundle);
+
+    create(result)
+        .assertNext(
+            bundle -> {
+              assertThat(bundle).isNotNull();
+              assertThat(bundle.getIdPart()).isEqualTo("resolved-bundle-retry-success");
+            })
+        .verifyComplete();
+
+    wireMock.verifyThat(3, postRequestedFor(urlEqualTo(FHIR_PSEUDONYMIZER_ENDPOINT)));
+  }
+
+  @Test
+  void testConfigurationValues() {
+    assertThat(step).isNotNull();
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMock.resetMappings();
+    wireMock.resetScenarios();
+  }
+}

--- a/research-domain-agent/src/test/resources/projects/fhir-pseudonymizer-example.yaml
+++ b/research-domain-agent/src/test/resources/projects/fhir-pseudonymizer-example.yaml
@@ -1,0 +1,15 @@
+# Example project configuration using FHIR Pseudonymizer for transport ID resolution
+# This configuration demonstrates how to use the FhirPseudonymizerStep in RDA context
+# to resolve transport IDs (tIDs) to secure pseudonyms (sIDs) via TCA
+
+deidentificator:
+  fhir-pseudonymizer:
+    server:
+      baseUrl: "http://fhir-pseudonymizer:8080"
+    timeout: 60s
+    maxRetries: 3
+
+bundleSender:
+  fhirStore:
+    fhirServer:
+      baseUrl: "http://rd-hds:8080/fhir"


### PR DESCRIPTION
## Summary
- Adds `FhirPseudonymizerStep` for RDA deidentification pipeline
- Adds `FhirPseudonymizerStepFactory` for project configuration
- Adds `FhirPseudonymizerConfig` for TCA service URL, timeout, auth settings
- Example project YAML configuration

## Data flow
1. RDA receives bundle with transport IDs (tIDs)
2. FhirPseudonymizerStep sends bundle to external FHIR Pseudonymizer
3. FHIR Pseudonymizer calls TCA's RDA endpoint to resolve tIDs→sIDs
4. Bundle with final pseudonyms stored in research FHIR store

## Test plan
- [x] Unit tests for config and factory
- [x] Integration tests for step behavior
- [ ] Builds successfully

Depends on: #1345