### PR TITLE
Fix Timeout Scenario in Connection Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ compile:
 	mvn ${MAVEN_ARGS} clean compile
 
 test:
-	mvn ${MAVEN_ARGS} clean verify
+	mvn ${MAVEN_ARGS} clean verify -Dfts.retryTimeout=false
 
 format:
 	find -type f -name '*.java' | xargs google-java-format -i

--- a/test-util/src/main/java/care/smith/fts/test/connection_scenario/ScenarioMockUtil.java
+++ b/test-util/src/main/java/care/smith/fts/test/connection_scenario/ScenarioMockUtil.java
@@ -26,8 +26,8 @@ public interface ScenarioMockUtil {
     stubFor(builder.willReturn(delayedResponse()));
     StepVerifier.withVirtualTime(fn)
         .expectSubscription()
-        .thenAwait(Duration.ofSeconds(12))
-        .expectError(TimeoutException.class)
+        .thenAwait(Duration.ofSeconds(60))
+        .expectErrorMatches(e -> e instanceof TimeoutException || Exceptions.isRetryExhausted(e))
         .verify();
   }
 


### PR DESCRIPTION
## Summary
- Set `fts.retryTimeout=false` in `make test` to match CI configuration
- Increase `thenAwait` from 12s to 60s (virtual time, zero real cost) to ensure timeout/retry exhaustion triggers
- Accept both `TimeoutException` and `RetryExhaustedException` in timeout assertion

Closes #1423

## Test plan
- [x] `RdaBundleSenderIT` passes (15/15 tests)