### PR TITLE
Retry gPAS/gICS Containers On Startup Fail

### DIFF
--- a/.github/test/compose.yaml
+++ b/.github/test/compose.yaml
@@ -49,6 +49,7 @@ services:
     image: mosaicgreifswald/gics:2025.2.0@sha256:56ea729ddba0ab110c945b5bd649055406ef55bf2a3f9fe85932e88cbe09c75d
     ports: [ ":8080" ]
     networks: [ "gics", "trust-center" ]
+    restart: on-failure:3
     environment:
       TTP_GICS_DB_HOST: "gics-db"
       WF_NO_ADMIN: "true"
@@ -84,6 +85,7 @@ services:
     image: mosaicgreifswald/gpas:2025.2.0@sha256:e61946ae994e658ecdeb5dfc86b4102d248e22cfdde10b6c6e6dfefeb654739c
     ports: [ ":8080" ]
     networks: [ "gpas", "trust-center" ]
+    restart: on-failure:3
     environment:
       TTP_GPAS_DB_HOST: "gpas-db"
       WF_NO_ADMIN: "true"


### PR DESCRIPTION
## Summary
- Add `restart: on-failure:3` to `gpas` and `gics` services in `.github/test/compose.yaml`
- Mitigates transient startup abort where `disoptdepl` exits 0 but the gPAS supervisor treats it as an unexpected stop and aborts the whole container

Closes #1584