### PR TITLE
Install GNU Wget for mTLS Health Checks

### DIFF
--- a/clinical-domain-agent/Dockerfile
+++ b/clinical-domain-agent/Dockerfile
@@ -1,5 +1,9 @@
 FROM eclipse-temurin:21.0.10_7-jre-alpine@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
+# GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
+# --private-key, and --ca-certificate.
+RUN apk add --no-cache -q wget
+
 COPY --chown=nobody:nobody target/clinical-domain-agent.jar /app/clinical-domain-agent.jar
 COPY --chown=nobody:nobody application.yaml                 /app/application.yaml
 

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -71,12 +71,27 @@ the client and the server by encrypting data.
     certificate files into the container. Ensure that the SSL bundle files (certificates, private
     keys, and CA certificates) are properly mounted as volumes or bind mounts to make them
     accessible to the agent within the container.
-  * Health checks in the compose configuration must be updated to use `https` instead of `http` when
-    SSL is enabled. Using wget with `--no-check-certificate` or `--ca-certificate` might be
-    necessary.
+  * Health checks in the compose configuration must be updated to use `https` instead of `http`
+    when SSL is enabled. The agent images ship with GNU `wget`, which supports TLS options such
+    as `--ca-certificate`, `--certificate`, and `--private-key`.
   * When client authentication is set to `need`, the health check must include a valid client
-    certificate (via wget `--certificate` and `--private-key`) to successfully authenticate with the
-    server. For `want` mode, client certificates are optional for health checks.
+    certificate to authenticate with the server. Mount the client certificate, private key, and
+    CA certificate into the container and pass them to `wget`, for example:
+
+    ```yaml
+    healthcheck:
+      test:
+      - CMD
+      - wget
+      - -qO-
+      - --ca-certificate=/app/ssl/ca.crt
+      - --certificate=/app/ssl/client.crt
+      - --private-key=/app/ssl/client.key
+      - https://localhost:8080/actuator/health
+    ```
+
+    For `want` mode, client certificates are optional for health checks; omit `--certificate`
+    and `--private-key` but still validate the server certificate with `--ca-certificate`.
 
 * **Reverse Proxy**:
   * When behind a reverse proxy, `forward-headers-strategy: framework` ensures correct link 

--- a/research-domain-agent/Dockerfile
+++ b/research-domain-agent/Dockerfile
@@ -1,5 +1,9 @@
 FROM eclipse-temurin:21.0.10_7-jre-alpine@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
+# GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
+# --private-key, and --ca-certificate.
+RUN apk add --no-cache -q wget
+
 COPY --chown=nobody:nobody target/research-domain-agent.jar /app/research-domain-agent.jar
 COPY --chown=nobody:nobody application.yaml                 /app/application.yaml
 

--- a/trust-center-agent/Dockerfile
+++ b/trust-center-agent/Dockerfile
@@ -1,5 +1,9 @@
 FROM eclipse-temurin:21.0.10_7-jre-alpine@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
+# GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
+# --private-key, and --ca-certificate.
+RUN apk add --no-cache -q wget
+
 COPY --chown=nobody:nobody target/trust-center-agent.jar /app/trust-center-agent.jar
 COPY --chown=nobody:nobody application.yaml              /app/application.yaml
 


### PR DESCRIPTION
## Summary

- Install GNU `wget` via `apk add --no-cache wget` in all three agent Dockerfiles (CDA, TCA, RDA). Alpine's default BusyBox `wget` does not support `--ca-certificate`, `--certificate`, or `--private-key`, which made Docker healthchecks impossible when `server.ssl.client-auth: need` was enabled.
- Update `docs/configuration/server.md` to explain the BusyBox limitation, confirm that GNU `wget` is now preinstalled, and replace the previous ambiguous guidance with a concrete mTLS-aware compose healthcheck example. The `want` mode guidance no longer suggests `--no-check-certificate`; it recommends `--ca-certificate` so the server certificate is still validated.

Verified locally: `docker run --rm eclipse-temurin:21.0.10_7-jre-alpine sh -c "apk add --no-cache wget && wget --version"` installs `GNU Wget 1.25.0` (pulls in `pcre2`; ~2 MiB overhead).

Closes #1611