### PR TITLE
Fix Null In TCA gICS Startup Log

### DIFF
--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/configuration/GicsConfiguration.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/configuration/GicsConfiguration.java
@@ -45,7 +45,7 @@ public class GicsConfiguration {
   ApplicationRunner runner(@Qualifier("gicsFhirHttpClient") WebClient gicsClient) {
     return args ->
         verifyGicsCapabilities(gicsClient)
-            .doOnNext(c -> log.info("gICS {} available", c.getSoftware().getVersion()))
+            .doOnNext(c -> log.info("gICS available"))
             .doOnError(GicsConfiguration::logWarning)
             .onErrorComplete()
             .subscribe();


### PR DESCRIPTION
## Summary
- gICS `CapabilityStatement` does not populate `software.version`, so the startup runner logged `gICS null available`.
- `GicsConfiguration` now logs a fixed `gICS available` message, dropping the version entirely.

Closes #1651