### PR TITLE
Docs and API: 'IDs' Vs 'Identifiers' in CDA

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunner.java
@@ -38,5 +38,12 @@ public interface TransferProcessRunner {
     }
   }
 
-  record PatientError(String patientId, Step step, String errorMessage) {}
+  /**
+   * Error information for a failed patient transfer.
+   *
+   * @param patientIdentifier the patient identifier value
+   * @param step the transfer step at which the failure occurred
+   * @param errorMessage human-readable error message
+   */
+  record PatientError(String patientIdentifier, Step step, String errorMessage) {}
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -58,8 +58,8 @@ public class TransferProcessController {
           """
           **Since 5.0**
 
-          Start a transfer of patients with IDs given in the request body or if empty start
-           a transfer of all consented patients.
+          Start a transfer of patients with identifiers given in the request body or if empty
+           start a transfer of all consented patients.
           """,
       parameters = {
         @Parameter(
@@ -70,15 +70,15 @@ public class TransferProcessController {
       },
       requestBody =
           @io.swagger.v3.oas.annotations.parameters.RequestBody(
-              description = "IDs of patients to transfer",
+              description = "Identifiers of patients to transfer",
               content =
                   @Content(
                       mediaType = "application/json",
                       schema = @Schema(implementation = String.class),
                       examples =
                           @ExampleObject(
-                              name = "List of three patient IDs",
-                              value = "[\"id1\", \"id2\", \"id3\"]"))),
+                              name = "List of three patient identifiers",
+                              value = "[\"identifier-1\", \"identifier-2\", \"identifier-3\"]"))),
       responses = {
         @ApiResponse(
             responseCode = "202",
@@ -157,7 +157,8 @@ public class TransferProcessController {
   @GetMapping("/process/status/{processId:[\\w-]+}/failed_patients")
   @Operation(
       summary = "Failed patients of a transfer process",
-      description = "**Since 6.0**\n\nReturns patient IDs and error messages for failed transfers.",
+      description =
+          "**Since 6.0**\n\nReturns patient identifiers and error messages for failed transfers.",
       parameters = {
         @Parameter(
             name = "processId",
@@ -176,8 +177,8 @@ public class TransferProcessController {
                           name = "Failed patients",
                           value =
 """
-[{"patientId":"patient-001","step":"SELECT_DATA","errorMessage":"Connection refused"},\
-{"patientId":"patient-042","step":"DEIDENTIFY","errorMessage":"Cannot deidentify bundle"}]
+[{"patientIdentifier":"patient-001","step":"SELECT_DATA","errorMessage":"Connection refused"},\
+{"patientIdentifier":"patient-042","step":"DEIDENTIFY","errorMessage":"Cannot deidentify bundle"}]
 """)
                     })),
         @ApiResponse(responseCode = "404", description = "The process could not be found")

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -305,7 +305,7 @@ class DefaultTransferProcessRunnerTest {
         .assertNext(
             errors -> {
               assertThat(errors).hasSize(1);
-              assertThat(errors.getFirst().patientId()).isEqualTo(PATIENT_IDENTIFIER_2);
+              assertThat(errors.getFirst().patientIdentifier()).isEqualTo(PATIENT_IDENTIFIER_2);
               assertThat(errors.getFirst().step()).isEqualTo(Step.SELECT_DATA);
               assertThat(errors.getFirst().errorMessage()).isEqualTo("Cannot select data");
             })

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerTest.java
@@ -188,9 +188,9 @@ class TransferProcessControllerTest {
             r -> {
               assertThat(r.getStatusCode()).isEqualTo(OK);
               assertThat(r.getBody()).hasSize(2);
-              assertThat(r.getBody().get(0).patientId()).isEqualTo("patient-001");
+              assertThat(r.getBody().get(0).patientIdentifier()).isEqualTo("patient-001");
               assertThat(r.getBody().get(0).step()).isEqualTo(Step.SELECT_DATA);
-              assertThat(r.getBody().get(1).patientId()).isEqualTo("patient-042");
+              assertThat(r.getBody().get(1).patientIdentifier()).isEqualTo("patient-042");
               assertThat(r.getBody().get(1).step()).isEqualTo(Step.DEIDENTIFY);
             })
         .verifyComplete();

--- a/docs/cd-agent/cohort-selector/trustCenterAgent.md
+++ b/docs/cd-agent/cohort-selector/trustCenterAgent.md
@@ -1,6 +1,6 @@
 # TCA Cohort Selector <Badge type="tip" text="Clinical Domain Agent" /> <Badge type="warning" text="Since 5.0" />
 
-The TCA based implementation uses the connection to the TCA to select patient IDs for transfer.
+The TCA based implementation uses the connection to the TCA to select patient identifiers for transfer.
 
 ## Example Configuration
 

--- a/docs/usage/execution.md
+++ b/docs/usage/execution.md
@@ -88,12 +88,12 @@ curl -sSf "https://cd-agent:8080/api/v2/process/status/52792219-b966-44bf-bc1b-c
 ```json
 [
   {
-    "patientId": "patient-001",
+    "patientIdentifier": "patient-001",
     "step": "SELECT_DATA",
     "errorMessage": "Connection refused"
   },
   {
-    "patientId": "patient-042",
+    "patientIdentifier": "patient-042",
     "step": "DEIDENTIFY",
     "errorMessage": "Cannot deidentify bundle"
   }
@@ -103,7 +103,7 @@ curl -sSf "https://cd-agent:8080/api/v2/process/status/52792219-b966-44bf-bc1b-c
 
 | Field          | Description                                                                                      |
 |----------------|--------------------------------------------------------------------------------------------------|
-| `patientId`    | Identifier of the patient whose transfer failed                                                  |
+| `patientIdentifier` | Identifier of the patient whose transfer failed                                             |
 | `step`         | Processing step where the error occurred (`SELECT_DATA`, `DEIDENTIFY`, `SEND_BUNDLE`)            |
 | `errorMessage` | Error message describing the failure                                                             |
 


### PR DESCRIPTION
## Summary

- Replace "IDs"/"patient IDs" wording with "identifiers"/"patient identifiers" in CDA `TransferProcessController` OpenAPI annotations (operation description, request body description, example name/value, `failedPatients` description).
- Update request body example value from `["id1","id2","id3"]` to `["identifier-1","identifier-2","identifier-3"]`.
- Update `docs/cd-agent/cohort-selector/trustCenterAgent.md` wording.
- Rename `TransferProcessRunner.PatientError` record component `patientId` → `patientIdentifier`. **Breaking change**: the JSON response of `GET /process/status/{processId}/failed_patients` now serializes the field as `patientIdentifier` instead of `patientId`.
- Add javadoc to `PatientError` documenting that `patientIdentifier` is the patient identifier value (not the FHIR resource ID).
- **Fix**: `docs/usage/execution.md` showed `createdAt`/`finishedAt` as int arrays (`[2024, 11, 13, ...]`), but the runtime serializes `LocalDateTime` as ISO-8601 strings (`JavaTimeModule` + `WRITE_DATES_AS_TIMESTAMPS` disabled in `AgentConfiguration`). Doc example corrected to match actual API output.

Closes #1663