### PR TITLE
Docs: Dedent Spring OAuth2 Yaml Template

### DIFF
--- a/clinical-domain-agent/application.yaml
+++ b/clinical-domain-agent/application.yaml
@@ -94,17 +94,17 @@
 
 ### Spring OAuth2 Client Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/oauth2-client
-#   spring.security.oauth2:
-#     client:
-#       registration:
-#         agent:
-#           authorization-grant-type: client_credentials
-#           client-id: cd-client
-#           client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
-#           provider: keycloak
-#       provider:
-#         keycloak:
-#           issuer-uri: http://localhost:8080/realms/fts
+# spring.security.oauth2:
+#   client:
+#     registration:
+#       agent:
+#         authorization-grant-type: client_credentials
+#         client-id: cd-client
+#         client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
+#         provider: keycloak
+#     provider:
+#       keycloak:
+#         issuer-uri: http://localhost:8080/realms/fts
 
 ### Monitoring
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/observability

--- a/research-domain-agent/application.yaml
+++ b/research-domain-agent/application.yaml
@@ -83,17 +83,17 @@
 
 ### Spring OAuth2 Client Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/oauth2-client
-#   spring.security.oauth2:
-#     client:
-#       registration:
-#         agent:
-#           authorization-grant-type: client_credentials
-#           client-id: rd-client
-#           client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
-#           provider: keycloak
-#       provider:
-#         keycloak:
-#           issuer-uri: http://localhost:8080/realms/fts
+# spring.security.oauth2:
+#   client:
+#     registration:
+#       agent:
+#         authorization-grant-type: client_credentials
+#         client-id: rd-client
+#         client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
+#         provider: keycloak
+#     provider:
+#       keycloak:
+#         issuer-uri: http://localhost:8080/realms/fts
 
 ### Monitoring
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/observability

--- a/trust-center-agent/application.yaml
+++ b/trust-center-agent/application.yaml
@@ -101,22 +101,22 @@
 
 ### Spring OAuth2 Client Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/oauth2-client
-#   spring.security.oauth2:
-#     client:
-#       registration:
-#         cd-agent:
-#           authorization-grant-type: client_credentials
-#           client-id: cd-client
-#           client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
-#           provider: keycloak
-#         rd-agent:
-#           authorization-grant-type: client_credentials
-#           client-id: rd-client
-#           client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
-#           provider: keycloak
-#       provider:
-#         keycloak:
-#           issuer-uri: http://localhost:8080/realms/fts
+# spring.security.oauth2:
+#   client:
+#     registration:
+#       cd-agent:
+#         authorization-grant-type: client_credentials
+#         client-id: cd-client
+#         client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
+#         provider: keycloak
+#       rd-agent:
+#         authorization-grant-type: client_credentials
+#         client-id: rd-client
+#         client-secret: tIQfOvBuhyR1dw9OQ3E4tCeTvcHtiW84
+#         provider: keycloak
+#     provider:
+#       keycloak:
+#         issuer-uri: http://localhost:8080/realms/fts
 
 ### Monitoring
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/observability


### PR DESCRIPTION
## Summary

- Dedent commented `spring.security.oauth2` block to column 0 in all three agent `application.yaml` templates (CDA, TCA, RDA).
- Previously indented under `security:`, so uncommenting produced `security.spring.security.oauth2.*` keys, which `OAuth2ConfigurationExistsCondition` does not match — `HttpClientOAuth2Auth` was never registered and startup failed with `Cannot configure oauth2 authentication, missing implementing class.`
- Post-fix structure matches the working reference `trust-center-agent/src/test/resources/application-auth_oauth2.yaml`.

Closes #1600