### PR TITLE
Enable Bean Validation in CDA and RDA

### DIFF
--- a/clinical-domain-agent/pom.xml
+++ b/clinical-domain-agent/pom.xml
@@ -38,14 +38,8 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.validation</groupId>
-      <artifactId>jakarta.validation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
     <dependency>

--- a/research-domain-agent/pom.xml
+++ b/research-domain-agent/pom.xml
@@ -34,14 +34,8 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.validation</groupId>
-      <artifactId>jakarta.validation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary

- Replace test-scoped `hibernate-validator` in CDA and RDA with `spring-boot-starter-validation`, matching TCA.
- Activates existing `@Valid` / `@Validated` / `@NotNull` annotations on CDA and RDA controllers and config records at runtime instead of silently no-op'ing.
- Removes the `NoProviderFoundException` warning logged at CDA/RDA startup and unblocks the springdoc 2.8.17 upgrade (`SchemaUtils.applyValidationsToSchema` references `org.hibernate.validator.constraints.Range`, which must be on the runtime classpath).

Closes #1589