### PR TITLE
Fix LocalDateTime Serialized as JSON Arrays

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -141,7 +141,7 @@ public class TransferProcessController {
                           name = "Transfer process status",
                           value =
 """
-{"processId":"ChlblQ","phase":"RUNNING","createdAt":[2024,12,16,9,29,37,186662587],"finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
+{"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T09:29:37.186662587","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
 """)
                     })),
         @ApiResponse(responseCode = "404", description = "The project could not be found")
@@ -207,8 +207,8 @@ public class TransferProcessController {
                           value =
 """
 [
-  {"processId":"8R9JGu","phase":"COMPLETED","createdAt":[2024,12,16,9,28,50,772443200],"finishedAt":[2024,12,16,9,29,31,776068091],"totalPatients":100,"totalBundles":119,"deidentifiedBundles":118,"sentBundles":118,"skippedBundles":0},
-  {"processId":"ChlblQ","phase":"RUNNING","createdAt":[2024,12,16,9,29,37,186662587],"finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
+  {"processId":"8R9JGu","phase":"COMPLETED","createdAt":"2024-12-16T09:28:50.772443200","finishedAt":"2024-12-16T09:29:31.776068091","totalPatients":100,"totalBundles":119,"deidentifiedBundles":118,"sentBundles":118,"skippedBundles":0},
+  {"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T09:29:37.186662587","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
 ]
 """)
                     })),

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
@@ -1,0 +1,104 @@
+package care.smith.fts.cda.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static reactor.test.StepVerifier.create;
+
+import care.smith.fts.cda.ClinicalDomainAgent;
+import care.smith.fts.cda.TransferProcessRunner;
+import care.smith.fts.cda.TransferProcessRunner.Phase;
+import care.smith.fts.cda.TransferProcessStatus;
+import care.smith.fts.test.TestWebClientFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(classes = ClinicalDomainAgent.class, webEnvironment = RANDOM_PORT)
+@Import(TestWebClientFactory.class)
+class TransferProcessStatusSerializationIT {
+
+  @MockitoBean private TransferProcessRunner processRunner;
+
+  @Autowired private ObjectMapper primaryObjectMapper;
+
+  private WebClient client;
+
+  @BeforeEach
+  void setUp(@LocalServerPort int port, @Autowired TestWebClientFactory factory) {
+    client = factory.webClient("https://localhost:" + port);
+  }
+
+  @Test
+  void statusBodySerializesLocalDateTimeAsIsoString() {
+    var processId = "iso-test";
+    var status =
+        new TransferProcessStatus(
+            processId,
+            Phase.COMPLETED,
+            LocalDateTime.of(2026, 5, 13, 3, 0, 0, 818008066),
+            LocalDateTime.of(2026, 5, 13, 3, 0, 10, 543337718),
+            0,
+            0,
+            0,
+            0,
+            0);
+    Mockito.when(processRunner.status(processId)).thenReturn(Mono.just(status));
+
+    create(
+            client
+                .get()
+                .uri("/api/v2/process/status/" + processId)
+                .retrieve()
+                .bodyToMono(String.class))
+        .assertNext(
+            body -> {
+              assertThat(body).contains("\"createdAt\":\"2026-05-13T03:00:00.818008066\"");
+              assertThat(body).contains("\"finishedAt\":\"2026-05-13T03:00:10.543337718\"");
+              assertThat(body).doesNotContain("\"createdAt\":[");
+              assertThat(body).doesNotContain("\"finishedAt\":[");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void primaryObjectMapperSerializesLocalDateTimeAsIsoString() throws Exception {
+    var status = TransferProcessStatus.create("direct");
+    var json = primaryObjectMapper.writeValueAsString(status);
+    assertThat(json).doesNotContain("\"createdAt\":[");
+    assertThat(json).contains("\"createdAt\":\"2");
+  }
+
+  @Test
+  void statusesBodySerializesLocalDateTimeAsIsoString() {
+    var status =
+        new TransferProcessStatus(
+            "iso-list",
+            Phase.RUNNING,
+            LocalDateTime.of(2026, 5, 13, 3, 0, 0, 818008066),
+            null,
+            0,
+            0,
+            0,
+            0,
+            0);
+    Mockito.when(processRunner.statuses()).thenReturn(Mono.just(List.of(status)));
+
+    create(client.get().uri("/api/v2/process/statuses").retrieve().bodyToMono(String.class))
+        .assertNext(
+            body -> {
+              assertThat(body).contains("\"createdAt\":\"2026-05-13T03:00:00.818008066\"");
+              assertThat(body).doesNotContain("\"createdAt\":[");
+            })
+        .verifyComplete();
+  }
+}

--- a/docs/usage/execution.md
+++ b/docs/usage/execution.md
@@ -50,8 +50,8 @@ The status response looks like this:
 {
   "processId": "e17d319e-d967-467e-8c8a-0c464bb14951",
   "phase": "COMPLETED",
-  "createdAt": [ 2024, 11, 13, 8, 35, 35, 262354492 ],
-  "finishedAt": [ 2024, 11, 13, 8, 36, 17, 358171815 ],
+  "createdAt": "2024-11-13T08:35:35.262354492",
+  "finishedAt": "2024-11-13T08:36:17.358171815",
   "totalPatients": 100,
   "totalBundles": 119,
   "deidentifiedBundles": 118,

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -7,6 +7,7 @@ import care.smith.fts.util.auth.HttpServerAuthConfig;
 import care.smith.fts.util.auth.OAuth2ConfigurationExistsCondition;
 import care.smith.fts.util.fhir.FhirCodecConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.net.http.HttpClient;
 import org.springframework.context.annotation.Bean;
@@ -44,7 +45,9 @@ public class AgentConfiguration {
   @Bean
   @Primary
   public ObjectMapper defaultObjectMapper() {
-    return new ObjectMapper().registerModule(new JavaTimeModule());
+    return new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
   }
 
   @Bean


### PR DESCRIPTION
## Summary
- Disable `WRITE_DATES_AS_TIMESTAMPS` on the `@Primary` `defaultObjectMapper` in `AgentConfiguration`. `JavaTimeModule` defaults to numeric-array serialization for `LocalDateTime` unless this feature is disabled.
- Update OpenAPI example payloads in `TransferProcessController` and the usage docs to show ISO-8601 strings.
- Add `TransferProcessStatusSerializationIT` covering the `@Primary` mapper directly and the `/api/v2/process/status/*` endpoint.

Closes #1654