### PR TITLE
Fix Zone-Ambiguous Process Timestamps

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -9,7 +9,7 @@ import care.smith.fts.api.ConsentedPatientBundle;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender.Result;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -66,7 +66,7 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
   }
 
   private synchronized void removeOldProcesses() {
-    var removeBefore = LocalDateTime.now().minus(config.processTtl);
+    var removeBefore = Instant.now().minus(config.processTtl);
     var forRemoval =
         instances.values().stream()
             .filter(inst -> inst.status().mayBeRemoved(removeBefore))

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java
@@ -1,16 +1,19 @@
 package care.smith.fts.cda;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 import static lombok.AccessLevel.PRIVATE;
 
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
 import lombok.With;
 
 public record TransferProcessStatus(
     String processId,
     @With(PRIVATE) Phase phase,
-    LocalDateTime createdAt,
-    @With(PRIVATE) LocalDateTime finishedAt,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX") Instant createdAt,
+    @With(PRIVATE) @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+        Instant finishedAt,
     @With(PRIVATE) long totalPatients,
     @With(PRIVATE) long totalBundles,
     @With(PRIVATE) long deidentifiedBundles,
@@ -18,8 +21,7 @@ public record TransferProcessStatus(
     @With(PRIVATE) long skippedBundles) {
 
   public static TransferProcessStatus create(String processId) {
-    return new TransferProcessStatus(
-        processId, Phase.QUEUED, LocalDateTime.now(), null, 0, 0, 0, 0, 0);
+    return new TransferProcessStatus(processId, Phase.QUEUED, Instant.now(), null, 0, 0, 0, 0, 0);
   }
 
   public TransferProcessStatus incTotalPatients() {
@@ -54,16 +56,14 @@ public record TransferProcessStatus(
   }
 
   private TransferProcessStatus setAnyCompleted(Phase phase) {
-    return isCompleted(phase)
-        ? withPhase(phase).withFinishedAt(LocalDateTime.now())
-        : withPhase(phase);
+    return isCompleted(phase) ? withPhase(phase).withFinishedAt(Instant.now()) : withPhase(phase);
   }
 
   public static Boolean isCompleted(Phase phase) {
     return phase == Phase.COMPLETED || phase == Phase.COMPLETED_WITH_ERROR || phase == Phase.FATAL;
   }
 
-  public Boolean mayBeRemoved(LocalDateTime before) {
+  public Boolean mayBeRemoved(Instant before) {
     return finishedAt != null && finishedAt.isBefore(before);
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java
@@ -141,7 +141,7 @@ public class TransferProcessController {
                           name = "Transfer process status",
                           value =
 """
-{"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T09:29:37.186662587","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
+{"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T10:29:37.186+01:00","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
 """)
                     })),
         @ApiResponse(responseCode = "404", description = "The project could not be found")
@@ -208,8 +208,8 @@ public class TransferProcessController {
                           value =
 """
 [
-  {"processId":"8R9JGu","phase":"COMPLETED","createdAt":"2024-12-16T09:28:50.772443200","finishedAt":"2024-12-16T09:29:31.776068091","totalPatients":100,"totalBundles":119,"deidentifiedBundles":118,"sentBundles":118,"skippedBundles":0},
-  {"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T09:29:37.186662587","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
+  {"processId":"8R9JGu","phase":"COMPLETED","createdAt":"2024-12-16T10:28:50.772+01:00","finishedAt":"2024-12-16T10:29:31.776+01:00","totalPatients":100,"totalBundles":119,"deidentifiedBundles":118,"sentBundles":118,"skippedBundles":0},
+  {"processId":"ChlblQ","phase":"RUNNING","createdAt":"2024-12-16T10:29:37.186+01:00","finishedAt":null,"totalPatients":100,"totalBundles":53,"deidentifiedBundles":32,"sentBundles":0,"skippedBundles":0}
 ]
 """)
                     })),

--- a/clinical-domain-agent/src/main/resources/application.yaml
+++ b/clinical-domain-agent/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+spring:
+  jackson:
+    time-zone: ${TZ:Europe/Berlin}
+
 management:
   endpoints:
     web:

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessStatusTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessStatusTest.java
@@ -3,7 +3,8 @@ package care.smith.fts.cda;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.cda.TransferProcessRunner.Phase;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class TransferProcessStatusTest {
@@ -68,7 +69,7 @@ class TransferProcessStatusTest {
   @Test
   void testMayBeRemoved() {
     var status = TransferProcessStatus.create("process123");
-    LocalDateTime pastDate = LocalDateTime.now().plusDays(1);
+    Instant pastDate = Instant.now().plus(Duration.ofDays(1));
 
     // Initially finishedAt is null
     assertThat(status.mayBeRemoved(pastDate)).isFalse();

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
@@ -10,7 +10,7 @@ import care.smith.fts.cda.TransferProcessRunner.Phase;
 import care.smith.fts.cda.TransferProcessStatus;
 import care.smith.fts.test.TestWebClientFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,12 +19,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @SpringBootTest(classes = ClinicalDomainAgent.class, webEnvironment = RANDOM_PORT)
 @Import(TestWebClientFactory.class)
+@TestPropertySource(properties = "spring.jackson.time-zone=Europe/Berlin")
 class TransferProcessStatusSerializationIT {
 
   @MockitoBean private TransferProcessRunner processRunner;
@@ -39,14 +41,14 @@ class TransferProcessStatusSerializationIT {
   }
 
   @Test
-  void statusBodySerializesLocalDateTimeAsIsoString() {
+  void statusBodySerializesInstantInConfiguredZone() {
     var processId = "iso-test";
     var status =
         new TransferProcessStatus(
             processId,
             Phase.COMPLETED,
-            LocalDateTime.of(2026, 5, 13, 3, 0, 0, 818008066),
-            LocalDateTime.of(2026, 5, 13, 3, 0, 10, 543337718),
+            Instant.parse("2026-05-13T03:00:00.818008066Z"),
+            Instant.parse("2026-05-13T03:00:10.543337718Z"),
             0,
             0,
             0,
@@ -62,8 +64,8 @@ class TransferProcessStatusSerializationIT {
                 .bodyToMono(String.class))
         .assertNext(
             body -> {
-              assertThat(body).contains("\"createdAt\":\"2026-05-13T03:00:00.818008066\"");
-              assertThat(body).contains("\"finishedAt\":\"2026-05-13T03:00:10.543337718\"");
+              assertThat(body).contains("\"createdAt\":\"2026-05-13T05:00:00.818+02:00\"");
+              assertThat(body).contains("\"finishedAt\":\"2026-05-13T05:00:10.543+02:00\"");
               assertThat(body).doesNotContain("\"createdAt\":[");
               assertThat(body).doesNotContain("\"finishedAt\":[");
             })
@@ -71,20 +73,20 @@ class TransferProcessStatusSerializationIT {
   }
 
   @Test
-  void primaryObjectMapperSerializesLocalDateTimeAsIsoString() throws Exception {
+  void primaryObjectMapperSerializesInstantWithOffset() throws Exception {
     var status = TransferProcessStatus.create("direct");
     var json = primaryObjectMapper.writeValueAsString(status);
     assertThat(json).doesNotContain("\"createdAt\":[");
-    assertThat(json).contains("\"createdAt\":\"2");
+    assertThat(json).containsPattern("\"createdAt\":\"[^\"]+\\+\\d\\d:\\d\\d\"");
   }
 
   @Test
-  void statusesBodySerializesLocalDateTimeAsIsoString() {
+  void statusesBodySerializesInstantInConfiguredZone() {
     var status =
         new TransferProcessStatus(
             "iso-list",
             Phase.RUNNING,
-            LocalDateTime.of(2026, 5, 13, 3, 0, 0, 818008066),
+            Instant.parse("2026-05-13T03:00:00.818008066Z"),
             null,
             0,
             0,
@@ -96,7 +98,7 @@ class TransferProcessStatusSerializationIT {
     create(client.get().uri("/api/v2/process/statuses").retrieve().bodyToMono(String.class))
         .assertNext(
             body -> {
-              assertThat(body).contains("\"createdAt\":\"2026-05-13T03:00:00.818008066\"");
+              assertThat(body).contains("\"createdAt\":\"2026-05-13T05:00:00.818+02:00\"");
               assertThat(body).doesNotContain("\"createdAt\":[");
             })
         .verifyComplete();

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -86,6 +86,7 @@ export default withMermaid({
               [
                 {text: 'Projects', link: '/configuration/projects'},
                 {text: 'Runner', link: '/configuration/runner'},
+                {text: 'Time Zone', link: '/configuration/time-zone'},
                 {text: 'Logging', link: '/configuration/logging'},
                 {text: 'SSL Bundles', link: '/configuration/ssl-bundles'},
                 {text: 'Server', link: '/configuration/server'},

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -11,6 +11,7 @@ documentation. Each configuration entry contains a link to the documentation pag
 
 * [Projects](./configuration/projects)
 * [Runner](./configuration/runner)
+* [Time Zone](./configuration/time-zone)
 * [Logging](./configuration/logging)
 * [SSL](./configuration/ssl-bundles)
 * [Server](./configuration/server)

--- a/docs/configuration/time-zone.md
+++ b/docs/configuration/time-zone.md
@@ -1,0 +1,28 @@
+# Time Zone <Badge type="warning" text="Since 5.0" />
+
+FTSnext serializes process timestamps (e.g. `createdAt`, `finishedAt`) as ISO-8601
+strings with an explicit UTC offset. The offset is derived from the agent's
+configured time zone.
+
+## Setting the Time Zone
+
+Set the `TZ` environment variable on the agent process. In a Docker Compose
+deployment:
+
+```yaml
+services:
+  cd-agent:
+    environment:
+      TZ: Europe/Berlin
+```
+
+If `TZ` is unset, `Europe/Berlin` is used.
+
+## Notes
+
+* The time zone only affects how timestamps are formatted in JSON responses.
+  Comparisons and TTL cleanup (`runner.processTtl`) are unaffected.
+* Valid values are IANA zone IDs (e.g. `Europe/Berlin`, `UTC`,
+  `America/New_York`). See [the IANA tz database][iana].
+
+[iana]: https://www.iana.org/time-zones

--- a/docs/usage/execution.md
+++ b/docs/usage/execution.md
@@ -50,8 +50,8 @@ The status response looks like this:
 {
   "processId": "e17d319e-d967-467e-8c8a-0c464bb14951",
   "phase": "COMPLETED",
-  "createdAt": "2024-11-13T08:35:35.262354492",
-  "finishedAt": "2024-11-13T08:36:17.358171815",
+  "createdAt": "2024-11-13T09:35:35.262+01:00",
+  "finishedAt": "2024-11-13T09:36:17.358+01:00",
   "totalPatients": 100,
   "totalBundles": 119,
   "deidentifiedBundles": 118,
@@ -65,8 +65,8 @@ The status response looks like this:
 |-----------------------|------------------------------------------------------------------------------------------|
 | `processId`           | Process ID                                                                               |
 | `phase`               | Status of the process (`QUEUED`, `RUNNING`, `COMPLETED`)                                 |
-| `createdAt`           | Point in time when the process was created                                               |
-| `finishedAt`          | Point in time when the process finished                                                  |
+| `createdAt`           | Point in time when the process was created (ISO-8601 with offset; see [Time Zone](../configuration/time-zone)) |
+| `finishedAt`          | Point in time when the process finished (ISO-8601 with offset; see [Time Zone](../configuration/time-zone))    |
 | `totalPatients`       | Total number of patients to be processed, may change while the process is running        |
 | `totalBundles`        | Total number of bundles to be processed                                                  |
 | `deidentifiedBundles` | Number of bundles after deidentification                                                 |

--- a/research-domain-agent/src/main/resources/application.yaml
+++ b/research-domain-agent/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+spring:
+  jackson:
+    time-zone: ${TZ:Europe/Berlin}
+
 management:
   endpoints:
     web:

--- a/trust-center-agent/src/main/resources/application.yaml
+++ b/trust-center-agent/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+spring:
+  jackson:
+    time-zone: ${TZ:Europe/Berlin}
+
 management:
   endpoints:
     web:

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.net.http.HttpClient;
+import java.util.TimeZone;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -44,10 +46,12 @@ public class AgentConfiguration {
 
   @Bean
   @Primary
-  public ObjectMapper defaultObjectMapper() {
+  public ObjectMapper defaultObjectMapper(
+      @Value("${spring.jackson.time-zone:UTC}") String timeZone) {
     return new ObjectMapper()
         .registerModule(new JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .setTimeZone(TimeZone.getTimeZone(timeZone));
   }
 
   @Bean


### PR DESCRIPTION
## Summary

Resolve timezone ambiguity in `TransferProcessStatus.createdAt` / `finishedAt`, and let operators pick the display zone via the `TZ` environment variable.

**Storage:** `Instant` (UTC, zone-agnostic) — no more silent dependence on JVM default `TZ`. Cross-agent comparisons and `processTtl` cleanup are now correct across DST and zone changes.

**Display:** `@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")` on both timestamp fields. Output carries an explicit offset (e.g. `2024-12-16T10:29:37.186+01:00`), unambiguous regardless of consumer locale.

**Configurable zone:** `TZ` environment variable (default `Europe/Berlin`). All three agent `src/main/resources/application.yaml` files bind `spring.jackson.time-zone: ${TZ:-Europe/Berlin}`. `AgentConfiguration.defaultObjectMapper` reads the resolved value and calls `.setTimeZone(...)` so the manually-built `ObjectMapper` honors it. The Spring property is intentionally not surfaced in the bundled (commented) `application.yaml` examples — operators configure via `TZ`, internals stay hidden.

## Changes

- `clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessStatus.java` — `LocalDateTime` → `Instant`; `@JsonFormat` on both timestamps.
- `clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java` — `Instant.now().minus(processTtl)`.
- `util/src/main/java/care/smith/fts/util/AgentConfiguration.java` — primary `ObjectMapper` reads `spring.jackson.time-zone`.
- `{clinical,research,trust-center}-domain-agent/src/main/resources/application.yaml` — `spring.jackson.time-zone: ${TZ:-Europe/Berlin}`.
- `clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/TransferProcessController.java` — OpenAPI examples reflect offset format.
- `docs/configuration/time-zone.md` (new) — operator-facing `TZ` doc, wired into `docs/agent.md` and `docs/.vitepress/config.mts` sidebar.
- `docs/usage/execution.md` — example + field descriptions updated, link to new Time Zone page.
- Tests pinned to `Europe/Berlin` via `@TestPropertySource` for deterministic offset assertions.

## Tradeoff

Precision drops from nanoseconds to milliseconds (`SSS` in the pattern). Old: `.818008066`. New: `.818`. Acceptable for ops display; switch to `SSSSSSSSS` if sub-ms log correlation is needed.

Closes #1656