### PR TITLE
Distinguish FHIR ID and Identifier

### DIFF
--- a/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
+++ b/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
@@ -22,15 +22,15 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 public record ConsentedPatient(
-    String id, String patientIdentifierSystem, ConsentedPolicies consentedPolicies) {
+    String identifier, String patientIdentifierSystem, ConsentedPolicies consentedPolicies) {
 
   public ConsentedPatient {
-    requireNonNull(id, "Patient's id cannot be null");
+    requireNonNull(identifier, "Patient's identifier cannot be null");
     requireNonNull(consentedPolicies, "Consented policies cannot be null");
   }
 
-  public ConsentedPatient(String id, String patientIdentifierSystem) {
-    this(id, patientIdentifierSystem, new ConsentedPolicies());
+  public ConsentedPatient(String identifier, String patientIdentifierSystem) {
+    this(identifier, patientIdentifierSystem, new ConsentedPolicies());
   }
 
   public Optional<Period> maxConsentedPeriod() {

--- a/api/src/main/java/care/smith/fts/api/cda/CohortSelector.java
+++ b/api/src/main/java/care/smith/fts/api/cda/CohortSelector.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Flux;
 
 public interface CohortSelector extends TransferProcessStep {
 
-  Flux<ConsentedPatient> selectCohort(@NotNull List<String> pids);
+  Flux<ConsentedPatient> selectCohort(@NotNull List<String> identifiers);
 
   interface Factory<C> extends TransferProcessStepFactory<CohortSelector, Config, C> {}
 

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
@@ -5,7 +5,7 @@ import java.util.List;
 import reactor.core.publisher.Mono;
 
 public interface TransferProcessRunner {
-  String start(TransferProcessDefinition process, @NotNull List<String> pids);
+  String start(TransferProcessDefinition process, @NotNull List<String> identifiers);
 
   Mono<List<TransferProcessStatus>> statuses();
 

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
@@ -70,10 +70,10 @@ class DeidentifhirStep implements Deidentificator {
             response -> {
               var transportMapping = response.transportMapping();
               var registry =
-                  generateRegistry(patient.id(), transportMapping, dateTransportMappings);
+                  generateRegistry(patient.identifier(), transportMapping, dateTransportMappings);
               var deidentified =
                   DeidentifhirUtils.deidentify(
-                      config, registry, bundle.bundle(), patient.id(), meterRegistry);
+                      config, registry, bundle.bundle(), patient.identifier(), meterRegistry);
               return new TransportBundle(deidentified, response.transferId());
             });
   }
@@ -82,7 +82,7 @@ class DeidentifhirStep implements Deidentificator {
       ConsentedPatient patient, Set<String> ids, Map<String, String> dateTransportMappings) {
     var request =
         new TransportMappingRequest(
-            patient.id(),
+            patient.identifier(),
             patient.patientIdentifierSystem(),
             ids,
             dateTransportMappings,

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/ExternalCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/ExternalCohortSelector.java
@@ -23,10 +23,13 @@ public class ExternalCohortSelector
 
   @Override
   public CohortSelector create(CohortSelector.Config ignored, Config config) {
-    return pids -> {
-      log.debug("pids: {}", pids);
+    return identifiers -> {
+      log.debug("identifiers: {}", identifiers);
       return fromStream(
-          pids.stream().map(id -> new ConsentedPatient(id, config.patientIdentifierSystem())));
+          identifiers.stream()
+              .map(
+                  identifier ->
+                      new ConsentedPatient(identifier, config.patientIdentifierSystem())));
     };
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -91,16 +91,17 @@ public class TransferProcessController {
       })
   Mono<ResponseEntity<Object>> start(
       @PathVariable("project") String project,
-      @Valid @RequestBody(required = false) List<String> pids,
+      @Valid @RequestBody(required = false) List<String> identifiers,
       UriComponentsBuilder uriBuilder) {
     var process = findProcess(project);
     if (process.isPresent()) {
       log.debug("Running process: {}", process.get());
 
-      var id = processRunner.start(process.get(), Optional.ofNullable(pids).orElse(List.of()));
-      var jobUri = generateJobUri(uriBuilder, id);
+      var processId =
+          processRunner.start(process.get(), Optional.ofNullable(identifiers).orElse(List.of()));
+      var jobUri = generateJobUri(uriBuilder, processId);
       return processRunner
-          .status(id)
+          .status(processId)
           .map(
               s ->
                   ResponseEntity.accepted()

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DataScraper.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DataScraper.java
@@ -34,8 +34,8 @@ public class DataScraper {
   private final java.util.Map<String, String> dateTransportMappings = new HashMap<>();
 
   public DataScraper(Config config, ConsentedPatient patient) {
-    var patientId = patient.id();
-    var keyCreator = NamespacingReplacementProvider.withNamespacing(patientId);
+    var patientIdentifier = patient.identifier();
+    var keyCreator = NamespacingReplacementProvider.withNamespacing(patientIdentifier);
     scrapingStorage = new ScrapingStorage(keyCreator);
 
     var registry = new Registry();

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
@@ -36,10 +36,10 @@ public interface DeidentifhirUtils {
   }
 
   static Registry generateRegistry(
-      String patientId,
+      String patientIdentifier,
       java.util.Map<String, String> transportIds,
       java.util.Map<String, String> dateTransportMappings) {
-    var keyCreator = NamespacingReplacementProvider.withNamespacing(patientId);
+    var keyCreator = NamespacingReplacementProvider.withNamespacing(patientIdentifier);
     var replacementProvider = NamespacingReplacementProvider.of(keyCreator, transportIds);
 
     // Invert tID→dateValue to dateValue→tID for lookup during date processing.
@@ -88,11 +88,12 @@ public interface DeidentifhirUtils {
       Config config,
       Registry registry,
       Bundle bundle,
-      String patientId,
+      String patientIdentifier,
       MeterRegistry meterRegistry) {
     var sample = Timer.start(meterRegistry);
 
-    Map<String, String> staticContext = new Map.Map1<>(Handlers.patientIdentifierKey(), patientId);
+    Map<String, String> staticContext =
+        new Map.Map1<>(Handlers.patientIdentifierKey(), patientIdentifier);
     Deidentifhir deidentifhir = Deidentifhir.apply(config, registry);
     var deidentified = (Bundle) deidentifhir.deidentify(bundle, staticContext);
     sample.stop(meterRegistry.timer("deidentify"));

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -31,10 +31,12 @@ import reactor.test.StepVerifier;
 
 class DefaultTransferProcessRunnerTest {
 
-  private static final String PATIENT_ID = "patient-150622";
-  private static final ConsentedPatient PATIENT = new ConsentedPatient(PATIENT_ID, "system");
-  private static final String PATIENT_ID_2 = "patient-142391";
-  private static final ConsentedPatient PATIENT_2 = new ConsentedPatient(PATIENT_ID_2, "system");
+  private static final String PATIENT_IDENTIFIER = "patient-150622";
+  private static final ConsentedPatient PATIENT =
+      new ConsentedPatient(PATIENT_IDENTIFIER, "system");
+  private static final String PATIENT_IDENTIFIER_2 = "patient-142391";
+  private static final ConsentedPatient PATIENT_2 =
+      new ConsentedPatient(PATIENT_IDENTIFIER_2, "system");
 
   private DefaultTransferProcessRunner runner;
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/ExternalCohortSelectorTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/ExternalCohortSelectorTest.java
@@ -27,7 +27,7 @@ class ExternalCohortSelectorTest {
 
   @Test
   void containsExactlyPatientsConfigured() {
-    create(selector.selectCohort(List.of("pid-1", "pid-2")).map(ConsentedPatient::id))
+    create(selector.selectCohort(List.of("pid-1", "pid-2")).map(ConsentedPatient::identifier))
         .expectNext("pid-1", "pid-2")
         .verifyComplete();
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/FhirResolveServiceIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/FhirResolveServiceIT.java
@@ -44,7 +44,7 @@ import reactor.core.publisher.Mono;
 @WireMockTest
 class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
 
-  private static final String PATIENT_ID = "patient-141392";
+  private static final String PATIENT_IDENTIFIER = "patient-141392";
   public static final String PID_SYSTEM = "patientIdentifierSystem";
 
   @Autowired MeterRegistry meterRegistry;
@@ -79,7 +79,7 @@ class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
 
       @Override
       public Mono<IIdType> executeStep() {
-        return service.resolve(new ConsentedPatient(PATIENT_ID, PID_SYSTEM));
+        return service.resolve(new ConsentedPatient(PATIENT_IDENTIFIER, PID_SYSTEM));
       }
 
       @Override
@@ -113,7 +113,7 @@ class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
     }
 
     create(service.resolve(new ConsentedPatient("external-141392", PID_SYSTEM)))
-        .assertNext(pid -> assertThat(pid.getIdPart()).isEqualTo(PATIENT_ID))
+        .assertNext(pid -> assertThat(pid.getIdPart()).isEqualTo(PATIENT_IDENTIFIER))
         .verifyComplete();
   }
 
@@ -151,7 +151,7 @@ class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
     var fhirResolveGen = resolveSearchResponse(() -> "id1", () -> "patient-1", randomUuid());
     var bundle = fhirResolveGen.generateResources().limit(2).collect(toBundle());
     wireMock.register(fhirStoreRequest().willReturn(fhirResponse(bundle)));
-    create(service.resolve(new ConsentedPatient(PATIENT_ID, PID_SYSTEM)))
+    create(service.resolve(new ConsentedPatient(PATIENT_IDENTIFIER, PID_SYSTEM)))
         .expectError(IllegalStateException.class)
         .verify();
   }
@@ -172,7 +172,7 @@ class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
     }
 
     create(service.resolve(patient))
-        .assertNext(pid -> assertThat(pid.getIdPart()).isEqualTo(PATIENT_ID))
+        .assertNext(pid -> assertThat(pid.getIdPart()).isEqualTo(PATIENT_IDENTIFIER))
         .verifyComplete();
 
     wireMock.verify(

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
@@ -39,13 +39,14 @@ class DeidentifhirUtilsTest {
                 "tid1.identifier.identifierSystem1:tidentifier1",
             "id1.Patient:id1", "tid1.Patient:tid1");
 
-    Registry registry = generateRegistry(patient.id(), transportIDs, Map.of());
+    Registry registry = generateRegistry(patient.identifier(), transportIDs, Map.of());
 
     var config = parseResources(DeidentifhirUtilsTest.class, "CDtoTransport.profile");
 
     var bundle =
         TestPatientGenerator.generateOnePatient("id1", "2023", "identifierSystem1", "identifier1");
-    Bundle deidentifiedBundle = deidentify(config, registry, bundle, patient.id(), meterRegistry);
+    Bundle deidentifiedBundle =
+        deidentify(config, registry, bundle, patient.identifier(), meterRegistry);
     Bundle b = (Bundle) deidentifiedBundle.getEntryFirstRep().getResource();
 
     Patient p = (Patient) b.getEntryFirstRep().getResource();

--- a/test-util/src/main/java/care/smith/fts/test/FhirCohortGenerator.java
+++ b/test-util/src/main/java/care/smith/fts/test/FhirCohortGenerator.java
@@ -133,10 +133,10 @@ public class FhirCohortGenerator {
         "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient");
     patient.setMeta(meta);
 
-    var patientId = new Identifier();
-    patientId.setSystem(pidSystem);
-    patientId.setValue("patient-identifier-" + id);
+    var patientIdentifier = new Identifier();
+    patientIdentifier.setSystem(pidSystem);
+    patientIdentifier.setValue("patient-identifier-" + id);
 
-    return patient.setIdentifier(List.of(patientId));
+    return patient.setIdentifier(List.of(patientIdentifier));
   }
 }

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/ConsentedPatientsProvider.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/ConsentedPatientsProvider.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 public interface ConsentedPatientsProvider {
 
   /**
-   * Fetch consent for all patient IDs provided by `consentRequest.pids()`.
+   * Fetch consent for all patient identifiers provided by `consentRequest.identifiers()`.
    *
    * @param consentRequest
    * @param requestUrl

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProvider.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProvider.java
@@ -38,7 +38,7 @@ public class GicsFhirConsentedPatientsProvider implements ConsentedPatientsProvi
   @Override
   public Mono<Bundle> fetch(
       ConsentFetchRequest req, UriComponentsBuilder requestUrl, PagingParams paging) {
-    if (req.policies().isEmpty() || req.pids().isEmpty()) {
+    if (req.policies().isEmpty() || req.identifiers().isEmpty()) {
       return Mono.just(new Bundle());
     }
 

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/FhirMappingProviderTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/FhirMappingProviderTest.java
@@ -366,12 +366,12 @@ class FhirMappingProviderTest {
   }
 
   @Nested
-  class PatientIdPseudonymsTests {
+  class PatientIdentifierPseudonymsTests {
 
     @Test
-    void patientIdPseudonymsFiltersCorrectKeys() {
-      var patientId = "patient123";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsFiltersCorrectKeys() {
+      var patientIdentifier = "patient123";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping =
           Map.of(
               "Observation.obs1", "tid1",
@@ -382,11 +382,14 @@ class FhirMappingProviderTest {
               "some.other.patient123", "tid6");
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              patientId, "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              patientIdentifier,
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
       assertThat(result).hasSize(1);
-      assertThat(result).containsEntry("tid4", patientIdPseudonym);
+      assertThat(result).containsEntry("tid4", patientIdentifierPseudonym);
       assertThat(result).doesNotContainKey("tid1");
       assertThat(result).doesNotContainKey("tid2");
       assertThat(result).doesNotContainKey("tid3");
@@ -395,22 +398,25 @@ class FhirMappingProviderTest {
     }
 
     @Test
-    void patientIdPseudonymsHandlesEmptyMapping() {
-      var patientId = "patient123";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsHandlesEmptyMapping() {
+      var patientIdentifier = "patient123";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping = Map.<String, String>of();
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              "patient-id", "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              "patient-id",
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
       assertThat(result).isEmpty();
     }
 
     @Test
-    void patientIdPseudonymsHandlesNoMatches() {
-      var patientId = "patient123";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsHandlesNoMatches() {
+      var patientIdentifier = "patient123";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping =
           Map.of(
               "Observation.obs1", "tid1",
@@ -418,31 +424,37 @@ class FhirMappingProviderTest {
               "Patient.differentpatient", "tid3");
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              patientId, "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              patientIdentifier,
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
       assertThat(result).isEmpty();
     }
 
     @Test
-    void patientIdPseudonymsHandlesExactMatch() {
-      var patientId = "patient123";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsHandlesExactMatch() {
+      var patientIdentifier = "patient123";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping =
           Map.of("patient123.identifier.patientIdentifierSystem:patient123", "tid1");
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              patientId, "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              patientIdentifier,
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
       assertThat(result).hasSize(1);
-      assertThat(result).containsEntry("tid1", patientIdPseudonym);
+      assertThat(result).containsEntry("tid1", patientIdentifierPseudonym);
     }
 
     @Test
-    void patientIdPseudonymsHandlesPartialMatches() {
-      var patientId = "123";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsHandlesPartialMatches() {
+      var patientIdentifier = "123";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping =
           Map.of(
               "123.identifier.patientIdentifierSystem:123", "tid1",
@@ -451,28 +463,34 @@ class FhirMappingProviderTest {
               "differentKey", "tid4");
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              patientId, "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              patientIdentifier,
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
       assertThat(result).hasSize(1);
-      assertThat(result).containsEntry("tid1", patientIdPseudonym);
+      assertThat(result).containsEntry("tid1", patientIdentifierPseudonym);
       assertThat(result).doesNotContainKey("tid2");
       assertThat(result).doesNotContainKey("tid3");
       assertThat(result).doesNotContainKey("tid4");
     }
 
     @Test
-    void patientIdPseudonymsHandlesSpecialCharacters() {
-      var patientId = "patient@#$%";
-      var patientIdPseudonym = "pseudonym456";
+    void patientIdentifierPseudonymsHandlesSpecialCharacters() {
+      var patientIdentifier = "patient@#$%";
+      var patientIdentifierPseudonym = "pseudonym456";
       var transportMapping =
           Map.of("patient@#$%.identifier.patientIdentifierSystem:patient@#$%", "tid1");
 
       var result =
-          FhirMappingProvider.patientIdPseudonyms(
-              patientId, "patientIdentifierSystem", patientIdPseudonym, transportMapping);
+          FhirMappingProvider.patientIdentifierPseudonyms(
+              patientIdentifier,
+              "patientIdentifierSystem",
+              patientIdentifierPseudonym,
+              transportMapping);
 
-      assertThat(result).containsEntry("tid1", patientIdPseudonym);
+      assertThat(result).containsEntry("tid1", patientIdentifierPseudonym);
     }
   }
 

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/DeIdentificationControllerIT.java
@@ -93,7 +93,7 @@ class DeIdentificationControllerIT extends BaseIT {
         doPost(
             ofEntries(
                 entry("tcaDomains", DEFAULT_DOMAINS),
-                entry("patientId", "id-144218"),
+                entry("patientIdentifier", "id-144218"),
                 entry("patientIdentifierSystem", "http://fts.smith.care"),
                 entry("resourceIds", Set.of("id-144218", "id-244194")),
                 entry("dateTransportMappings", Map.of()),
@@ -139,7 +139,7 @@ class DeIdentificationControllerIT extends BaseIT {
         doPost(
             ofEntries(
                 entry("tcaDomains", DEFAULT_DOMAINS),
-                entry("patientId", "id-144218"),
+                entry("patientIdentifier", "id-144218"),
                 entry("patientIdentifierSystem", "http://fts.smith.care"),
                 entry("resourceIds", Set.of("id-144218", "id-244194")),
                 entry("dateTransportMappings", Map.of()),
@@ -209,7 +209,7 @@ class DeIdentificationControllerIT extends BaseIT {
         doPost(
                 ofEntries(
                     entry("tcaDomains", DEFAULT_DOMAINS),
-                    entry("patientId", "id-144218"),
+                    entry("patientIdentifier", "id-144218"),
                     entry("patientIdentifierSystem", "http://fts.smith.care"),
                     entry("resourceIds", Set.of("id-144218", "id-244194")),
                     entry("dateTransportMappings", Map.of("tId-date-1", "2024-03-15")),

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/FetchConsentControllerIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/FetchConsentControllerIT.java
@@ -46,7 +46,7 @@ class FetchConsentControllerIT extends BaseIT {
           entry("policies", Set.of("")),
           entry("policySystem", "sys"),
           entry("patientIdentifierSystem", "sys"),
-          entry("pids", List.of("FTS001")));
+          entry("identifiers", List.of("FTS001")));
 
   private WebClient client;
 

--- a/util/src/main/java/care/smith/fts/util/tca/ConsentFetchRequest.java
+++ b/util/src/main/java/care/smith/fts/util/tca/ConsentFetchRequest.java
@@ -10,5 +10,5 @@ public record ConsentFetchRequest(
     @NotNull(groups = ConsentFetchRequest.class) Set<String> policies,
     @NotBlank(groups = ConsentFetchRequest.class) String policySystem,
     @NotBlank(groups = ConsentFetchRequest.class) String patientIdentifierSystem,
-    List<String> pids)
+    List<String> identifiers)
     implements ConsentRequest {}

--- a/util/src/main/java/care/smith/fts/util/tca/TransportMappingRequest.java
+++ b/util/src/main/java/care/smith/fts/util/tca/TransportMappingRequest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * Request from CDA to TCA for transport mappings.
  *
- * @param patientId the patient ID
+ * @param patientIdentifier the patient identifier
  * @param patientIdentifierSystem the patient identifier system
  * @param resourceIds set of resource IDs to generate transport mappings for
  * @param dateTransportMappings map of transport ID → original date value (tID→date)
@@ -18,7 +18,7 @@ import java.util.Set;
  * @param dateShiftPreserve date shift preservation mode
  */
 public record TransportMappingRequest(
-    @NotNull(groups = TransportMappingRequest.class) String patientId,
+    @NotNull(groups = TransportMappingRequest.class) String patientIdentifier,
     @NotNull(groups = TransportMappingRequest.class) String patientIdentifierSystem,
     @NotNull(groups = TransportMappingRequest.class) Set<String> resourceIds,
     @NotNull(groups = TransportMappingRequest.class) Map<String, String> dateTransportMappings,

--- a/util/src/test/java/care/smith/fts/util/ConsentedPatientExtractorTest.java
+++ b/util/src/test/java/care/smith/fts/util/ConsentedPatientExtractorTest.java
@@ -31,13 +31,13 @@ class ConsentedPatientExtractorTest {
                 POLICY_SYSTEM,
                 Stream.of(bundle1, bundle2, bundle3),
                 POLICIES_TO_CHECK,
-                bundle -> getPatientId(bundle))
+                bundle -> getPatientIdentifier(bundle))
             .collect(Collectors.toList());
 
     assertThat(result).hasSize(2); // Only bundles with all policies should be included
-    assertThat(result.get(0).id()).isEqualTo("12345");
+    assertThat(result.get(0).identifier()).isEqualTo("12345");
     assertThat(result.get(0).patientIdentifierSystem()).isEqualTo(PATIENT_IDENTIFIER_SYSTEM);
-    assertThat(result.get(1).id()).isEqualTo("67890");
+    assertThat(result.get(1).identifier()).isEqualTo("67890");
     assertThat(result.get(1).patientIdentifierSystem()).isEqualTo(PATIENT_IDENTIFIER_SYSTEM);
   }
 
@@ -51,10 +51,10 @@ class ConsentedPatientExtractorTest {
             POLICY_SYSTEM,
             bundle,
             POLICIES_TO_CHECK,
-            b -> getPatientId(b));
+            b -> getPatientIdentifier(b));
 
     assertThat(result).isPresent();
-    assertThat(result.get().id()).isEqualTo("12345");
+    assertThat(result.get().identifier()).isEqualTo("12345");
     assertThat(result.get().patientIdentifierSystem()).isEqualTo(PATIENT_IDENTIFIER_SYSTEM);
     assertThat(result.get().consentedPolicies().hasAllPolicies(POLICIES_TO_CHECK)).isTrue();
   }
@@ -69,7 +69,7 @@ class ConsentedPatientExtractorTest {
             POLICY_SYSTEM,
             bundle,
             POLICIES_TO_CHECK,
-            b -> getPatientId(b));
+            b -> getPatientIdentifier(b));
 
     assertThat(result).isEmpty();
   }
@@ -192,10 +192,10 @@ class ConsentedPatientExtractorTest {
     assertThat(policies).doesNotContain("POLICY_C"); // Not in concept
   }
 
-  private static Bundle generateBundleWithConsent(String patientId, String... policies) {
+  private static Bundle generateBundleWithConsent(String patientIdentifier, String... policies) {
     var patient = new Patient();
     patient.addIdentifier(
-        new Identifier().setSystem(PATIENT_IDENTIFIER_SYSTEM).setValue(patientId));
+        new Identifier().setSystem(PATIENT_IDENTIFIER_SYSTEM).setValue(patientIdentifier));
 
     var consent = new Consent();
     var mainProvision = new Consent.ProvisionComponent().setType(Consent.ConsentProvisionType.DENY);
@@ -221,7 +221,7 @@ class ConsentedPatientExtractorTest {
         .setPeriod(new Period().setStart(new Date(0)).setEnd(new Date(1)));
   }
 
-  private static Optional<String> getPatientId(Bundle bundle) {
+  private static Optional<String> getPatientIdentifier(Bundle bundle) {
     return bundle.getEntry().stream()
         .map(Bundle.BundleEntryComponent::getResource)
         .filter(Patient.class::isInstance)

--- a/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
@@ -35,7 +35,7 @@ class WebClientDefaultsTest {
                 jsonResponse(
                     """
                     {
-                      "id": "patient",
+                      "identifier": "patient",
                       "patientIdentifierSystem": "system",
                       "consentedPolicies": {
                         "policies":{
@@ -55,7 +55,7 @@ class WebClientDefaultsTest {
     create(webClient.post().retrieve().bodyToMono(ConsentedPatient.class))
         .assertNext(
             b -> {
-              assertThat(b.id()).isEqualTo("patient");
+              assertThat(b.identifier()).isEqualTo("patient");
               assertThat(b.patientIdentifierSystem()).isEqualTo("system");
               assertThat(b.consentedPolicies().policyNames()).isNotEmpty();
             })

--- a/util/src/test/java/care/smith/fts/util/tca/ConsentFetchRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/ConsentFetchRequestTest.java
@@ -44,7 +44,7 @@ class ConsentFetchRequestTest {
           "policies": ["policy1", "policy2"],
           "policySystem": "policySystem",
           "patientIdentifierSystem": "patientIdentifierSystem",
-          "pids": ["id1"]
+          "identifiers": ["id1"]
         }
         """;
 
@@ -54,6 +54,6 @@ class ConsentFetchRequestTest {
     assertThat(request.policies()).containsExactlyInAnyOrder("policy1", "policy2");
     assertThat(request.policySystem()).isEqualTo("policySystem");
     assertThat(request.patientIdentifierSystem()).isEqualTo("patientIdentifierSystem");
-    assertThat(request.pids()).containsExactlyInAnyOrder("id1");
+    assertThat(request.identifiers()).containsExactlyInAnyOrder("id1");
   }
 }

--- a/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
@@ -50,7 +50,7 @@ class TransportMappingRequestTest {
     String json =
         """
         {
-          "patientId": "patient123",
+          "patientIdentifier": "patient123",
           "patientIdentifierSystem": "patientIdentifierSystem",
           "resourceIds": ["id1", "id2"],
           "dateTransportMappings": {"tId1": "2024-03-15", "tId2": "2024-01-01"},
@@ -65,7 +65,7 @@ class TransportMappingRequestTest {
 
     TransportMappingRequest request = objectMapper.readValue(json, TransportMappingRequest.class);
 
-    assertThat(request.patientId()).isEqualTo("patient123");
+    assertThat(request.patientIdentifier()).isEqualTo("patient123");
     assertThat(request.resourceIds()).containsExactlyInAnyOrder("id1", "id2");
     assertThat(request.dateTransportMappings())
         .containsExactlyInAnyOrderEntriesOf(Map.of("tId1", "2024-03-15", "tId2", "2024-01-01"));


### PR DESCRIPTION
## Summary
- Renames `patientId` to `patientIdentifier` throughout the codebase to clarify the distinction between FHIR resource IDs and FHIR Identifiers
- Updates `ConsentedPatient` record field from `id()` to `identifier()`
- Ensures consistent naming in transport mapping requests and consent handling