### PR TITLE
Fix Quadratic Cost in CDA Failure Tracking

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -168,7 +168,7 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
       // Increment counter first so a concurrent reader never observes more queued
       // failures than skippedBundles reports.
       status.updateAndGet(TransferProcessStatus::incSkippedBundles);
-      failedPatients.offer(new PatientError(patientId, step, e.getMessage()));
+      failedPatients.add(new PatientError(patientId, step, e.getMessage()));
       return Mono.empty();
     }
 

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -8,7 +8,6 @@ import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.ConsentedPatientBundle;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender.Result;
-import care.smith.fts.cda.TransferProcessStatus.Step;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -16,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,17 +87,24 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
 
   @Override
   public synchronized Mono<TransferProcessStatus> status(String processId) {
-    var transferProcessInstance = instances.get(processId);
-    if (transferProcessInstance != null) {
-      return Mono.just(transferProcessInstance.status());
-    } else {
-      return Mono.justOrEmpty(
-              queued.stream().filter(q -> q.processId().equals(processId)).findFirst())
-          .map(TransferProcessInstance::status)
-          .switchIfEmpty(
-              Mono.error(
-                  new IllegalStateException("No transfer process with processId: " + processId)));
+    return findInstance(processId).map(TransferProcessInstance::status);
+  }
+
+  @Override
+  public synchronized Mono<List<PatientError>> failedPatients(String processId) {
+    return findInstance(processId).map(TransferProcessInstance::failedPatients);
+  }
+
+  private Mono<TransferProcessInstance> findInstance(String processId) {
+    var instance = instances.get(processId);
+    if (instance != null) {
+      return Mono.just(instance);
     }
+    return Mono.justOrEmpty(
+            queued.stream().filter(q -> q.processId().equals(processId)).findFirst())
+        .switchIfEmpty(
+            Mono.error(
+                new IllegalStateException("No transfer process with processId: " + processId)));
   }
 
   private synchronized void onComplete() {
@@ -112,6 +119,7 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
 
     private final TransferProcessDefinition process;
     private final AtomicReference<TransferProcessStatus> status;
+    private final Queue<PatientError> failedPatients = new ConcurrentLinkedQueue<>();
     private final List<String> identifiers;
 
     public TransferProcessInstance(
@@ -157,8 +165,10 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
 
     private <T> Mono<T> handlePatientError(String patientId, Step step, Throwable e) {
       logError(step, patientId, e);
-      status.updateAndGet(
-          s -> s.incSkippedBundles().addFailedPatient(patientId, step, e.getMessage()));
+      // Increment counter first so a concurrent reader never observes more queued
+      // failures than skippedBundles reports.
+      status.updateAndGet(TransferProcessStatus::incSkippedBundles);
+      failedPatients.offer(new PatientError(patientId, step, e.getMessage()));
       return Mono.empty();
     }
 
@@ -214,6 +224,10 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
 
     public TransferProcessStatus status() {
       return status.get();
+    }
+
+    public List<PatientError> failedPatients() {
+      return List.copyOf(failedPatients);
     }
 
     private String processId() {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
@@ -11,6 +11,8 @@ public interface TransferProcessRunner {
 
   Mono<TransferProcessStatus> status(String processId);
 
+  Mono<List<PatientError>> failedPatients(String processId);
+
   enum Phase {
     QUEUED,
     RUNNING,
@@ -18,4 +20,23 @@ public interface TransferProcessRunner {
     COMPLETED_WITH_ERROR,
     FATAL
   }
+
+  enum Step {
+    SELECT_DATA("select data"),
+    DEIDENTIFY("deidentify bundle"),
+    SEND_BUNDLE("send bundle");
+
+    private final String displayName;
+
+    Step(String displayName) {
+      this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
+  }
+
+  record PatientError(String patientId, Step step, String errorMessage) {}
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
@@ -3,10 +3,7 @@ package care.smith.fts.cda;
 import static lombok.AccessLevel.PRIVATE;
 
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.With;
 
 public record TransferProcessStatus(
@@ -18,31 +15,11 @@ public record TransferProcessStatus(
     @With(PRIVATE) long totalBundles,
     @With(PRIVATE) long deidentifiedBundles,
     @With(PRIVATE) long sentBundles,
-    @With(PRIVATE) long skippedBundles,
-    @JsonIgnore @With(PRIVATE) List<PatientError> failedPatients) {
-
-  public enum Step {
-    SELECT_DATA("select data"),
-    DEIDENTIFY("deidentify bundle"),
-    SEND_BUNDLE("send bundle");
-
-    private final String displayName;
-
-    Step(String displayName) {
-      this.displayName = displayName;
-    }
-
-    @Override
-    public String toString() {
-      return displayName;
-    }
-  }
-
-  public record PatientError(String patientId, Step step, String errorMessage) {}
+    @With(PRIVATE) long skippedBundles) {
 
   public static TransferProcessStatus create(String processId) {
     return new TransferProcessStatus(
-        processId, Phase.QUEUED, LocalDateTime.now(), null, 0, 0, 0, 0, 0, List.of());
+        processId, Phase.QUEUED, LocalDateTime.now(), null, 0, 0, 0, 0, 0);
   }
 
   public TransferProcessStatus incTotalPatients() {
@@ -63,12 +40,6 @@ public record TransferProcessStatus(
 
   public TransferProcessStatus incSkippedBundles() {
     return withSkippedBundles(skippedBundles + 1);
-  }
-
-  public TransferProcessStatus addFailedPatient(String patientId, Step step, String errorMessage) {
-    var updated = new ArrayList<>(failedPatients);
-    updated.add(new PatientError(patientId, step, errorMessage));
-    return withFailedPatients(List.copyOf(updated));
   }
 
   /**

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -8,8 +8,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import care.smith.fts.cda.TransferProcessConfig;
 import care.smith.fts.cda.TransferProcessDefinition;
 import care.smith.fts.cda.TransferProcessRunner;
+import care.smith.fts.cda.TransferProcessRunner.PatientError;
 import care.smith.fts.cda.TransferProcessStatus;
-import care.smith.fts.cda.TransferProcessStatus.PatientError;
 import care.smith.fts.util.error.ErrorResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -185,8 +185,8 @@ public class TransferProcessController {
   Mono<ResponseEntity<List<PatientError>>> failedPatients(
       @PathVariable(value = "processId") String processId) {
     return processRunner
-        .status(processId)
-        .map(s -> ResponseEntity.ok().body(s.failedPatients()))
+        .failedPatients(processId)
+        .map(ResponseEntity::ok)
         .onErrorResume(ErrorResponseUtil::notFound);
   }
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -13,7 +13,7 @@ import care.smith.fts.api.cda.BundleSender.Result;
 import care.smith.fts.api.cda.DataSelector;
 import care.smith.fts.api.cda.Deidentificator;
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import care.smith.fts.cda.TransferProcessStatus.Step;
+import care.smith.fts.cda.TransferProcessRunner.Step;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.hl7.fhir.r4.model.Bundle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -298,11 +299,15 @@ class DefaultTransferProcessRunnerTest {
             r -> {
               assertThat(r.phase()).isEqualTo(Phase.COMPLETED_WITH_ERROR);
               assertThat(r.sentBundles()).isEqualTo(2);
-              assertThat(r.failedPatients()).hasSize(1);
-              assertThat(r.failedPatients().getFirst().patientId()).isEqualTo(PATIENT_IDENTIFIER_2);
-              assertThat(r.failedPatients().getFirst().step()).isEqualTo(Step.SELECT_DATA);
-              assertThat(r.failedPatients().getFirst().errorMessage())
-                  .isEqualTo("Cannot select data");
+            })
+        .verifyComplete();
+    create(runner.failedPatients(processId))
+        .assertNext(
+            errors -> {
+              assertThat(errors).hasSize(1);
+              assertThat(errors.getFirst().patientId()).isEqualTo(PATIENT_IDENTIFIER_2);
+              assertThat(errors.getFirst().step()).isEqualTo(Step.SELECT_DATA);
+              assertThat(errors.getFirst().errorMessage()).isEqualTo("Cannot select data");
             })
         .verifyComplete();
   }
@@ -326,10 +331,14 @@ class DefaultTransferProcessRunnerTest {
             r -> {
               assertThat(r.phase()).isEqualTo(Phase.COMPLETED_WITH_ERROR);
               assertThat(r.sentBundles()).isEqualTo(2);
-              assertThat(r.failedPatients()).hasSize(1);
-              assertThat(r.failedPatients().getFirst().step()).isEqualTo(Step.DEIDENTIFY);
-              assertThat(r.failedPatients().getFirst().errorMessage())
-                  .isEqualTo("Cannot deidentify bundle");
+            })
+        .verifyComplete();
+    create(runner.failedPatients(processId))
+        .assertNext(
+            errors -> {
+              assertThat(errors).hasSize(1);
+              assertThat(errors.getFirst().step()).isEqualTo(Step.DEIDENTIFY);
+              assertThat(errors.getFirst().errorMessage()).isEqualTo("Cannot deidentify bundle");
             })
         .verifyComplete();
   }
@@ -353,10 +362,14 @@ class DefaultTransferProcessRunnerTest {
             r -> {
               assertThat(r.phase()).isEqualTo(Phase.COMPLETED_WITH_ERROR);
               assertThat(r.sentBundles()).isEqualTo(2);
-              assertThat(r.failedPatients()).hasSize(1);
-              assertThat(r.failedPatients().getFirst().step()).isEqualTo(Step.SEND_BUNDLE);
-              assertThat(r.failedPatients().getFirst().errorMessage())
-                  .isEqualTo("Cannot send bundle");
+            })
+        .verifyComplete();
+    create(runner.failedPatients(processId))
+        .assertNext(
+            errors -> {
+              assertThat(errors).hasSize(1);
+              assertThat(errors.getFirst().step()).isEqualTo(Step.SEND_BUNDLE);
+              assertThat(errors.getFirst().errorMessage()).isEqualTo("Cannot send bundle");
             })
         .verifyComplete();
   }
@@ -374,10 +387,70 @@ class DefaultTransferProcessRunnerTest {
 
     var processId = runner.start(process, List.of());
     create(runner.status(processId))
+        .assertNext(r -> assertThat(r.phase()).isEqualTo(Phase.COMPLETED))
+        .verifyComplete();
+    create(runner.failedPatients(processId))
+        .assertNext(errors -> assertThat(errors).isEmpty())
+        .verifyComplete();
+  }
+
+  @Test
+  void failedPatientsForUnknownProcessIdErrors() {
+    create(runner.failedPatients("unknown"))
+        .expectErrorMatches(
+            e ->
+                e instanceof IllegalStateException
+                    && e.getMessage().contains("No transfer process with processId"))
+        .verify();
+  }
+
+  @Test
+  void failedPatientsForQueuedProcessIsEmpty() {
+    var process =
+        new TransferProcessDefinition(
+            "test",
+            rawConfig,
+            pids -> fromIterable(List.of(PATIENT)),
+            p -> fromIterable(List.of(new ConsentedPatientBundle(new Bundle(), PATIENT))),
+            b ->
+                just(new TransportBundle(new Bundle(), "transferId"))
+                    .delayElement(Duration.ofMillis(100)),
+            b -> just(new Result()));
+
+    runner.start(process, List.of());
+    runner.start(process, List.of());
+    var queuedId = runner.start(process, List.of());
+
+    create(runner.failedPatients(queuedId))
+        .assertNext(errors -> assertThat(errors).isEmpty())
+        .verifyComplete();
+  }
+
+  @Test
+  void manyFailuresAreAllRecorded() {
+    int n = 5_000;
+    var patients =
+        IntStream.range(0, n)
+            .mapToObj(i -> new ConsentedPatient("patient-" + i, "system"))
+            .toList();
+    var process =
+        new TransferProcessDefinition(
+            "test",
+            rawConfig,
+            pids -> fromIterable(patients),
+            p -> Flux.error(new RuntimeException("Cannot select data")),
+            b -> just(new TransportBundle(new Bundle(), "transferId")),
+            b -> just(new Result()));
+
+    var processId = runner.start(process, List.of());
+    waitForCompletion(processId);
+
+    create(runner.failedPatients(processId))
         .assertNext(
-            r -> {
-              assertThat(r.phase()).isEqualTo(Phase.COMPLETED);
-              assertThat(r.failedPatients()).isEmpty();
+            errors -> {
+              assertThat(errors).hasSize(n);
+              assertThat(errors).allMatch(e -> e.step() == Step.SELECT_DATA);
+              assertThat(errors).allMatch(e -> "Cannot select data".equals(e.errorMessage()));
             })
         .verifyComplete();
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessStatusTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessStatusTest.java
@@ -1,11 +1,8 @@
 package care.smith.fts.cda;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import care.smith.fts.cda.TransferProcessStatus.PatientError;
-import care.smith.fts.cda.TransferProcessStatus.Step;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +22,6 @@ class TransferProcessStatusTest {
     assertThat(status.deidentifiedBundles()).isEqualTo(0);
     assertThat(status.sentBundles()).isEqualTo(0);
     assertThat(status.skippedBundles()).isEqualTo(0);
-    assertThat(status.failedPatients()).isEmpty();
   }
 
   @Test
@@ -96,51 +92,5 @@ class TransferProcessStatusTest {
 
     status = status.setPhase(Phase.FATAL);
     assertThat(TransferProcessStatus.isCompleted(status.phase())).isTrue();
-  }
-
-  @Test
-  void addFailedPatientAddsEntry() {
-    var status =
-        TransferProcessStatus.create("process123")
-            .addFailedPatient("patient-1", Step.SELECT_DATA, "Connection refused");
-
-    assertThat(status.failedPatients()).hasSize(1);
-    assertThat(status.failedPatients().getFirst().patientId()).isEqualTo("patient-1");
-    assertThat(status.failedPatients().getFirst().step()).isEqualTo(Step.SELECT_DATA);
-    assertThat(status.failedPatients().getFirst().errorMessage()).isEqualTo("Connection refused");
-  }
-
-  @Test
-  void addMultipleFailedPatientsAccumulatesAll() {
-    var status =
-        TransferProcessStatus.create("process123")
-            .addFailedPatient("patient-1", Step.SELECT_DATA, "Error A")
-            .addFailedPatient("patient-2", Step.DEIDENTIFY, "Error B");
-
-    assertThat(status.failedPatients()).hasSize(2);
-    assertThat(status.failedPatients().get(0).patientId()).isEqualTo("patient-1");
-    assertThat(status.failedPatients().get(0).step()).isEqualTo(Step.SELECT_DATA);
-    assertThat(status.failedPatients().get(1).patientId()).isEqualTo("patient-2");
-    assertThat(status.failedPatients().get(1).step()).isEqualTo(Step.DEIDENTIFY);
-  }
-
-  @Test
-  void addFailedPatientPreservesImmutability() {
-    var original = TransferProcessStatus.create("process123");
-    var withError = original.addFailedPatient("patient-1", Step.SEND_BUNDLE, "Error");
-
-    assertThat(original.failedPatients()).isEmpty();
-    assertThat(withError.failedPatients()).hasSize(1);
-  }
-
-  @Test
-  void failedPatientsListIsUnmodifiable() {
-    var status =
-        TransferProcessStatus.create("process123")
-            .addFailedPatient("patient-1", Step.SELECT_DATA, "Error");
-
-    assertThatThrownBy(
-            () -> status.failedPatients().add(new PatientError("x", Step.SELECT_DATA, "y")))
-        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
@@ -12,9 +12,10 @@ import static reactor.test.StepVerifier.create;
 import care.smith.fts.cda.TransferProcessConfig;
 import care.smith.fts.cda.TransferProcessDefinition;
 import care.smith.fts.cda.TransferProcessRunner;
+import care.smith.fts.cda.TransferProcessRunner.PatientError;
 import care.smith.fts.cda.TransferProcessRunner.Phase;
+import care.smith.fts.cda.TransferProcessRunner.Step;
 import care.smith.fts.cda.TransferProcessStatus;
-import care.smith.fts.cda.TransferProcessStatus.Step;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -175,12 +176,12 @@ class TransferProcessControllerTest {
   @Test
   void failedPatientsReturnsErrors() {
     var processId = "failed-123456";
-    var result =
-        TransferProcessStatus.create(processId)
-            .addFailedPatient("patient-001", Step.SELECT_DATA, "Connection refused")
-            .addFailedPatient("patient-042", Step.DEIDENTIFY, "Cannot deidentify bundle");
+    var errors =
+        List.of(
+            new PatientError("patient-001", Step.SELECT_DATA, "Connection refused"),
+            new PatientError("patient-042", Step.DEIDENTIFY, "Cannot deidentify bundle"));
 
-    when(mockRunner.status(processId)).thenReturn(Mono.just(result));
+    when(mockRunner.failedPatients(processId)).thenReturn(Mono.just(errors));
 
     create(api.failedPatients(processId))
         .assertNext(
@@ -197,7 +198,7 @@ class TransferProcessControllerTest {
 
   @Test
   void failedPatientsWithUnknownProcessIdReturns404() {
-    when(mockRunner.status(Mockito.anyString()))
+    when(mockRunner.failedPatients(Mockito.anyString()))
         .thenReturn(Mono.error(new IllegalStateException("No transfer process with processId: ")));
 
     create(api.failedPatients("unknown"))


### PR DESCRIPTION
## Summary

- Move `failedPatients` off the immutable `TransferProcessStatus` record onto a `ConcurrentLinkedQueue` on `TransferProcessInstance`. Adding a failure is now O(1).
- Extend `TransferProcessRunner` with `Mono<List<PatientError>> failedPatients(String processId)`; controller endpoint switches to it.
- Move `Step` and `PatientError` from `TransferProcessStatus` to `TransferProcessRunner` (they describe runner failures, not status counters).
- Increment `skippedBundles` before enqueueing the `PatientError` so a concurrent reader never observes more queued failures than `skippedBundles` reports.

## Why

`TransferProcessStatus.addFailedPatient` copied the failure list twice on every call inside `AtomicReference.updateAndGet`. For N failures the aggregate work was O(N²), and CAS retries amplified it. Invisible on the happy path, but during a cascading outage (TCA unreachable, HDS slow, bad config) the bookkeeping path becomes the bottleneck.

Closes #1641