### PR TITLE
Redesign FP Date Shift Architecture

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerConfig.java
@@ -1,0 +1,31 @@
+package care.smith.fts.cda.impl;
+
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.tca.TcaDomains;
+import java.io.File;
+import java.time.Duration;
+import java.util.Optional;
+
+public record FhirPseudonymizerConfig(
+    HttpClientConfig server,
+    File anonymizationConfig,
+    TCAConfig trustCenterAgent,
+    Duration maxDateShift,
+    DateShiftPreserve dateShiftPreserve) {
+
+  public FhirPseudonymizerConfig(
+      HttpClientConfig server,
+      File anonymizationConfig,
+      TCAConfig trustCenterAgent,
+      Duration maxDateShift,
+      DateShiftPreserve dateShiftPreserve) {
+    this.server = server;
+    this.anonymizationConfig = anonymizationConfig;
+    this.trustCenterAgent = trustCenterAgent;
+    this.maxDateShift = maxDateShift;
+    this.dateShiftPreserve = Optional.ofNullable(dateShiftPreserve).orElse(DateShiftPreserve.NONE);
+  }
+
+  public record TCAConfig(HttpClientConfig server, TcaDomains domains) {}
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerStep.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerStep.java
@@ -1,0 +1,152 @@
+package care.smith.fts.cda.impl;
+
+import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
+import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
+
+import care.smith.fts.api.ConsentedPatientBundle;
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.api.TransportBundle;
+import care.smith.fts.api.cda.Deidentificator;
+import care.smith.fts.util.fhir.DateShiftAnonymizer;
+import care.smith.fts.util.tca.TcaDomains;
+import care.smith.fts.util.tca.TransportMappingResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Deidentification step using an external FHIR Pseudonymizer service. Handles date nullification
+ * locally, delegates ID pseudonymization to FP (which calls TCA), then consolidates all mappings
+ * via TCA.
+ */
+@Slf4j
+class FhirPseudonymizerStep implements Deidentificator {
+
+  private static final Pattern TID_PATTERN = Pattern.compile("[A-Za-z0-9_-]{32}");
+
+  private final WebClient fpClient;
+  private final WebClient tcaClient;
+  private final TcaDomains domains;
+  private final Duration maxDateShift;
+  private final DateShiftPreserve preserve;
+  private final List<String> dateShiftPaths;
+  private final MeterRegistry meterRegistry;
+
+  FhirPseudonymizerStep(
+      WebClient fpClient,
+      WebClient tcaClient,
+      TcaDomains domains,
+      Duration maxDateShift,
+      DateShiftPreserve preserve,
+      List<String> dateShiftPaths,
+      MeterRegistry meterRegistry) {
+    this.fpClient = fpClient;
+    this.tcaClient = tcaClient;
+    this.domains = domains;
+    this.maxDateShift = maxDateShift;
+    this.preserve = preserve;
+    this.dateShiftPaths = dateShiftPaths;
+    this.meterRegistry = meterRegistry;
+  }
+
+  @Override
+  public Mono<TransportBundle> deidentify(ConsentedPatientBundle bundle) {
+    return Mono.defer(
+        () -> {
+          var patient = bundle.consentedPatient();
+          var dateMappings = DateShiftAnonymizer.nullifyDates(bundle.bundle(), dateShiftPaths);
+
+          log.trace(
+              "Nullified {} date elements, sending to FHIR Pseudonymizer", dateMappings.size());
+
+          return sendToFhirPseudonymizer(bundle.bundle())
+              .flatMap(
+                  pseudonymizedBundle -> {
+                    var identityTIds = extractTransportIds(pseudonymizedBundle);
+                    if (identityTIds.isEmpty() && dateMappings.isEmpty()) {
+                      return Mono.empty();
+                    }
+                    return consolidateViaTca(patient.identifier(), identityTIds, dateMappings)
+                        .map(transferId -> new TransportBundle(pseudonymizedBundle, transferId));
+                  });
+        });
+  }
+
+  private Mono<Bundle> sendToFhirPseudonymizer(Bundle bundle) {
+    return fpClient
+        .post()
+        .uri("/$de-identify")
+        .headers(h -> h.setContentType(APPLICATION_FHIR_JSON))
+        .headers(h -> h.setAccept(List.of(APPLICATION_FHIR_JSON)))
+        .bodyValue(bundle)
+        .retrieve()
+        .bodyToMono(Bundle.class)
+        .timeout(Duration.ofSeconds(60))
+        .retryWhen(defaultRetryStrategy(meterRegistry, "sendToFhirPseudonymizer"))
+        .doOnError(e -> log.error("FHIR Pseudonymizer call failed: {}", e.getMessage()));
+  }
+
+  /**
+   * Extracts transport IDs from the pseudonymized bundle. After FP processing, resource IDs that
+   * were pseudonymized will be 32-char Base64URL tIDs from TCA.
+   */
+  static Set<String> extractTransportIds(Bundle bundle) {
+    return bundle.getEntry().stream()
+        .map(Bundle.BundleEntryComponent::getResource)
+        .filter(r -> r != null && r.hasId())
+        .map(r -> r.getIdElement().getIdPart())
+        .filter(id -> id != null && TID_PATTERN.matcher(id).matches())
+        .collect(Collectors.toSet());
+  }
+
+  private Mono<String> consolidateViaTca(
+      String patientIdentifier, Set<String> identityTIds, Map<String, String> dateMappings) {
+
+    var request =
+        new FpTransportMappingRequest(
+            patientIdentifier,
+            identityTIds,
+            dateMappings,
+            domains.dateShift(),
+            maxDateShift,
+            preserve);
+
+    log.trace(
+        "Consolidating {} identity tIDs + {} date mappings via TCA",
+        identityTIds.size(),
+        dateMappings.size());
+
+    return tcaClient
+        .post()
+        .uri("/api/v2/cd/fhir-pseudonymizer/transport-mapping")
+        .headers(h -> h.setContentType(MediaType.APPLICATION_JSON))
+        .bodyValue(request)
+        .retrieve()
+        .bodyToMono(TransportMappingResponse.class)
+        .timeout(Duration.ofSeconds(30))
+        .retryWhen(defaultRetryStrategy(meterRegistry, "consolidateViaTca"))
+        .doOnError(e -> log.error("TCA consolidation failed: {}", e.getMessage()))
+        .map(TransportMappingResponse::transferId);
+  }
+
+  /**
+   * DTO matching TCA's FpTransportMappingRequest. Duplicated here to avoid cross-module dependency
+   * on the TCA rest package.
+   */
+  record FpTransportMappingRequest(
+      String patientIdentifier,
+      Set<String> transportIds,
+      Map<String, String> dateMappings,
+      String dateShiftDomain,
+      Duration maxDateShift,
+      DateShiftPreserve dateShiftPreserve) {}
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerStepFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirPseudonymizerStepFactory.java
@@ -1,0 +1,53 @@
+package care.smith.fts.cda.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import care.smith.fts.api.cda.Deidentificator;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.fhir.DateShiftAnonymizer;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component("fhir-pseudonymizerDeidentificator")
+public class FhirPseudonymizerStepFactory
+    implements Deidentificator.Factory<FhirPseudonymizerConfig> {
+
+  private final WebClientFactory clientFactory;
+  private final MeterRegistry meterRegistry;
+
+  public FhirPseudonymizerStepFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+    this.clientFactory = clientFactory;
+    this.meterRegistry = meterRegistry;
+  }
+
+  @Override
+  public Class<FhirPseudonymizerConfig> getConfigType() {
+    return FhirPseudonymizerConfig.class;
+  }
+
+  @Override
+  public Deidentificator create(
+      Deidentificator.Config commonConfig, FhirPseudonymizerConfig implConfig) {
+    var fpClient = clientFactory.create(implConfig.server());
+    var tcaClient = clientFactory.create(implConfig.trustCenterAgent().server());
+
+    List<String> dateShiftPaths;
+    try {
+      dateShiftPaths =
+          DateShiftAnonymizer.parseDateShiftPaths(requireNonNull(implConfig.anonymizationConfig()));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to parse anonymization config", e);
+    }
+
+    return new FhirPseudonymizerStep(
+        fpClient,
+        tcaClient,
+        implConfig.trustCenterAgent().domains(),
+        implConfig.maxDateShift(),
+        implConfig.dateShiftPreserve(),
+        dateShiftPaths,
+        meterRegistry);
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerConfigTest.java
@@ -1,0 +1,66 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.tca.TcaDomains;
+import java.io.File;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class FhirPseudonymizerConfigTest {
+
+  @Test
+  void dateShiftPreserveDefaultsToNoneWhenNull() {
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+
+    var config =
+        new FhirPseudonymizerConfig(
+            serviceUrl, new File("anon.yaml"), tcaConfig, Duration.ofDays(14), null);
+
+    assertThat(config.dateShiftPreserve()).isEqualTo(DateShiftPreserve.NONE);
+  }
+
+  @Test
+  void dateShiftPreserveRetainsExplicitValue() {
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+
+    var config =
+        new FhirPseudonymizerConfig(
+            serviceUrl,
+            new File("anon.yaml"),
+            tcaConfig,
+            Duration.ofDays(14),
+            DateShiftPreserve.WEEKDAY);
+
+    assertThat(config.dateShiftPreserve()).isEqualTo(DateShiftPreserve.WEEKDAY);
+  }
+
+  @Test
+  void recordAccessors() {
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+    var anonFile = new File("anon.yaml");
+    var maxShift = Duration.ofDays(14);
+
+    var config =
+        new FhirPseudonymizerConfig(
+            serviceUrl, anonFile, tcaConfig, maxShift, DateShiftPreserve.DAYTIME);
+
+    assertThat(config.server()).isEqualTo(serviceUrl);
+    assertThat(config.anonymizationConfig()).isEqualTo(anonFile);
+    assertThat(config.trustCenterAgent()).isEqualTo(tcaConfig);
+    assertThat(config.maxDateShift()).isEqualTo(maxShift);
+    assertThat(config.trustCenterAgent().server()).isEqualTo(tcaServer);
+    assertThat(config.trustCenterAgent().domains()).isEqualTo(domains);
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerStepFactoryTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerStepFactoryTest.java
@@ -1,0 +1,111 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.api.cda.Deidentificator;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.tca.TcaDomains;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class FhirPseudonymizerStepFactoryTest {
+
+  @Mock private WebClientFactory clientFactory;
+  @Mock private WebClient webClient;
+  @TempDir File tempDir;
+
+  private FhirPseudonymizerStepFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    factory = new FhirPseudonymizerStepFactory(clientFactory, new SimpleMeterRegistry());
+  }
+
+  @Test
+  void getConfigTypeReturnsFhirPseudonymizerConfig() {
+    assertThat(factory.getConfigType()).isEqualTo(FhirPseudonymizerConfig.class);
+  }
+
+  @Test
+  void createReturnsDeidentificatorWithValidConfig() throws IOException {
+    when(clientFactory.create(any(HttpClientConfig.class))).thenReturn(webClient);
+
+    var configFile = writeAnonymizationConfig();
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+
+    var implConfig =
+        new FhirPseudonymizerConfig(
+            serviceUrl, configFile, tcaConfig, Duration.ofDays(14), DateShiftPreserve.NONE);
+
+    Deidentificator result = factory.create(new Deidentificator.Config(), implConfig);
+
+    assertThat(result).isInstanceOf(FhirPseudonymizerStep.class);
+  }
+
+  @Test
+  void createThrowsWhenAnonymizationConfigIsNull() {
+    when(clientFactory.create(any(HttpClientConfig.class))).thenReturn(webClient);
+
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+
+    var implConfig =
+        new FhirPseudonymizerConfig(
+            serviceUrl, null, tcaConfig, Duration.ofDays(14), DateShiftPreserve.NONE);
+
+    assertThatThrownBy(() -> factory.create(new Deidentificator.Config(), implConfig))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void createThrowsWhenConfigFileDoesNotExist() {
+    when(clientFactory.create(any(HttpClientConfig.class))).thenReturn(webClient);
+
+    var nonExistent = new File(tempDir, "nonexistent.yaml");
+    var serviceUrl = new HttpClientConfig("http://localhost:1234");
+    var tcaServer = new HttpClientConfig("http://localhost:5678");
+    var domains = new TcaDomains("pseudo", "salt", "dateshift");
+    var tcaConfig = new FhirPseudonymizerConfig.TCAConfig(tcaServer, domains);
+
+    var implConfig =
+        new FhirPseudonymizerConfig(
+            serviceUrl, nonExistent, tcaConfig, Duration.ofDays(14), DateShiftPreserve.NONE);
+
+    assertThatThrownBy(() -> factory.create(new Deidentificator.Config(), implConfig))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to parse anonymization config");
+  }
+
+  private File writeAnonymizationConfig() throws IOException {
+    var file = new File(tempDir, "anonymization.yaml");
+    Files.writeString(
+        file.toPath(),
+        """
+        fhirPathRules:
+          - path: "Encounter.period.start"
+            method: "dateshift"
+        """);
+    return file;
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerStepTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirPseudonymizerStepTest.java
@@ -1,0 +1,226 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.api.ConsentedPatient;
+import care.smith.fts.api.ConsentedPatientBundle;
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.util.tca.TcaDomains;
+import care.smith.fts.util.tca.TransportMappingResponse;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class FhirPseudonymizerStepTest {
+
+  @Mock private WebClient fpClient;
+  @Mock private WebClient tcaClient;
+  @Mock private WebClient.RequestBodyUriSpec fpPostSpec;
+  @Mock private WebClient.RequestBodySpec fpBodySpec;
+  @Mock private WebClient.RequestHeadersSpec fpHeadersSpec;
+  @Mock private WebClient.ResponseSpec fpResponseSpec;
+  @Mock private WebClient.RequestBodyUriSpec tcaPostSpec;
+  @Mock private WebClient.RequestBodySpec tcaBodySpec;
+  @Mock private WebClient.RequestHeadersSpec tcaHeadersSpec;
+  @Mock private WebClient.ResponseSpec tcaResponseSpec;
+
+  private FhirPseudonymizerStep step;
+
+  @BeforeEach
+  void setUp() {
+    var domains = new TcaDomains("pseudo-domain", "salt-domain", "dateshift-domain");
+    step =
+        new FhirPseudonymizerStep(
+            fpClient,
+            tcaClient,
+            domains,
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE,
+            List.of(),
+            new SimpleMeterRegistry());
+
+    // FP client mock chain (lenient: not all tests exercise FP)
+    lenient().when(fpClient.post()).thenReturn(fpPostSpec);
+    lenient().when(fpPostSpec.uri(any(String.class))).thenReturn(fpBodySpec);
+    lenient().when(fpBodySpec.headers(any(Consumer.class))).thenReturn(fpBodySpec);
+    lenient().when(fpBodySpec.bodyValue(any())).thenReturn(fpHeadersSpec);
+    lenient().when(fpHeadersSpec.retrieve()).thenReturn(fpResponseSpec);
+
+    // TCA client mock chain (lenient: not all tests exercise TCA)
+    lenient().when(tcaClient.post()).thenReturn(tcaPostSpec);
+    lenient().when(tcaPostSpec.uri(any(String.class))).thenReturn(tcaBodySpec);
+    lenient().when(tcaBodySpec.headers(any(Consumer.class))).thenReturn(tcaBodySpec);
+    lenient().when(tcaBodySpec.bodyValue(any())).thenReturn(tcaHeadersSpec);
+    lenient().when(tcaHeadersSpec.retrieve()).thenReturn(tcaResponseSpec);
+  }
+
+  @Test
+  void extractTransportIdsFinds32CharBase64UrlIds() {
+    var bundle = new Bundle();
+
+    var patient = new Patient();
+    patient.setId("AbCdEfGhIjKlMnOpQrStUvWxYz012345"); // 32 chars Base64URL
+    bundle.addEntry().setResource(patient);
+
+    var encounter = new Encounter();
+    encounter.setId("short-id"); // Not a tID
+    bundle.addEntry().setResource(encounter);
+
+    var encounter2 = new Encounter();
+    encounter2.setId("a-uuid-that-is-longer-than-32-chars-total"); // Not a 32-char tID
+    bundle.addEntry().setResource(encounter2);
+
+    var tIds = FhirPseudonymizerStep.extractTransportIds(bundle);
+
+    assertThat(tIds).containsExactly("AbCdEfGhIjKlMnOpQrStUvWxYz012345");
+  }
+
+  @Test
+  void extractTransportIdsReturnsEmptyForNoMatches() {
+    var bundle = new Bundle();
+    var patient = new Patient();
+    patient.setId("regular-uuid-id");
+    bundle.addEntry().setResource(patient);
+
+    var tIds = FhirPseudonymizerStep.extractTransportIds(bundle);
+
+    assertThat(tIds).isEmpty();
+  }
+
+  @Test
+  void deidentifyReturnsBundleWithTransferId() {
+    var pseudonymizedBundle = new Bundle();
+    var pseudoPatient = new Patient();
+    pseudoPatient.setId("AbCdEfGhIjKlMnOpQrStUvWxYz012345");
+    pseudonymizedBundle.addEntry().setResource(pseudoPatient);
+
+    when(fpResponseSpec.bodyToMono(Bundle.class)).thenReturn(Mono.just(pseudonymizedBundle));
+    when(tcaResponseSpec.bodyToMono(TransportMappingResponse.class))
+        .thenReturn(Mono.just(new TransportMappingResponse("transfer-id-abc")));
+
+    var patient = new ConsentedPatient("patient-1", "http://system");
+    var inputBundle = new Bundle();
+    inputBundle.addEntry().setResource(new Patient());
+
+    var result = step.deidentify(new ConsentedPatientBundle(inputBundle, patient));
+
+    StepVerifier.create(result)
+        .assertNext(
+            transport -> {
+              assertThat(transport.transferId()).isEqualTo("transfer-id-abc");
+              assertThat(transport.bundle()).isEqualTo(pseudonymizedBundle);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void deidentifyReturnsEmptyWhenNoMappings() {
+    var emptyBundle = new Bundle();
+
+    when(fpResponseSpec.bodyToMono(Bundle.class)).thenReturn(Mono.just(emptyBundle));
+
+    var patient = new ConsentedPatient("patient-1", "http://system");
+    var inputBundle = new Bundle();
+
+    var result = step.deidentify(new ConsentedPatientBundle(inputBundle, patient));
+
+    StepVerifier.create(result).verifyComplete();
+  }
+
+  @Test
+  void extractTransportIdsSkipsNullResource() {
+    var bundle = new Bundle();
+    bundle.addEntry(); // entry with null resource
+
+    var tIds = FhirPseudonymizerStep.extractTransportIds(bundle);
+
+    assertThat(tIds).isEmpty();
+  }
+
+  @Test
+  void extractTransportIdsSkipsResourceWithoutId() {
+    var bundle = new Bundle();
+    var patient = new Patient(); // no ID set
+    bundle.addEntry().setResource(patient);
+
+    var tIds = FhirPseudonymizerStep.extractTransportIds(bundle);
+
+    assertThat(tIds).isEmpty();
+  }
+
+  @Test
+  void extractTransportIdsSkipsNullIdPart() {
+    var bundle = new Bundle();
+    var patient = new Patient();
+    // setId with just a type prefix — getIdPart() returns null
+    patient.getIdElement().setValue("Patient/");
+    bundle.addEntry().setResource(patient);
+
+    var tIds = FhirPseudonymizerStep.extractTransportIds(bundle);
+
+    assertThat(tIds).isEmpty();
+  }
+
+  @Test
+  void deidentifyConsolidatesWhenOnlyDateMappingsPresent() {
+    // Step with dateShiftPaths so date mappings are produced
+    var domains = new TcaDomains("pseudo-domain", "salt-domain", "dateshift-domain");
+    var stepWithDatePaths =
+        new FhirPseudonymizerStep(
+            fpClient,
+            tcaClient,
+            domains,
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE,
+            List.of("Encounter.period.start"),
+            new SimpleMeterRegistry());
+
+    // FP returns a bundle with no tIDs (no 32-char IDs)
+    var pseudonymizedBundle = new Bundle();
+    var encounter = new Encounter();
+    encounter.setId("regular-id");
+    pseudonymizedBundle.addEntry().setResource(encounter);
+
+    when(fpResponseSpec.bodyToMono(Bundle.class)).thenReturn(Mono.just(pseudonymizedBundle));
+    when(tcaResponseSpec.bodyToMono(TransportMappingResponse.class))
+        .thenReturn(Mono.just(new TransportMappingResponse("transfer-id-xyz")));
+
+    // Input bundle has a date that will be nullified
+    var inputEncounter = new Encounter();
+    var period = new Period();
+    period.setStartElement(new DateTimeType("2020-06-15"));
+    inputEncounter.setPeriod(period);
+
+    var inputBundle = new Bundle();
+    inputBundle.addEntry().setResource(inputEncounter);
+
+    var patient = new ConsentedPatient("patient-1", "http://system");
+    var result = stepWithDatePaths.deidentify(new ConsentedPatientBundle(inputBundle, patient));
+
+    StepVerifier.create(result)
+        .assertNext(
+            transport -> {
+              assertThat(transport.transferId()).isEqualTo("transfer-id-xyz");
+            })
+        .verifyComplete();
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerController.java
@@ -180,6 +180,7 @@ public class CdAgentFhirPseudonymizerController {
   private Mono<PseudonymEntry> createPseudonymEntry(
       String original, String sId, String namespace, Duration ttl) {
     var tId = transportIdService.generateId();
+
     return transportIdService
         .storeMapping(tId, sId, ttl)
         .thenReturn(new PseudonymEntry(namespace, original, tId));

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/FpTransportMappingController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/FpTransportMappingController.java
@@ -1,0 +1,90 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.tca.deidentification.DateShiftUtil.generate;
+import static care.smith.fts.tca.deidentification.DateShiftUtil.shiftDate;
+import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_PREFIX;
+import static java.util.Set.of;
+
+import care.smith.fts.tca.deidentification.GpasClient;
+import care.smith.fts.tca.services.TransportIdService;
+import care.smith.fts.util.error.ErrorResponseUtil;
+import care.smith.fts.util.tca.TransportMappingResponse;
+import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * Receives date mappings from CDA after FHIR Pseudonymizer processing, computes shifted dates, and
+ * consolidates all mappings (identity tID→sID + date entries) into a single transferId-based
+ * MapCache for RDA retrieval.
+ */
+@Slf4j
+@RestController
+@RequestMapping("api/v2")
+@Validated
+public class FpTransportMappingController {
+
+  private final TransportIdService transportIdService;
+  private final GpasClient gpasClient;
+
+  public FpTransportMappingController(
+      TransportIdService transportIdService, GpasClient gpasClient) {
+    this.transportIdService = transportIdService;
+    this.gpasClient = gpasClient;
+  }
+
+  @PostMapping("cd/fhir-pseudonymizer/transport-mapping")
+  public Mono<ResponseEntity<TransportMappingResponse>> consolidateTransportMappings(
+      @Valid @RequestBody FpTransportMappingRequest request) {
+
+    log.debug(
+        "Consolidating {} identity tIDs + {} date mappings for patient",
+        request.transportIds().size(),
+        request.dateMappings().size());
+
+    return fetchDateShiftSeed(request)
+        .map(seed -> computeShiftedDates(seed, request))
+        .flatMap(dsEntries -> consolidate(request, dsEntries))
+        .map(transferId -> ResponseEntity.ok(new TransportMappingResponse(transferId)))
+        .onErrorResume(this::handleError);
+  }
+
+  private Mono<String> fetchDateShiftSeed(FpTransportMappingRequest request) {
+    var seedKey = "%s_%s".formatted(request.maxDateShift().toString(), request.patientIdentifier());
+    return gpasClient
+        .fetchOrCreatePseudonyms(request.dateShiftDomain(), of(seedKey))
+        .map(m -> m.get(seedKey));
+  }
+
+  private Map<String, String> computeShiftedDates(String seed, FpTransportMappingRequest request) {
+    if (request.dateMappings().isEmpty()) {
+      return Map.of();
+    }
+
+    var shift = generate(seed, request.maxDateShift(), request.dateShiftPreserve());
+
+    return request.dateMappings().entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                e -> DATE_SHIFT_PREFIX + e.getKey(), e -> shiftDate(e.getValue(), shift)));
+  }
+
+  private Mono<String> consolidate(
+      FpTransportMappingRequest request, Map<String, String> dsEntries) {
+    var ttl = transportIdService.getDefaultTtl();
+    return transportIdService.consolidateMappings(request.transportIds(), dsEntries, ttl);
+  }
+
+  private Mono<ResponseEntity<TransportMappingResponse>> handleError(Throwable error) {
+    log.error("Failed to consolidate transport mappings: {}", error.getMessage());
+    return ErrorResponseUtil.internalServerError(error);
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/FpTransportMappingRequest.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/FpTransportMappingRequest.java
@@ -1,0 +1,26 @@
+package care.smith.fts.tca.rest;
+
+import care.smith.fts.api.DateShiftPreserve;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Request from CDA to consolidate transport mappings after FHIR Pseudonymizer processing.
+ *
+ * @param patientIdentifier patient ID used to derive the deterministic dateshift seed
+ * @param transportIds identity tIDs from $create-pseudonym (already stored as tid:tId→sId in Redis)
+ * @param dateMappings tID→originalDate for each date element nullified by CDA
+ * @param dateShiftDomain gPAS domain for fetching the dateshift seed
+ * @param maxDateShift maximum shift duration (e.g., P14D)
+ * @param dateShiftPreserve preservation strategy (NONE, WEEKDAY, DAYTIME)
+ */
+public record FpTransportMappingRequest(
+    @NotBlank String patientIdentifier,
+    @NotNull Set<String> transportIds,
+    @NotNull Map<String, String> dateMappings,
+    @NotBlank String dateShiftDomain,
+    @NotNull Duration maxDateShift,
+    @NotNull DateShiftPreserve dateShiftPreserve) {}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/services/TransportIdService.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/services/TransportIdService.java
@@ -26,9 +26,9 @@ import reactor.core.publisher.Mono;
  *
  * <ul>
  *   <li>Generate cryptographically secure transport IDs (32 chars, Base64URL)
- *   <li>Store tID→sID mappings in Redis grouped by transfer session
+ *   <li>Store tID→sID mappings in Redis (individually or grouped by transfer session)
  *   <li>Resolve transport IDs back to secure pseudonyms for RDA
- *   <li>Manage date shift values per transfer session
+ *   <li>Consolidate per-tID mappings into transferId-based MapCache for RDA retrieval
  * </ul>
  */
 @Slf4j
@@ -79,16 +79,13 @@ public class TransportIdService {
    * @return Mono completing when storage is done
    */
   public Mono<Void> storeAllMappings(String transferId, Map<String, String> allData, Duration ttl) {
-    return Mono.defer(
-        () -> {
-          var mapCache = getMapCache(transferId);
-          return mapCache
-              .expire(ttl)
-              .then(mapCache.putAll(allData))
-              .retryWhen(defaultRetryStrategy(meterRegistry, "storeAllMappings"))
-              .doOnSuccess(
-                  v -> log.trace("Stored {} entries: transferId={}", allData.size(), transferId));
-        });
+    var mapCache = getMapCache(transferId);
+    return mapCache
+        .expire(ttl)
+        .then(mapCache.putAll(allData))
+        .retryWhen(defaultRetryStrategy(meterRegistry, "storeAllMappings"))
+        .doOnSuccess(
+            v -> log.trace("Stored {} entries: transferId={}", allData.size(), transferId));
   }
 
   /**
@@ -98,15 +95,10 @@ public class TransportIdService {
    * @return Mono emitting all stored data for this session
    */
   public Mono<Map<String, String>> fetchAllMappings(String transferId) {
-    return Mono.defer(
-        () -> {
-          var mapCache = getMapCache(transferId);
-          return mapCache
-              .readAllMap()
-              .retryWhen(defaultRetryStrategy(meterRegistry, "fetchAllMappings"))
-              .doOnSuccess(
-                  m -> log.trace("Fetched {} entries: transferId={}", m.size(), transferId));
-        });
+    return getMapCache(transferId)
+        .readAllMap()
+        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchAllMappings"))
+        .doOnSuccess(m -> log.trace("Fetched {} entries: transferId={}", m.size(), transferId));
   }
 
   // ========== Direct tid→sid storage (without transferId grouping) ==========
@@ -123,14 +115,12 @@ public class TransportIdService {
    * @return Mono completing when storage is done
    */
   public Mono<Void> storeMapping(String tid, String sid, Duration ttl) {
-    return Mono.defer(
-        () -> {
-          var bucket = redisClient.reactive().<String>getBucket(tidKey(tid));
-          return bucket
-              .set(sid, ttl)
-              .retryWhen(defaultRetryStrategy(meterRegistry, "storeMapping"))
-              .doOnSuccess(v -> log.trace("Stored direct mapping: tid={}", tid));
-        });
+    return redisClient
+        .reactive()
+        .<String>getBucket(tidKey(tid))
+        .set(sid, ttl)
+        .retryWhen(defaultRetryStrategy(meterRegistry, "storeMapping"))
+        .doOnSuccess(v -> log.trace("Stored direct mapping: tid={}", tid));
   }
 
   /**
@@ -140,14 +130,12 @@ public class TransportIdService {
    * @return Mono emitting the sid, or empty if not found
    */
   public Mono<String> fetchMapping(String tid) {
-    return Mono.defer(
-        () -> {
-          var bucket = redisClient.reactive().<String>getBucket(tidKey(tid));
-          return bucket
-              .get()
-              .retryWhen(defaultRetryStrategy(meterRegistry, "fetchMapping"))
-              .doOnSuccess(sid -> log.trace("Fetched mapping: tid={}, found={}", tid, sid != null));
-        });
+    return redisClient
+        .reactive()
+        .<String>getBucket(tidKey(tid))
+        .get()
+        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchMapping"))
+        .doOnSuccess(sid -> log.trace("Fetched mapping: tid={}, found={}", tid, sid != null));
   }
 
   /**
@@ -161,19 +149,13 @@ public class TransportIdService {
     if (tidToSid.isEmpty()) {
       return Mono.empty();
     }
-    return Mono.defer(
-        () -> {
-          var batch = redisClient.reactive().createBatch();
-          tidToSid.forEach(
-              (tid, sid) -> {
-                batch.<String>getBucket(tidKey(tid)).set(sid, ttl);
-              });
-          return batch
-              .execute()
-              .retryWhen(defaultRetryStrategy(meterRegistry, "storeMappings"))
-              .doOnSuccess(v -> log.trace("Stored {} direct mappings", tidToSid.size()))
-              .then();
-        });
+    var batch = redisClient.reactive().createBatch();
+    tidToSid.forEach((tid, sid) -> batch.<String>getBucket(tidKey(tid)).set(sid, ttl));
+    return batch
+        .execute()
+        .retryWhen(defaultRetryStrategy(meterRegistry, "storeMappings"))
+        .doOnSuccess(v -> log.trace("Stored {} direct mappings", tidToSid.size()))
+        .then();
   }
 
   /**
@@ -189,24 +171,20 @@ public class TransportIdService {
     if (tids.isEmpty()) {
       return Mono.just(Map.of());
     }
-    return Mono.defer(
-        () -> {
-          var keys = tids.stream().map(this::tidKey).toArray(String[]::new);
-          return redisClient
-              .reactive()
-              .getBuckets()
-              .<String>get(keys)
-              .retryWhen(defaultRetryStrategy(meterRegistry, "fetchMappings"))
-              .map(
-                  result ->
-                      result.entrySet().stream()
-                          .collect(
-                              Collectors.toMap(
-                                  e -> e.getKey().substring(TID_KEY_PREFIX.length()),
-                                  Map.Entry::getValue)))
-              .doOnSuccess(
-                  m -> log.trace("Fetched {} of {} requested mappings", m.size(), tids.size()));
-        });
+    var keys = tids.stream().map(this::tidKey).toArray(String[]::new);
+    return redisClient
+        .reactive()
+        .getBuckets()
+        .<String>get(keys)
+        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchMappings"))
+        .map(
+            result ->
+                result.entrySet().stream()
+                    .collect(
+                        Collectors.toMap(
+                            e -> e.getKey().substring(TID_KEY_PREFIX.length()),
+                            Map.Entry::getValue)))
+        .doOnSuccess(m -> log.trace("Fetched {} of {} requested mappings", m.size(), tids.size()));
   }
 
   /**
@@ -224,5 +202,53 @@ public class TransportIdService {
 
   private RMapCacheReactive<String, String> getMapCache(String transferId) {
     return redisClient.reactive().getMapCache(transferId);
+  }
+
+  /**
+   * Consolidates identity tID→sID mappings and date shift entries into a single MapCache keyed by a
+   * new transferId, then deletes the individual tid:* keys.
+   *
+   * <p>This is the bridge between the FHIR Pseudonymizer's per-tID storage and the RDA's
+   * transferId-based retrieval via /rd/secure-mapping.
+   *
+   * @param identityTIds identity transport IDs from $create-pseudonym (stored as tid:tId→sId)
+   * @param dateShiftEntries already-prefixed ds:tId→shiftedDate entries
+   * @param ttl time-to-live for the consolidated MapCache
+   * @return Mono emitting the generated transferId
+   */
+  public Mono<String> consolidateMappings(
+      Set<String> identityTIds, Map<String, String> dateShiftEntries, Duration ttl) {
+    var transferId = generateId();
+
+    return fetchMappings(identityTIds)
+        .flatMap(
+            tidSidMap -> {
+              var allData = new java.util.HashMap<>(tidSidMap);
+              allData.putAll(dateShiftEntries);
+
+              log.debug(
+                  "Consolidating {} identity + {} dateshift entries into transferId={}",
+                  tidSidMap.size(),
+                  dateShiftEntries.size(),
+                  transferId);
+
+              return storeAllMappings(transferId, Map.copyOf(allData), ttl)
+                  .then(deleteIndividualTidKeys(identityTIds))
+                  .thenReturn(transferId);
+            });
+  }
+
+  private Mono<Void> deleteIndividualTidKeys(Set<String> tids) {
+    if (tids.isEmpty()) {
+      return Mono.empty();
+    }
+    var keys = tids.stream().map(this::tidKey).toArray(String[]::new);
+    return redisClient
+        .reactive()
+        .getKeys()
+        .delete(keys)
+        .retryWhen(defaultRetryStrategy(meterRegistry, "deleteIndividualTidKeys"))
+        .doOnSuccess(count -> log.trace("Deleted {} individual tid keys", count))
+        .then();
   }
 }

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/CdAgentFhirPseudonymizerControllerTest.java
@@ -173,33 +173,6 @@ class CdAgentFhirPseudonymizerControllerTest {
         .verifyComplete();
   }
 
-  @Test
-  void createPseudonymSucceedsEvenWhenDateShiftLinkingFails() {
-    var requestParams = createSingleValueRequest("test-domain", "patient-123");
-    var ttl = Duration.ofMinutes(10);
-
-    when(transportIdService.generateId()).thenReturn("tId-abc123");
-    when(transportIdService.getDefaultTtl()).thenReturn(ttl);
-    when(transportIdService.storeMapping(eq("tId-abc123"), eq("sId-456"), eq(ttl)))
-        .thenReturn(Mono.empty());
-    when(transportIdService.fetchAndDeleteTempDateShift(anyString()))
-        .thenReturn(Mono.error(new RuntimeException("Redis connection failed")));
-    when(gpasClient.fetchOrCreatePseudonyms(eq("test-domain"), anySet()))
-        .thenReturn(Mono.just(Map.of("patient-123", "sId-456")));
-
-    var result = controller.createPseudonym(requestParams);
-
-    StepVerifier.create(result)
-        .assertNext(
-            response -> {
-              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-              var params = response.getBody();
-              assertThat(params).isNotNull();
-              assertThat(findParameterValue(params, "pseudonymValue")).isEqualTo("tId-abc123");
-            })
-        .verifyComplete();
-  }
-
   private Parameters createSingleValueRequest(String namespace, String originalValue) {
     var params = new Parameters();
     params.addParameter().setName("namespace").setValue(new StringType(namespace));

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/FpTransportMappingControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/FpTransportMappingControllerTest.java
@@ -1,0 +1,183 @@
+package care.smith.fts.tca.rest;
+
+import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_PREFIX;
+import static java.util.Set.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.api.DateShiftPreserve;
+import care.smith.fts.tca.deidentification.GpasClient;
+import care.smith.fts.tca.services.TransportIdService;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class FpTransportMappingControllerTest {
+
+  @Mock private TransportIdService transportIdService;
+  @Mock private GpasClient gpasClient;
+
+  @Captor private ArgumentCaptor<Map<String, String>> dateShiftEntriesCaptor;
+
+  private FpTransportMappingController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new FpTransportMappingController(transportIdService, gpasClient);
+  }
+
+  @Test
+  void consolidateReturnsTransferIdOnSuccess() {
+    var request =
+        new FpTransportMappingRequest(
+            "patient-123",
+            Set.of("tId-1", "tId-2"),
+            Map.of("dateTid-1", "2020-06-15"),
+            "dateshift-domain",
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE);
+
+    var seedKey = "PT336H_patient-123";
+    when(gpasClient.fetchOrCreatePseudonyms(eq("dateshift-domain"), eq(of(seedKey))))
+        .thenReturn(Mono.just(Map.of(seedKey, "seed-abc")));
+    when(transportIdService.getDefaultTtl()).thenReturn(Duration.ofMinutes(10));
+    when(transportIdService.consolidateMappings(anySet(), anyMap(), any(Duration.class)))
+        .thenReturn(Mono.just("transferId-xyz"));
+
+    var result = controller.consolidateTransportMappings(request);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(response.getBody()).isNotNull();
+              assertThat(response.getBody().transferId()).isEqualTo("transferId-xyz");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void consolidatePrefixesDateShiftEntriesWithDsPrefix() {
+    var request =
+        new FpTransportMappingRequest(
+            "patient-456",
+            Set.of("tId-1"),
+            Map.of("dateTid-1", "2020-06-15", "dateTid-2", "2021-01-01"),
+            "dateshift-domain",
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE);
+
+    var seedKey = "PT336H_patient-456";
+    when(gpasClient.fetchOrCreatePseudonyms(eq("dateshift-domain"), eq(of(seedKey))))
+        .thenReturn(Mono.just(Map.of(seedKey, "seed-def")));
+    when(transportIdService.getDefaultTtl()).thenReturn(Duration.ofMinutes(10));
+    when(transportIdService.consolidateMappings(
+            anySet(), dateShiftEntriesCaptor.capture(), any(Duration.class)))
+        .thenReturn(Mono.just("transferId-abc"));
+
+    controller.consolidateTransportMappings(request).block();
+
+    var captured = dateShiftEntriesCaptor.getValue();
+    assertThat(captured).hasSize(2);
+    assertThat(captured.keySet()).allMatch(key -> key.startsWith(DATE_SHIFT_PREFIX));
+  }
+
+  @Test
+  void consolidateAppliesDateShiftToOriginalDates() {
+    var request =
+        new FpTransportMappingRequest(
+            "patient-789",
+            Set.of("tId-1"),
+            Map.of("dateTid-1", "2020-06-15"),
+            "dateshift-domain",
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE);
+
+    var seedKey = "PT336H_patient-789";
+    when(gpasClient.fetchOrCreatePseudonyms(eq("dateshift-domain"), eq(of(seedKey))))
+        .thenReturn(Mono.just(Map.of(seedKey, "seed-ghi")));
+    when(transportIdService.getDefaultTtl()).thenReturn(Duration.ofMinutes(10));
+    when(transportIdService.consolidateMappings(
+            anySet(), dateShiftEntriesCaptor.capture(), any(Duration.class)))
+        .thenReturn(Mono.just("transferId-def"));
+
+    controller.consolidateTransportMappings(request).block();
+
+    var captured = dateShiftEntriesCaptor.getValue();
+    assertThat(captured).hasSize(1);
+    // The shifted date should not equal the original
+    var shiftedDate = captured.get(DATE_SHIFT_PREFIX + "dateTid-1");
+    assertThat(shiftedDate).isNotNull();
+    // With a fixed seed, the shift is deterministic but not zero
+  }
+
+  @Test
+  void consolidateWithEmptyDateMappingsSucceeds() {
+    var request =
+        new FpTransportMappingRequest(
+            "patient-empty",
+            Set.of("tId-1", "tId-2"),
+            Map.of(),
+            "dateshift-domain",
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE);
+
+    var seedKey = "PT336H_patient-empty";
+    when(gpasClient.fetchOrCreatePseudonyms(eq("dateshift-domain"), eq(of(seedKey))))
+        .thenReturn(Mono.just(Map.of(seedKey, "seed-jkl")));
+    when(transportIdService.getDefaultTtl()).thenReturn(Duration.ofMinutes(10));
+    when(transportIdService.consolidateMappings(
+            eq(Set.of("tId-1", "tId-2")), eq(Map.of()), any(Duration.class)))
+        .thenReturn(Mono.just("transferId-ghi"));
+
+    var result = controller.consolidateTransportMappings(request);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(response.getBody().transferId()).isEqualTo("transferId-ghi");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void consolidateReturns500OnGpasFailure() {
+    var request =
+        new FpTransportMappingRequest(
+            "patient-fail",
+            Set.of("tId-1"),
+            Map.of("dateTid-1", "2020-06-15"),
+            "dateshift-domain",
+            Duration.ofDays(14),
+            DateShiftPreserve.NONE);
+
+    var seedKey = "PT336H_patient-fail";
+    when(gpasClient.fetchOrCreatePseudonyms(eq("dateshift-domain"), eq(of(seedKey))))
+        .thenReturn(Mono.error(new RuntimeException("gPAS unavailable")));
+
+    var result = controller.consolidateTransportMappings(request);
+
+    StepVerifier.create(result)
+        .assertNext(
+            response -> {
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            })
+        .verifyComplete();
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/services/TransportIdServiceTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/services/TransportIdServiceTest.java
@@ -24,6 +24,7 @@ import org.redisson.api.BatchResult;
 import org.redisson.api.RBatchReactive;
 import org.redisson.api.RBucketReactive;
 import org.redisson.api.RBucketsReactive;
+import org.redisson.api.RKeysReactive;
 import org.redisson.api.RMapCacheReactive;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.RedissonReactiveClient;
@@ -39,6 +40,7 @@ class TransportIdServiceTest {
   @Mock private RBucketReactive<String> bucket;
   @Mock private RBatchReactive batch;
   @Mock private RBucketsReactive buckets;
+  @Mock private RKeysReactive keys;
 
   private TransportIdService service;
   private MeterRegistry meterRegistry;
@@ -59,6 +61,7 @@ class TransportIdServiceTest {
     lenient().when(reactiveClient.<String>getBucket(anyString())).thenReturn(bucket);
     lenient().when(reactiveClient.createBatch()).thenReturn(batch);
     lenient().when(reactiveClient.getBuckets()).thenReturn(buckets);
+    lenient().when(reactiveClient.getKeys()).thenReturn(keys);
 
     service = new TransportIdService(redisClient, config, meterRegistry, randomGenerator);
   }
@@ -172,12 +175,10 @@ class TransportIdServiceTest {
     var result = service.storeMappings(Map.of(), defaultTtl);
 
     StepVerifier.create(result).verifyComplete();
-    // No Redis interactions should occur - batch.execute() would fail if called without setup
   }
 
   @Test
   void fetchMappingsRetrievesMultipleMappings() {
-    // RBuckets.get() returns map with full keys (including prefix)
     when(buckets.<String>get(any(String[].class)))
         .thenReturn(Mono.just(Map.of("tid:tId-1", "sId-1", "tid:tId-2", "sId-2")));
 
@@ -198,12 +199,10 @@ class TransportIdServiceTest {
     var result = service.fetchMappings(Set.of());
 
     StepVerifier.create(result).expectNext(Map.of()).verifyComplete();
-    // No Redis interactions should occur - buckets.get() would fail if called without setup
   }
 
   @Test
   void fetchMappingsExcludesNotFoundMappings() {
-    // RBuckets.get() only returns keys that exist - missing keys are not in the result map
     when(buckets.<String>get(any(String[].class)))
         .thenReturn(Mono.just(Map.of("tid:tId-1", "sId-1")));
 
@@ -215,6 +214,63 @@ class TransportIdServiceTest {
               assertThat(retrieved).hasSize(1);
               assertThat(retrieved).containsEntry("tId-1", "sId-1");
             })
+        .verifyComplete();
+  }
+
+  @Test
+  void consolidateMappingsMergesIdentityAndDateShiftEntries() {
+    // fetchMappings for identity tIDs
+    when(buckets.<String>get(any(String[].class)))
+        .thenReturn(Mono.just(Map.of("tid:tId-1", "sId-1", "tid:tId-2", "sId-2")));
+
+    // storeAllMappings
+    when(mapCache.expire(any(Duration.class))).thenReturn(Mono.just(true));
+    when(mapCache.putAll(any())).thenReturn(Mono.empty());
+
+    // deleteIndividualTidKeys
+    when(keys.delete(any(String[].class))).thenReturn(Mono.just(2L));
+
+    var dateShiftEntries = Map.of("ds:dateTid-1", "2020-06-15", "ds:dateTid-2", "2020-12-25");
+
+    var result =
+        service.consolidateMappings(Set.of("tId-1", "tId-2"), dateShiftEntries, defaultTtl);
+
+    StepVerifier.create(result)
+        .assertNext(
+            transferId -> {
+              assertThat(transferId).isNotNull().hasSize(32);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void consolidateMappingsWithEmptyDateShiftEntries() {
+    when(buckets.<String>get(any(String[].class)))
+        .thenReturn(Mono.just(Map.of("tid:tId-1", "sId-1")));
+
+    when(mapCache.expire(any(Duration.class))).thenReturn(Mono.just(true));
+    when(mapCache.putAll(any())).thenReturn(Mono.empty());
+    when(keys.delete(any(String[].class))).thenReturn(Mono.just(1L));
+
+    var result = service.consolidateMappings(Set.of("tId-1"), Map.of(), defaultTtl);
+
+    StepVerifier.create(result)
+        .assertNext(transferId -> assertThat(transferId).hasSize(32))
+        .verifyComplete();
+  }
+
+  @Test
+  void consolidateMappingsWithEmptyIdentityTidsSkipsDelete() {
+    when(mapCache.expire(any(Duration.class))).thenReturn(Mono.just(true));
+    when(mapCache.putAll(any())).thenReturn(Mono.empty());
+
+    // fetchMappings with empty set returns empty map directly (no Redis call)
+    var dateShiftEntries = Map.of("ds:dateTid-1", "2020-06-15");
+
+    var result = service.consolidateMappings(Set.of(), dateShiftEntries, defaultTtl);
+
+    StepVerifier.create(result)
+        .assertNext(transferId -> assertThat(transferId).hasSize(32))
         .verifyComplete();
   }
 }

--- a/util/src/main/java/care/smith/fts/util/fhir/DateShiftAnonymizer.java
+++ b/util/src/main/java/care/smith/fts/util/fhir/DateShiftAnonymizer.java
@@ -1,0 +1,131 @@
+package care.smith.fts.util.fhir;
+
+import static care.smith.fts.util.NanoIdUtils.nanoId;
+import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.FhirTerser;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.BaseDateTimeType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Parses a FHIR Pseudonymizer anonymization config and selectively nullifies date elements matching
+ * dateshift rules. For each nullified date, generates a transport ID and adds a DATE_SHIFT
+ * extension so RDA can later restore the shifted date.
+ */
+public interface DateShiftAnonymizer {
+
+  /**
+   * Extracts dateshift FHIRPath-like rules from an anonymization.yaml config.
+   *
+   * <p>The expected format is:
+   *
+   * <pre>
+   * fhirPathRules:
+   *   - path: "Encounter.period.start"
+   *     method: "dateshift"
+   *   - path: "Encounter.period.end"
+   *     method: "dateshift"
+   *   - path: "Patient.identifier.value"
+   *     method: "pseudonymize"
+   * </pre>
+   *
+   * Only rules with {@code method: "dateshift"} are returned.
+   *
+   * @param configFile the anonymization.yaml file
+   * @return list of dotted resource paths for dateshift rules (e.g., "Encounter.period.start")
+   */
+  @SuppressWarnings("unchecked")
+  static List<String> parseDateShiftPaths(File configFile) throws IOException {
+    var yaml = new Yaml();
+    Map<String, Object> root;
+    try (var input = new FileInputStream(configFile)) {
+      root = yaml.load(input);
+    }
+
+    if (root == null || !root.containsKey("fhirPathRules")) {
+      return List.of();
+    }
+
+    var rules = (List<Map<String, String>>) root.get("fhirPathRules");
+    return rules.stream()
+        .filter(rule -> "dateshift".equals(rule.get("method")))
+        .map(rule -> rule.get("path"))
+        .filter(path -> path != null && !path.isEmpty())
+        .toList();
+  }
+
+  /**
+   * Processes a bundle by nullifying date elements matching the given paths and adding dateshift
+   * extensions with transport IDs.
+   *
+   * @param bundle the FHIR bundle to process (modified in place)
+   * @param dateShiftPaths dotted resource paths (e.g., "Encounter.period.start")
+   * @return map of tID → original date value
+   */
+  static Map<String, String> nullifyDates(Bundle bundle, List<String> dateShiftPaths) {
+    if (dateShiftPaths.isEmpty()) {
+      return Map.of();
+    }
+
+    var terser = new FhirTerser(FhirContext.forR4Cached());
+    var dateMappings = new HashMap<String, String>();
+    var dateValueToTid = new HashMap<String, String>();
+
+    var pathsByResourceType =
+        dateShiftPaths.stream()
+            .filter(p -> p.contains("."))
+            .collect(
+                Collectors.groupingBy(
+                    p -> p.substring(0, p.indexOf('.')),
+                    Collectors.mapping(p -> p.substring(p.indexOf('.') + 1), Collectors.toList())));
+
+    for (var entry : bundle.getEntry()) {
+      var resource = entry.getResource();
+      if (resource == null) continue;
+
+      var resourceType = resource.fhirType();
+      var paths = pathsByResourceType.get(resourceType);
+      if (paths == null) continue;
+
+      for (var subPath : paths) {
+        processDateElements(terser, resource, subPath, dateMappings, dateValueToTid);
+      }
+    }
+
+    return Map.copyOf(dateMappings);
+  }
+
+  private static void processDateElements(
+      FhirTerser terser,
+      Resource resource,
+      String subPath,
+      Map<String, String> dateMappings,
+      Map<String, String> dateValueToTid) {
+
+    var values = terser.getValues(resource, subPath);
+    for (var value : values) {
+      if (value instanceof BaseDateTimeType dateTime && dateTime.getValue() != null) {
+        var originalDate = dateTime.getValueAsString();
+        var tId = dateValueToTid.computeIfAbsent(originalDate, k -> nanoId());
+
+        if (!dateMappings.containsKey(tId)) {
+          dateMappings.put(tId, originalDate);
+        }
+
+        dateTime.setValue(null);
+        dateTime.addExtension(DATE_SHIFT_EXTENSION_URL, new StringType(tId));
+      }
+    }
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/fhir/DateShiftAnonymizerTest.java
+++ b/util/src/test/java/care/smith/fts/util/fhir/DateShiftAnonymizerTest.java
@@ -1,0 +1,255 @@
+package care.smith.fts.util.fhir;
+
+import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Date;
+import java.util.List;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Period;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DateShiftAnonymizerTest {
+
+  @TempDir File tempDir;
+
+  @Test
+  void parseDateShiftPathsExtractsOnlyDateshiftRules() throws IOException {
+    var config =
+        """
+        fhirPathRules:
+          - path: "Encounter.period.start"
+            method: "dateshift"
+          - path: "Encounter.period.end"
+            method: "dateshift"
+          - path: "Patient.identifier.value"
+            method: "pseudonymize"
+          - path: "Patient.birthDate"
+            method: "dateshift"
+        """;
+    var file = writeConfig(config);
+
+    var paths = DateShiftAnonymizer.parseDateShiftPaths(file);
+
+    assertThat(paths)
+        .containsExactlyInAnyOrder(
+            "Encounter.period.start", "Encounter.period.end", "Patient.birthDate");
+  }
+
+  @Test
+  void parseDateShiftPathsReturnsEmptyForNoDateshiftRules() throws IOException {
+    var config =
+        """
+        fhirPathRules:
+          - path: "Patient.identifier.value"
+            method: "pseudonymize"
+        """;
+    var file = writeConfig(config);
+
+    var paths = DateShiftAnonymizer.parseDateShiftPaths(file);
+
+    assertThat(paths).isEmpty();
+  }
+
+  @Test
+  void parseDateShiftPathsReturnsEmptyForMissingRules() throws IOException {
+    var config = "someOtherConfig: true\n";
+    var file = writeConfig(config);
+
+    var paths = DateShiftAnonymizer.parseDateShiftPaths(file);
+
+    assertThat(paths).isEmpty();
+  }
+
+  @Test
+  void nullifyDatesNullifiesMatchingDateElements() {
+    var encounter = new Encounter();
+    var period = new Period();
+    period.setStartElement(new DateTimeType("2020-06-15T10:30:00+02:00"));
+    period.setEndElement(new DateTimeType("2020-06-16T08:00:00+02:00"));
+    encounter.setPeriod(period);
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(encounter);
+
+    var paths = List.of("Encounter.period.start", "Encounter.period.end");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).hasSize(2);
+    assertThat(period.getStartElement().getValue()).isNull();
+    assertThat(period.getEndElement().getValue()).isNull();
+    assertThat(period.getStartElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNotNull();
+    assertThat(period.getEndElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNotNull();
+  }
+
+  @Test
+  void nullifyDatesDeduplicatesSameDateValues() {
+    var enc1 = new Encounter();
+    var period1 = new Period();
+    period1.setStartElement(new DateTimeType("2020-06-15"));
+    enc1.setPeriod(period1);
+
+    var enc2 = new Encounter();
+    var period2 = new Period();
+    period2.setStartElement(new DateTimeType("2020-06-15"));
+    enc2.setPeriod(period2);
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(enc1);
+    bundle.addEntry().setResource(enc2);
+
+    var paths = List.of("Encounter.period.start");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    // Same date value → same tID, so only 1 entry in dateMappings
+    assertThat(dateMappings).hasSize(1);
+
+    // Both elements should have the same tID in their extension
+    var ext1 = period1.getStartElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL);
+    var ext2 = period2.getStartElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL);
+    assertThat(ext1.getValue().primitiveValue()).isEqualTo(ext2.getValue().primitiveValue());
+  }
+
+  @Test
+  void nullifyDatesSkipsNonMatchingResourceTypes() {
+    var patient = new Patient();
+    patient.setBirthDate(new Date());
+
+    var encounter = new Encounter();
+    var period = new Period();
+    period.setStartElement(new DateTimeType("2020-06-15"));
+    encounter.setPeriod(period);
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(patient);
+    bundle.addEntry().setResource(encounter);
+
+    // Only target Encounter dates, not Patient
+    var paths = List.of("Encounter.period.start");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).hasSize(1);
+    // Patient birthDate should be unchanged
+    assertThat(patient.getBirthDate()).isNotNull();
+  }
+
+  @Test
+  void nullifyDatesWithEmptyPathsReturnsEmpty() {
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(new Encounter());
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, List.of());
+
+    assertThat(dateMappings).isEmpty();
+  }
+
+  @Test
+  void nullifyDatesSkipsNullDateValues() {
+    var encounter = new Encounter();
+    encounter.setPeriod(new Period()); // period with no start/end set
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(encounter);
+
+    var paths = List.of("Encounter.period.start");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).isEmpty();
+  }
+
+  @Test
+  void nullifyDatesSkipsBaseDateTimeWithNullValue() {
+    var encounter = new Encounter();
+    var period = new Period();
+    // Explicitly set a DateTimeType with null value — the element exists but has no value
+    period.setStartElement(new DateTimeType((Date) null));
+    encounter.setPeriod(period);
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(encounter);
+
+    var paths = List.of("Encounter.period.start");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).isEmpty();
+  }
+
+  @Test
+  void parseDateShiftPathsReturnsEmptyForNullYamlRoot() throws IOException {
+    var file = writeConfig(""); // empty YAML parses to null root
+    var paths = DateShiftAnonymizer.parseDateShiftPaths(file);
+    assertThat(paths).isEmpty();
+  }
+
+  @Test
+  void parseDateShiftPathsFiltersNullAndEmptyPaths() throws IOException {
+    var config =
+        """
+        fhirPathRules:
+          - path: "Encounter.period.start"
+            method: "dateshift"
+          - method: "dateshift"
+          - path: ""
+            method: "dateshift"
+        """;
+    var file = writeConfig(config);
+
+    var paths = DateShiftAnonymizer.parseDateShiftPaths(file);
+
+    assertThat(paths).containsExactly("Encounter.period.start");
+  }
+
+  @Test
+  void nullifyDatesSkipsNullResource() {
+    var bundle = new Bundle();
+    bundle.addEntry(); // entry with no resource (null)
+    var encounter = new Encounter();
+    var period = new Period();
+    period.setStartElement(new DateTimeType("2020-06-15"));
+    encounter.setPeriod(period);
+    bundle.addEntry().setResource(encounter);
+
+    var paths = List.of("Encounter.period.start");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).hasSize(1);
+    assertThat(period.getStartElement().getValue()).isNull();
+  }
+
+  @Test
+  void nullifyDatesSkipsNonDateTimeValues() {
+    // Target a path that resolves to a non-BaseDateTimeType (e.g., StringType)
+    var encounter = new Encounter();
+    encounter.setId("enc-1");
+    encounter.addIdentifier().setValue("some-identifier");
+
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(encounter);
+
+    // identifier.value resolves to a StringType, not BaseDateTimeType
+    var paths = List.of("Encounter.identifier.value");
+
+    var dateMappings = DateShiftAnonymizer.nullifyDates(bundle, paths);
+
+    assertThat(dateMappings).isEmpty();
+  }
+
+  private File writeConfig(String content) throws IOException {
+    var file = new File(tempDir, "anonymization.yaml");
+    Files.writeString(file.toPath(), content);
+    return file;
+  }
+}


### PR DESCRIPTION
## Summary
- Move date nullification from TCA to CDA via new `DateShiftAnonymizer` utility
- Replace TCA `DateShiftController` with `FpTransportMappingController` that consolidates identity tIDs and date mappings in a single call
- Simplify `TransportIdService` by removing date-shift-specific logic
- Add CDA `FhirPseudonymizerStep` with external FHIR Pseudonymizer integration