### PR TITLE
Enable Bean Validation in TCA

### DIFF
--- a/trust-center-agent/pom.xml
+++ b/trust-center-agent/pom.xml
@@ -34,17 +34,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.validation</groupId>
-      <artifactId>jakarta.validation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary

- Replace test-scoped `hibernate-validator` (+ redundant `jakarta.validation-api`) with `spring-boot-starter-validation` in `trust-center-agent/pom.xml`.
- Unblocks springdoc-openapi 2.8.17 upgrade (PR #1572): TCA's `/api/v2/openapi` was hanging under 2.8.17 with `NoClassDefFoundError: org/hibernate/validator/constraints/Range`, causing Pages CI to run 3h+ until cancel.

## Root cause

TCA's pom declared `hibernate-validator` with `<scope>test</scope>`. Maven mediation: a direct declaration's scope overrides the compile-scope transitive from `spring-boot-starter-validation`, so hibernate-validator was missing from the runtime fat jar (`BOOT-INF/lib/` had only `jakarta.validation-api`).

`springdoc-openapi` 2.8.17 `SchemaUtils.applyValidationsToSchema` unconditionally references `o.h.v.constraints.Range` → `NoClassDefFoundError` → Reactor's `throwIfFatal` logs + drops the signal → HTTP response never completes → client hangs.

Reproduced locally on `renovate/org.springdoc-springdoc-openapi-starter-webflux-ui-2.x`; after this change, `curl /api/v2/openapi` returns HTTP 200 in <1s.

## Related

- Closes #1598
- Same pattern as #1590 (CDA + RDA) — TCA was missed because `spring-boot-starter-validation` was already declared, masking the scope override.
- Unblocks #1572 (springdoc 2.8.17 upgrade)