### PR TITLE
Stabilize gics/gpas CI Startup

### DIFF
--- a/.github/test/compose.yaml
+++ b/.github/test/compose.yaml
@@ -53,8 +53,7 @@ services:
     environment:
       TTP_GICS_DB_HOST: "gics-db"
       WF_NO_ADMIN: "true"
-      TTP_DISABLE_NOTI_CLIENT: "true"
-      TTP_DISABLE_NOTI_SERVICE: "true"
+      MOS_INCLUDE_PROCESSES: "wildfly"
     depends_on:
       gics-db:
         condition: service_healthy
@@ -89,8 +88,7 @@ services:
     environment:
       TTP_GPAS_DB_HOST: "gpas-db"
       WF_NO_ADMIN: "true"
-      TTP_DISABLE_NOTI_CLIENT: "true"
-      TTP_DISABLE_NOTI_SERVICE: "true"
+      MOS_INCLUDE_PROCESSES: "wildfly"
     depends_on:
       gpas-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Set `MOS_INCLUDE_PROCESSES: "wildfly"` on `gics` and `gpas` services in `.github/test/compose.yaml` to filter out `disoptdepl` from the mosaic supervisor's start loop, avoiding the write-order race in `processes.sh` that flakes e2e startup.
- Removed `TTP_DISABLE_NOTI_CLIENT` / `TTP_DISABLE_NOTI_SERVICE` — with `MOS_INCLUDE_PROCESSES=wildfly`, `disable_optional_deployments.sh` never runs, so these flags have no effect.

## Caveat

NOTI modules remain loaded but unused by e2e tests. Minor extra RAM/CPU per container, no functional impact. Once upstream ships a fix (mosaic-hgw/gICS#6), `MOS_INCLUDE_PROCESSES` can be dropped.

Closes #1609
Upstream: mosaic-hgw/gICS#6
Related: #1607, #1606