### PR TITLE
Add Self-Assessment Endpoint

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/SelfAssessmentController.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/rest/SelfAssessmentController.java
@@ -1,0 +1,32 @@
+package care.smith.fts.cda.rest;
+
+import care.smith.fts.cda.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("api/v2")
+public class SelfAssessmentController {
+
+  private final SelfAssessmentService service;
+
+  public SelfAssessmentController(SelfAssessmentService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/self-assessment")
+  @Operation(
+      summary = "Agent self-assessment",
+      description =
+          "Reports configuration validity per loaded project and live reachability of every "
+              + "configured downstream service. Always returns 200 with status inside the body.",
+      responses = {@ApiResponse(responseCode = "200", description = "Self-assessment report")})
+  public Mono<SelfAssessmentReport> get() {
+    return service.assess();
+  }
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/selfassessment/SelfAssessmentService.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/selfassessment/SelfAssessmentService.java
@@ -1,0 +1,90 @@
+package care.smith.fts.cda.selfassessment;
+
+import static care.smith.fts.util.selfassessment.Probes.DEFAULT_TIMEOUT;
+import static care.smith.fts.util.selfassessment.Probes.probeReachable;
+import static java.util.Objects.requireNonNullElse;
+
+import care.smith.fts.cda.TransferProcessConfig;
+import care.smith.fts.cda.TransferProcessDefinition;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.selfassessment.ComponentStatus;
+import care.smith.fts.util.selfassessment.DownstreamExtractor;
+import care.smith.fts.util.selfassessment.ProjectStatus;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.StatusAggregator;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SelfAssessmentService {
+
+  private static final String AGENT = "clinical-domain-agent";
+
+  private final List<TransferProcessDefinition> projects;
+  private final WebClientFactory webClientFactory;
+  private final Duration timeout;
+  private final int concurrency;
+
+  public SelfAssessmentService(
+      List<TransferProcessDefinition> projects,
+      WebClientFactory webClientFactory,
+      @Value("${selfassessment.timeout:PT3S}") Duration timeout,
+      @Value("${selfassessment.concurrency:8}") int concurrency) {
+    this.projects = projects;
+    this.webClientFactory = webClientFactory;
+    this.timeout = requireNonNullElse(timeout, DEFAULT_TIMEOUT);
+    this.concurrency = concurrency;
+  }
+
+  public Mono<SelfAssessmentReport> assess() {
+    return Flux.fromIterable(projects)
+        .flatMap(this::assessProject, concurrency)
+        .collectList()
+        .map(
+            list ->
+                new SelfAssessmentReport(
+                    AGENT,
+                    StatusAggregator.worstOf(list.stream().map(ProjectStatus::status)),
+                    List.of(),
+                    list));
+  }
+
+  private Mono<ProjectStatus> assessProject(TransferProcessDefinition def) {
+    var downstreams = DownstreamExtractor.extract(toMap(def.rawConfig()));
+    if (downstreams.isEmpty()) {
+      return Mono.just(
+          new ProjectStatus(
+              def.project(), true, care.smith.fts.util.selfassessment.Status.UP, List.of()));
+    }
+    return Flux.fromIterable(downstreams)
+        .flatMap(d -> probeDownstream(d.label(), d.baseUrl()), concurrency)
+        .collectList()
+        .map(
+            comps ->
+                new ProjectStatus(
+                    def.project(),
+                    true,
+                    StatusAggregator.worstOf(comps.stream().map(ComponentStatus::status)),
+                    comps));
+  }
+
+  private Mono<ComponentStatus> probeDownstream(String label, String baseUrl) {
+    var client = webClientFactory.create(new HttpClientConfig(baseUrl));
+    return probeReachable(client, label, "http", baseUrl, timeout);
+  }
+
+  private static java.util.Map<String, Object> toMap(TransferProcessConfig c) {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("cohortSelector", c.cohortSelector());
+    m.put("dataSelector", c.dataSelector());
+    m.put("deidentificator", c.deidentificator());
+    m.put("bundleSender", c.bundleSender());
+    return m;
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/SelfAssessmentControllerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/SelfAssessmentControllerTest.java
@@ -1,0 +1,30 @@
+package care.smith.fts.cda.rest;
+
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.cda.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.Status;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class SelfAssessmentControllerTest {
+
+  @Mock SelfAssessmentService service;
+
+  @Test
+  void getReturnsServiceReport() {
+    var report = new SelfAssessmentReport("clinical-domain-agent", Status.UP, List.of(), List.of());
+    when(service.assess()).thenReturn(Mono.just(report));
+
+    var controller = new SelfAssessmentController(service);
+
+    StepVerifier.create(controller.get()).expectNext(report).verifyComplete();
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/selfassessment/SelfAssessmentServiceTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/selfassessment/SelfAssessmentServiceTest.java
@@ -1,0 +1,108 @@
+package care.smith.fts.cda.selfassessment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.api.cda.BundleSender;
+import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.api.cda.DataSelector;
+import care.smith.fts.api.cda.Deidentificator;
+import care.smith.fts.cda.TransferProcessConfig;
+import care.smith.fts.cda.TransferProcessDefinition;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.selfassessment.Status;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+class SelfAssessmentServiceTest {
+
+  @RegisterExtension static WireMockExtension downstream = WireMockExtension.newInstance().build();
+
+  private static WebClientFactory factoryReturning(String url) {
+    var factory = mock(WebClientFactory.class);
+    when(factory.create(any(HttpClientConfig.class)))
+        .thenReturn(WebClient.builder().baseUrl(url).build());
+    return factory;
+  }
+
+  private static TransferProcessDefinition def(String name, Map<String, ?> bundleSender) {
+    return new TransferProcessDefinition(
+        name,
+        new TransferProcessConfig(Map.of(), Map.of(), Map.of(), bundleSender),
+        mock(CohortSelector.class),
+        mock(DataSelector.class),
+        mock(Deidentificator.class),
+        mock(BundleSender.class));
+  }
+
+  @Test
+  void singleProject_allDownstreamsUp() {
+    downstream.stubFor(get(urlPathMatching("/.*")).willReturn(aResponse().withStatus(200)));
+    var url = downstream.getRuntimeInfo().getHttpBaseUrl();
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("p1", Map.of("rda", Map.of("server", Map.of("baseUrl", url))))),
+            factoryReturning(url),
+            Duration.ofSeconds(5),
+            4);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.agent()).isEqualTo("clinical-domain-agent");
+              assertThat(r.overall()).isEqualTo(Status.UP);
+              assertThat(r.projects()).hasSize(1);
+              assertThat(r.projects().get(0).downstream()).hasSize(1);
+              assertThat(r.projects().get(0).downstream().get(0).status()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void projectWithoutDownstreams_projectUp() {
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("empty", Map.of())),
+            mock(WebClientFactory.class),
+            Duration.ofSeconds(5),
+            4);
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.projects()).hasSize(1);
+              assertThat(r.projects().get(0).downstream()).isEmpty();
+              assertThat(r.projects().get(0).status()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void downstreamConnectionRefused_projectDown() {
+    var deadUrl = "http://localhost:1";
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("p1", Map.of("rda", Map.of("server", Map.of("baseUrl", deadUrl))))),
+            factoryReturning(deadUrl),
+            Duration.ofMillis(800),
+            4);
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.overall()).isEqualTo(Status.DOWN);
+              assertThat(r.projects().get(0).status()).isEqualTo(Status.DOWN);
+            })
+        .verifyComplete();
+  }
+}

--- a/docs/details/self-assessment.md
+++ b/docs/details/self-assessment.md
@@ -1,0 +1,80 @@
+# Self-Assessment Endpoint
+
+Each agent exposes `GET /api/v2/self-assessment` to help operators verify a deployment is
+properly configured and that every external dependency is reachable. The endpoint is independent
+from `/actuator/health` so that deep probing never affects liveness/readiness signals consumed by
+Kubernetes.
+
+## Response shape
+
+The endpoint always returns HTTP 200 with the status inside the body:
+
+```json
+{
+  "agent": "trust-center-agent",
+  "overall": "DEGRADED",
+  "components": [
+    { "name": "gpas",     "kind": "fhir",   "url": "http://gpas:8080/...",   "status": "UP",      "latencyMs": 42 },
+    { "name": "gics",     "kind": "fhir",   "url": "http://gics:8080/...",   "status": "DOWN",    "reason": "connection refused" },
+    { "name": "redis",    "kind": "redis",  "url": "redis://keystore:6379",  "status": "UP",      "latencyMs": 3 },
+    { "name": "keycloak", "kind": "oauth2", "status": "SKIPPED",             "reason": "not configured" }
+  ],
+  "projects": []
+}
+```
+
+CDA and RDA additionally fill `projects[]`. Each entry lists every downstream URL discovered in
+the project YAML and the result of a TCP/HTTP reachability probe against it:
+
+```json
+"projects": [
+  {
+    "name": "example",
+    "valid": true,
+    "status": "UP",
+    "downstream": [
+      { "name": "deidentificator.idMapper.trustCenterAgent.server", "kind": "http", "url": "http://tc-agent:8080", "status": "UP", "latencyMs": 17 },
+      { "name": "bundleSender.fhirStore.server",                    "kind": "http", "url": "http://store:8080",    "status": "UP", "latencyMs": 21 }
+    ]
+  }
+]
+```
+
+`overall` rolls up component and project status: `DOWN` > `DEGRADED` > `UP`. `SKIPPED` never
+lowers the rollup.
+
+## Configuration
+
+| Property                    | Default | Effect                                 |
+|-----------------------------|---------|----------------------------------------|
+| `selfassessment.timeout`    | `PT3S`  | Per-probe timeout (ISO-8601 duration). |
+| `selfassessment.concurrency`| `8`     | Parallel probes per assessment call.   |
+
+## Probes
+
+* **TCA** probes its fixed dependencies — gPAS (FHIR `/metadata` capability + required ops), gICS
+  (capability + required ops, SKIPPED when not configured), Redis (Redisson bucket lookup), and
+  Keycloak (`/.well-known/openid-configuration` on the configured `issuer-uri`, SKIPPED otherwise).
+* **CDA / RDA** walk every loaded project's configuration, extract each `baseUrl`, and run a
+  host-reachability probe. Any HTTP response (including 4xx from auth-protected endpoints) counts
+  as reachable; only connect failures and timeouts produce `DOWN`.
+
+## Authentication
+
+The endpoint inherits the agent's global authentication configuration — the same gate that
+already protects `/api/v2/projects`. With `auth=none` the endpoint is publicly readable, which
+matches the exposure level of `/api/v2/projects`.
+
+## Sample usage
+
+```sh
+curl -sS http://localhost:8080/api/v2/self-assessment | jq .
+curl -sS -u user:pass http://localhost:8081/api/v2/self-assessment | jq .
+```
+
+Negative path:
+
+```sh
+docker stop gpas
+curl -sS http://localhost:8080/api/v2/self-assessment | jq '.overall, .components[] | select(.name=="gpas")'
+```

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/rest/SelfAssessmentController.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/rest/SelfAssessmentController.java
@@ -1,0 +1,32 @@
+package care.smith.fts.rda.rest;
+
+import care.smith.fts.rda.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("api/v2")
+public class SelfAssessmentController {
+
+  private final SelfAssessmentService service;
+
+  public SelfAssessmentController(SelfAssessmentService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/self-assessment")
+  @Operation(
+      summary = "Agent self-assessment",
+      description =
+          "Reports configuration validity per loaded project and live reachability of every "
+              + "configured downstream service. Always returns 200 with status inside the body.",
+      responses = {@ApiResponse(responseCode = "200", description = "Self-assessment report")})
+  public Mono<SelfAssessmentReport> get() {
+    return service.assess();
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/selfassessment/SelfAssessmentService.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/selfassessment/SelfAssessmentService.java
@@ -1,0 +1,88 @@
+package care.smith.fts.rda.selfassessment;
+
+import static care.smith.fts.util.selfassessment.Probes.DEFAULT_TIMEOUT;
+import static care.smith.fts.util.selfassessment.Probes.probeReachable;
+import static java.util.Objects.requireNonNullElse;
+
+import care.smith.fts.rda.TransferProcessConfig;
+import care.smith.fts.rda.TransferProcessDefinition;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.selfassessment.ComponentStatus;
+import care.smith.fts.util.selfassessment.DownstreamExtractor;
+import care.smith.fts.util.selfassessment.ProjectStatus;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.StatusAggregator;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SelfAssessmentService {
+
+  private static final String AGENT = "research-domain-agent";
+
+  private final List<TransferProcessDefinition> projects;
+  private final WebClientFactory webClientFactory;
+  private final Duration timeout;
+  private final int concurrency;
+
+  public SelfAssessmentService(
+      List<TransferProcessDefinition> projects,
+      WebClientFactory webClientFactory,
+      @Value("${selfassessment.timeout:PT3S}") Duration timeout,
+      @Value("${selfassessment.concurrency:8}") int concurrency) {
+    this.projects = projects;
+    this.webClientFactory = webClientFactory;
+    this.timeout = requireNonNullElse(timeout, DEFAULT_TIMEOUT);
+    this.concurrency = concurrency;
+  }
+
+  public Mono<SelfAssessmentReport> assess() {
+    return Flux.fromIterable(projects)
+        .flatMap(this::assessProject, concurrency)
+        .collectList()
+        .map(
+            list ->
+                new SelfAssessmentReport(
+                    AGENT,
+                    StatusAggregator.worstOf(list.stream().map(ProjectStatus::status)),
+                    List.of(),
+                    list));
+  }
+
+  private Mono<ProjectStatus> assessProject(TransferProcessDefinition def) {
+    var downstreams = DownstreamExtractor.extract(toMap(def.rawConfig()));
+    if (downstreams.isEmpty()) {
+      return Mono.just(
+          new ProjectStatus(
+              def.project(), true, care.smith.fts.util.selfassessment.Status.UP, List.of()));
+    }
+    return Flux.fromIterable(downstreams)
+        .flatMap(d -> probeDownstream(d.label(), d.baseUrl()), concurrency)
+        .collectList()
+        .map(
+            comps ->
+                new ProjectStatus(
+                    def.project(),
+                    true,
+                    StatusAggregator.worstOf(comps.stream().map(ComponentStatus::status)),
+                    comps));
+  }
+
+  private Mono<ComponentStatus> probeDownstream(String label, String baseUrl) {
+    var client = webClientFactory.create(new HttpClientConfig(baseUrl));
+    return probeReachable(client, label, "http", baseUrl, timeout);
+  }
+
+  private static java.util.Map<String, Object> toMap(TransferProcessConfig c) {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("deidentificator", c.deidentificator());
+    m.put("bundleSender", c.bundleSender());
+    return m;
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/rest/SelfAssessmentControllerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/rest/SelfAssessmentControllerTest.java
@@ -1,0 +1,30 @@
+package care.smith.fts.rda.rest;
+
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.rda.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.Status;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class SelfAssessmentControllerTest {
+
+  @Mock SelfAssessmentService service;
+
+  @Test
+  void getReturnsServiceReport() {
+    var report = new SelfAssessmentReport("research-domain-agent", Status.UP, List.of(), List.of());
+    when(service.assess()).thenReturn(Mono.just(report));
+
+    var controller = new SelfAssessmentController(service);
+
+    StepVerifier.create(controller.get()).expectNext(report).verifyComplete();
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/selfassessment/SelfAssessmentServiceTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/selfassessment/SelfAssessmentServiceTest.java
@@ -1,0 +1,109 @@
+package care.smith.fts.rda.selfassessment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.api.rda.BundleSender;
+import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.rda.TransferProcessConfig;
+import care.smith.fts.rda.TransferProcessDefinition;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.selfassessment.Status;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+class SelfAssessmentServiceTest {
+
+  @RegisterExtension static WireMockExtension downstream = WireMockExtension.newInstance().build();
+
+  private static WebClientFactory factoryReturning(String url) {
+    var factory = mock(WebClientFactory.class);
+    when(factory.create(any(HttpClientConfig.class)))
+        .thenReturn(WebClient.builder().baseUrl(url).build());
+    return factory;
+  }
+
+  private static TransferProcessDefinition def(String name, Map<String, ?> bundleSender) {
+    return new TransferProcessDefinition(
+        name,
+        new TransferProcessConfig(Map.of(), bundleSender),
+        mock(Deidentificator.class),
+        mock(BundleSender.class));
+  }
+
+  @Test
+  void allDownstreamsUp() {
+    downstream.stubFor(get(urlPathMatching("/.*")).willReturn(aResponse().withStatus(200)));
+    var url = downstream.getRuntimeInfo().getHttpBaseUrl();
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("p1", Map.of("fhirStore", Map.of("server", Map.of("baseUrl", url))))),
+            factoryReturning(url),
+            Duration.ofSeconds(5),
+            4);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.agent()).isEqualTo("research-domain-agent");
+              assertThat(r.overall()).isEqualTo(Status.UP);
+              assertThat(r.projects()).hasSize(1);
+              assertThat(r.projects().get(0).downstream().get(0).status()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void downstreamDown_overallDown() {
+    var deadUrl = "http://localhost:1";
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("p1", Map.of("fhirStore", Map.of("server", Map.of("baseUrl", deadUrl))))),
+            factoryReturning(deadUrl),
+            Duration.ofMillis(800),
+            4);
+    StepVerifier.create(svc.assess())
+        .assertNext(r -> assertThat(r.overall()).isEqualTo(Status.DOWN))
+        .verifyComplete();
+  }
+
+  @Test
+  void projectWithoutDownstreams_projectUp() {
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("empty", Map.of())),
+            mock(WebClientFactory.class),
+            Duration.ofSeconds(5),
+            4);
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.projects()).hasSize(1);
+              assertThat(r.projects().get(0).downstream()).isEmpty();
+              assertThat(r.projects().get(0).status()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void nullTimeoutFallsBackToDefault() {
+    var svc =
+        new SelfAssessmentService(
+            List.of(def("empty", Map.of())), mock(WebClientFactory.class), null, 4);
+    StepVerifier.create(svc.assess())
+        .assertNext(r -> assertThat(r.overall()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/rest/SelfAssessmentController.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/rest/SelfAssessmentController.java
@@ -1,0 +1,33 @@
+package care.smith.fts.tca.rest;
+
+import care.smith.fts.tca.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("api/v2")
+public class SelfAssessmentController {
+
+  private final SelfAssessmentService service;
+
+  public SelfAssessmentController(SelfAssessmentService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/self-assessment")
+  @Operation(
+      summary = "Agent self-assessment",
+      description =
+          "Reports configuration validity and live reachability of every external dependency "
+              + "configured for this agent. Always returns 200 with status inside the body so "
+              + "callers can branch on the response shape.",
+      responses = {@ApiResponse(responseCode = "200", description = "Self-assessment report")})
+  public Mono<SelfAssessmentReport> get() {
+    return service.assess();
+  }
+}

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/selfassessment/SelfAssessmentService.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/selfassessment/SelfAssessmentService.java
@@ -1,0 +1,127 @@
+package care.smith.fts.tca.selfassessment;
+
+import static care.smith.fts.util.selfassessment.Probes.DEFAULT_TIMEOUT;
+import static care.smith.fts.util.selfassessment.Probes.probeFhirCapability;
+import static care.smith.fts.util.selfassessment.Probes.probeGet;
+import static java.util.Objects.requireNonNullElse;
+
+import care.smith.fts.tca.consent.GicsFhirUtil;
+import care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.selfassessment.ComponentStatus;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.Status;
+import care.smith.fts.util.selfassessment.StatusAggregator;
+import jakarta.annotation.Nullable;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SelfAssessmentService {
+
+  private static final String AGENT = "trust-center-agent";
+
+  private final WebClient gpasClient;
+  private final String gpasBaseUrl;
+  private final @Nullable WebClient gicsClient;
+  private final String gicsBaseUrl;
+  private final RedissonClient redisClient;
+  private final String keystoreUrl;
+  private final String oauth2IssuerUri;
+  private final WebClientFactory webClientFactory;
+  private final Duration timeout;
+
+  public SelfAssessmentService(
+      @Qualifier("gpasFhirHttpClient") WebClient gpasClient,
+      GpasDeIdentificationConfiguration gpasCfg,
+      @Nullable @Qualifier("gicsFhirHttpClient") WebClient gicsClient,
+      @Value("${consent.gics.fhir.baseUrl:}") String gicsBaseUrl,
+      RedissonClient redisClient,
+      @Value("${de-identification.keystoreUrl:}") String keystoreUrl,
+      @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}") String oauth2IssuerUri,
+      WebClientFactory webClientFactory,
+      @Value("${selfassessment.timeout:PT3S}") Duration timeout) {
+    this.gpasClient = gpasClient;
+    this.gpasBaseUrl = gpasCfg.getFhir().baseUrl();
+    this.gicsClient = gicsClient;
+    this.gicsBaseUrl = gicsBaseUrl;
+    this.redisClient = redisClient;
+    this.keystoreUrl = keystoreUrl;
+    this.oauth2IssuerUri = oauth2IssuerUri;
+    this.webClientFactory = webClientFactory;
+    this.timeout = requireNonNullElse(timeout, DEFAULT_TIMEOUT);
+  }
+
+  public Mono<SelfAssessmentReport> assess() {
+    return Mono.zip(probeGpas(), probeGics(), probeRedis(), probeOauth2())
+        .map(
+            t -> {
+              var components = List.of(t.getT1(), t.getT2(), t.getT3(), t.getT4());
+              var overall =
+                  StatusAggregator.worstOf(components.stream().map(ComponentStatus::status));
+              return new SelfAssessmentReport(AGENT, overall, components, List.of());
+            });
+  }
+
+  private Mono<ComponentStatus> probeGpas() {
+    return probeFhirCapability(
+        gpasClient,
+        "gpas",
+        gpasBaseUrl,
+        timeout,
+        GpasDeIdentificationConfiguration.GPAS_OPERATIONS);
+  }
+
+  private Mono<ComponentStatus> probeGics() {
+    if (gicsClient == null) {
+      return Mono.just(ComponentStatus.skipped("gics", "fhir", "not configured"));
+    }
+    return probeFhirCapability(
+        gicsClient, "gics", gicsBaseUrl, timeout, GicsFhirUtil.GICS_OPERATIONS);
+  }
+
+  private Mono<ComponentStatus> probeRedis() {
+    long start = System.nanoTime();
+    return redisClient
+        .reactive()
+        .getBucket("__selfassessment_probe__")
+        .isExists()
+        .map(
+            ignored ->
+                ComponentStatus.up(
+                    "redis", "redis", keystoreUrl, (System.nanoTime() - start) / 1_000_000L))
+        .timeout(timeout)
+        .onErrorResume(
+            e -> Mono.just(ComponentStatus.down("redis", "redis", keystoreUrl, errorReason(e))));
+  }
+
+  private Mono<ComponentStatus> probeOauth2() {
+    if (oauth2IssuerUri == null || oauth2IssuerUri.isBlank()) {
+      return Mono.just(ComponentStatus.skipped("keycloak", "oauth2", "not configured"));
+    }
+    var client = webClientFactory.create(new HttpClientConfig(oauth2IssuerUri));
+    return probeGet(
+        client,
+        "/.well-known/openid-configuration",
+        "keycloak",
+        "oauth2",
+        oauth2IssuerUri,
+        timeout);
+  }
+
+  private static String errorReason(Throwable e) {
+    return Objects.toString(e.getMessage(), e.getClass().getSimpleName());
+  }
+
+  Status overallStatus(List<ComponentStatus> components) {
+    return StatusAggregator.worstOf(components.stream().map(ComponentStatus::status));
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/rest/SelfAssessmentControllerTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/rest/SelfAssessmentControllerTest.java
@@ -1,0 +1,30 @@
+package care.smith.fts.tca.rest;
+
+import static org.mockito.Mockito.when;
+
+import care.smith.fts.tca.selfassessment.SelfAssessmentService;
+import care.smith.fts.util.selfassessment.SelfAssessmentReport;
+import care.smith.fts.util.selfassessment.Status;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class SelfAssessmentControllerTest {
+
+  @Mock SelfAssessmentService service;
+
+  @Test
+  void getReturnsServiceReport() {
+    var report = new SelfAssessmentReport("trust-center-agent", Status.UP, List.of(), List.of());
+    when(service.assess()).thenReturn(Mono.just(report));
+
+    var controller = new SelfAssessmentController(service);
+
+    StepVerifier.create(controller.get()).expectNext(report).verifyComplete();
+  }
+}

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/selfassessment/SelfAssessmentServiceTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/selfassessment/SelfAssessmentServiceTest.java
@@ -1,0 +1,341 @@
+package care.smith.fts.tca.selfassessment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import care.smith.fts.util.fhir.FhirDecoder;
+import care.smith.fts.util.fhir.FhirEncoder;
+import care.smith.fts.util.selfassessment.Status;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.redisson.api.RedissonClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class SelfAssessmentServiceTest {
+
+  private static final FhirContext FHIR = FhirContext.forR4();
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  private static final String GPAS_CAPABILITY_OK =
+      """
+      {"resourceType":"CapabilityStatement",
+       "rest":[{"operation":[{"name":"pseudonymizeAllowCreate"}]}]}
+      """;
+  private static final String GICS_CAPABILITY_OK =
+      """
+      {"resourceType":"CapabilityStatement",
+       "rest":[{"operation":[
+         {"name":"allConsentsForDomain"},
+         {"name":"allConsentsForPerson"}]}]}
+      """;
+
+  @RegisterExtension static WireMockExtension gpas = WireMockExtension.newInstance().build();
+  @RegisterExtension static WireMockExtension gics = WireMockExtension.newInstance().build();
+  @RegisterExtension static WireMockExtension oauth = WireMockExtension.newInstance().build();
+
+  private static WebClient fhirClient(String baseUrl) {
+    return WebClient.builder()
+        .baseUrl(baseUrl)
+        .codecs(c -> c.customCodecs().register(new FhirDecoder(FHIR)))
+        .codecs(c -> c.customCodecs().register(new FhirEncoder(FHIR)))
+        .build();
+  }
+
+  private static GpasDeIdentificationConfiguration gpasConfig() {
+    var cfg = new GpasDeIdentificationConfiguration();
+    cfg.setFhir(new HttpClientConfig("http://gpas:8080"));
+    return cfg;
+  }
+
+  private static RedissonClient redisUp() {
+    var rc = mock(RedissonClient.class, RETURNS_DEEP_STUBS);
+    when(rc.reactive().getBucket("__selfassessment_probe__").isExists())
+        .thenReturn(Mono.just(false));
+    return rc;
+  }
+
+  private static RedissonClient redisDown() {
+    var rc = mock(RedissonClient.class, RETURNS_DEEP_STUBS);
+    when(rc.reactive().getBucket("__selfassessment_probe__").isExists())
+        .thenReturn(Mono.error(new RuntimeException("connection refused")));
+    return rc;
+  }
+
+  @Test
+  void allUp_whenGpasGicsRedisOauthAllReachable() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    gics.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GICS_CAPABILITY_OK)));
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            fhirClient(gics.getRuntimeInfo().getHttpBaseUrl()),
+            gics.getRuntimeInfo().getHttpBaseUrl(),
+            redisUp(),
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.agent()).isEqualTo("trust-center-agent");
+              assertThat(r.overall()).isEqualTo(Status.UP);
+              assertThat(r.components()).hasSize(4);
+              assertThat(r.components())
+                  .extracting("name")
+                  .containsExactly("gpas", "gics", "redis", "keycloak");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void overallDown_whenGpasDown() {
+    gpas.stubFor(get(urlPathEqualTo("/metadata")).willReturn(aResponse().withStatus(500)));
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisUp(),
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.overall()).isEqualTo(Status.DOWN);
+              assertThat(r.components().get(0).status()).isEqualTo(Status.DOWN);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void gicsSkipped_whenClientNull() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisUp(),
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              var gicsComp =
+                  r.components().stream()
+                      .filter(c -> "gics".equals(c.name()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(gicsComp.status()).isEqualTo(Status.SKIPPED);
+              assertThat(r.overall()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void oauth2ConfiguredAndReachable_keycloakUp() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    oauth.stubFor(
+        get(urlPathEqualTo("/.well-known/openid-configuration"))
+            .willReturn(aResponse().withStatus(200)));
+    var oauthUrl = oauth.getRuntimeInfo().getHttpBaseUrl();
+    var factory = mock(WebClientFactory.class);
+    when(factory.create(any(HttpClientConfig.class)))
+        .thenReturn(WebClient.builder().baseUrl(oauthUrl).build());
+
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisUp(),
+            "redis://keystore:6379",
+            oauthUrl,
+            factory,
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              var keycloak =
+                  r.components().stream()
+                      .filter(c -> "keycloak".equals(c.name()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(keycloak.status()).isEqualTo(Status.UP);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void oauth2IssuerNull_keycloakSkipped() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisUp(),
+            "redis://keystore:6379",
+            null,
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              var keycloak =
+                  r.components().stream()
+                      .filter(c -> "keycloak".equals(c.name()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(keycloak.status()).isEqualTo(Status.SKIPPED);
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void redisErrorWithoutMessage_reasonFallsBackToClassName() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    var rc = mock(RedissonClient.class, RETURNS_DEEP_STUBS);
+    when(rc.reactive().getBucket("__selfassessment_probe__").isExists())
+        .thenReturn(Mono.error(new RuntimeException()));
+
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            rc,
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              var redis =
+                  r.components().stream()
+                      .filter(c -> "redis".equals(c.name()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(redis.status()).isEqualTo(Status.DOWN);
+              assertThat(redis.reason()).isEqualTo("RuntimeException");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void overallStatusHelperDelegatesToAggregator() {
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisUp(),
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+    var components =
+        java.util.List.of(
+            care.smith.fts.util.selfassessment.ComponentStatus.up("a", "http", "http://a", 1L),
+            care.smith.fts.util.selfassessment.ComponentStatus.down("b", "http", "http://b", "x"));
+    assertThat(svc.overallStatus(components)).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  void redisDown_overallDown() {
+    gpas.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(GPAS_CAPABILITY_OK)));
+    var svc =
+        new SelfAssessmentService(
+            fhirClient(gpas.getRuntimeInfo().getHttpBaseUrl()),
+            gpasConfig(),
+            null,
+            "",
+            redisDown(),
+            "redis://keystore:6379",
+            "",
+            mock(WebClientFactory.class),
+            TIMEOUT);
+
+    StepVerifier.create(svc.assess())
+        .assertNext(
+            r -> {
+              assertThat(r.overall()).isEqualTo(Status.DOWN);
+              var redis =
+                  r.components().stream()
+                      .filter(c -> "redis".equals(c.name()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(redis.status()).isEqualTo(Status.DOWN);
+              assertThat(redis.reason()).contains("connection refused");
+            })
+        .verifyComplete();
+  }
+}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/ComponentStatus.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/ComponentStatus.java
@@ -1,0 +1,25 @@
+package care.smith.fts.util.selfassessment;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ComponentStatus(
+    String name, String kind, String url, Status status, Long latencyMs, String reason) {
+
+  public static ComponentStatus up(String name, String kind, String url, long latencyMs) {
+    return new ComponentStatus(name, kind, url, Status.UP, latencyMs, null);
+  }
+
+  public static ComponentStatus down(String name, String kind, String url, String reason) {
+    return new ComponentStatus(name, kind, url, Status.DOWN, null, reason);
+  }
+
+  public static ComponentStatus degraded(
+      String name, String kind, String url, long latencyMs, String reason) {
+    return new ComponentStatus(name, kind, url, Status.DEGRADED, latencyMs, reason);
+  }
+
+  public static ComponentStatus skipped(String name, String kind, String reason) {
+    return new ComponentStatus(name, kind, null, Status.SKIPPED, null, reason);
+  }
+}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/DownstreamExtractor.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/DownstreamExtractor.java
@@ -1,0 +1,38 @@
+package care.smith.fts.util.selfassessment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public interface DownstreamExtractor {
+
+  record Downstream(String label, String baseUrl) {}
+
+  String BASE_URL_KEY = "baseUrl";
+
+  static List<Downstream> extract(Map<String, ?> root) {
+    var out = new ArrayList<Downstream>();
+    walk("", root, out);
+    return List.copyOf(out);
+  }
+
+  private static void walk(String path, Object node, List<Downstream> out) {
+    if (node instanceof Map<?, ?> m) {
+      var url = m.get(BASE_URL_KEY);
+      if (url instanceof String s && !s.isBlank()) {
+        out.add(new Downstream(path.isEmpty() ? BASE_URL_KEY : path, s));
+      }
+      for (var e : m.entrySet()) {
+        var key = String.valueOf(e.getKey());
+        if (BASE_URL_KEY.equals(key)) {
+          continue;
+        }
+        walk(path.isEmpty() ? key : path + "." + key, e.getValue(), out);
+      }
+    } else if (node instanceof List<?> list) {
+      for (int i = 0; i < list.size(); i++) {
+        walk(path + "[" + i + "]", list.get(i), out);
+      }
+    }
+  }
+}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/Probes.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/Probes.java
@@ -1,0 +1,96 @@
+package care.smith.fts.util.selfassessment;
+
+import static care.smith.fts.util.fhir.FhirClientUtils.fetchCapabilityStatementOperations;
+import static care.smith.fts.util.fhir.FhirClientUtils.verifyOperationsExist;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+public interface Probes {
+
+  Duration DEFAULT_TIMEOUT = Duration.ofSeconds(3);
+
+  static Mono<ComponentStatus> probeFhirCapability(
+      WebClient client, String name, String url, Duration timeout, List<String> requiredOps) {
+    long start = System.nanoTime();
+    return fetchCapabilityStatementOperations(client)
+        .map(
+            cs -> {
+              long elapsed = elapsedMs(start);
+              if (requiredOps != null
+                  && !requiredOps.isEmpty()
+                  && !verifyOperationsExist(cs, requiredOps)) {
+                return ComponentStatus.degraded(
+                    name, "fhir", url, elapsed, "missing required operations: " + requiredOps);
+              }
+              return ComponentStatus.up(name, "fhir", url, elapsed);
+            })
+        .timeout(timeout)
+        .onErrorResume(e -> Mono.just(ComponentStatus.down(name, "fhir", url, reason(e))));
+  }
+
+  static Mono<ComponentStatus> probeActuatorHealth(
+      WebClient client, String name, String kind, String url, Duration timeout) {
+    long start = System.nanoTime();
+    return client
+        .get()
+        .uri("/actuator/health")
+        .retrieve()
+        .bodyToMono(ActuatorHealth.class)
+        .map(
+            h ->
+                "UP".equals(h.status())
+                    ? ComponentStatus.up(name, kind, url, elapsedMs(start))
+                    : ComponentStatus.degraded(
+                        name, kind, url, elapsedMs(start), "status=" + h.status()))
+        .timeout(timeout)
+        .onErrorResume(e -> Mono.just(ComponentStatus.down(name, kind, url, reason(e))));
+  }
+
+  static Mono<ComponentStatus> probeGet(
+      WebClient client, String path, String name, String kind, String url, Duration timeout) {
+    long start = System.nanoTime();
+    return client
+        .get()
+        .uri(path)
+        .retrieve()
+        .toBodilessEntity()
+        .map(e -> ComponentStatus.up(name, kind, url, elapsedMs(start)))
+        .timeout(timeout)
+        .onErrorResume(e -> Mono.just(ComponentStatus.down(name, kind, url, reason(e))));
+  }
+
+  /**
+   * Host-reachability probe: any HTTP response (including 4xx/5xx) counts as UP. Only connection
+   * failures and timeouts produce DOWN. Useful when probing endpoints behind auth where the probe
+   * itself isn't authenticated.
+   */
+  static Mono<ComponentStatus> probeReachable(
+      WebClient client, String name, String kind, String url, Duration timeout) {
+    long start = System.nanoTime();
+    return client
+        .get()
+        .exchangeToMono(
+            response ->
+                response
+                    .releaseBody()
+                    .thenReturn(ComponentStatus.up(name, kind, url, elapsedMs(start))))
+        .timeout(timeout)
+        .onErrorResume(e -> Mono.just(ComponentStatus.down(name, kind, url, reason(e))));
+  }
+
+  private static long elapsedMs(long startNs) {
+    return (System.nanoTime() - startNs) / 1_000_000L;
+  }
+
+  private static String reason(Throwable e) {
+    return Objects.toString(e.getMessage(), e.getClass().getSimpleName());
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ActuatorHealth(String status) {}
+}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/ProjectStatus.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/ProjectStatus.java
@@ -1,0 +1,6 @@
+package care.smith.fts.util.selfassessment;
+
+import java.util.List;
+
+public record ProjectStatus(
+    String name, boolean valid, Status status, List<ComponentStatus> downstream) {}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/SelfAssessmentReport.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/SelfAssessmentReport.java
@@ -1,0 +1,6 @@
+package care.smith.fts.util.selfassessment;
+
+import java.util.List;
+
+public record SelfAssessmentReport(
+    String agent, Status overall, List<ComponentStatus> components, List<ProjectStatus> projects) {}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/Status.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/Status.java
@@ -1,0 +1,8 @@
+package care.smith.fts.util.selfassessment;
+
+public enum Status {
+  UP,
+  DEGRADED,
+  DOWN,
+  SKIPPED
+}

--- a/util/src/main/java/care/smith/fts/util/selfassessment/StatusAggregator.java
+++ b/util/src/main/java/care/smith/fts/util/selfassessment/StatusAggregator.java
@@ -1,0 +1,23 @@
+package care.smith.fts.util.selfassessment;
+
+import java.util.stream.Stream;
+
+public interface StatusAggregator {
+
+  static Status worstOf(Stream<Status> statuses) {
+    return statuses.reduce(StatusAggregator::worse).orElse(Status.UP);
+  }
+
+  private static Status worse(Status a, Status b) {
+    return rank(a) >= rank(b) ? a : b;
+  }
+
+  private static int rank(Status s) {
+    return switch (s) {
+      case SKIPPED -> 0;
+      case UP -> 1;
+      case DEGRADED -> 2;
+      case DOWN -> 3;
+    };
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/ComponentStatusTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/ComponentStatusTest.java
@@ -1,0 +1,44 @@
+package care.smith.fts.util.selfassessment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ComponentStatusTest {
+
+  @Test
+  void upHasUpStatusAndLatencyAndNoReason() {
+    var c = ComponentStatus.up("gpas", "fhir", "http://gpas", 42L);
+    assertThat(c.status()).isEqualTo(Status.UP);
+    assertThat(c.latencyMs()).isEqualTo(42L);
+    assertThat(c.reason()).isNull();
+    assertThat(c.url()).isEqualTo("http://gpas");
+  }
+
+  @Test
+  void downHasDownStatusAndReasonAndNoLatency() {
+    var c = ComponentStatus.down("gpas", "fhir", "http://gpas", "refused");
+    assertThat(c.status()).isEqualTo(Status.DOWN);
+    assertThat(c.latencyMs()).isNull();
+    assertThat(c.reason()).isEqualTo("refused");
+  }
+
+  @Test
+  void degradedHasLatencyAndReason() {
+    var c = ComponentStatus.degraded("gpas", "fhir", "http://gpas", 12L, "missing ops");
+    assertThat(c.status()).isEqualTo(Status.DEGRADED);
+    assertThat(c.latencyMs()).isEqualTo(12L);
+    assertThat(c.reason()).isEqualTo("missing ops");
+  }
+
+  @Test
+  void skippedHasNullUrlAndNullLatencyAndReason() {
+    var c = ComponentStatus.skipped("gics", "fhir", "not configured");
+    assertThat(c.status()).isEqualTo(Status.SKIPPED);
+    assertThat(c.url()).isNull();
+    assertThat(c.latencyMs()).isNull();
+    assertThat(c.reason()).isEqualTo("not configured");
+    assertThat(c.name()).isEqualTo("gics");
+    assertThat(c.kind()).isEqualTo("fhir");
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/DownstreamExtractorTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/DownstreamExtractorTest.java
@@ -1,0 +1,66 @@
+package care.smith.fts.util.selfassessment;
+
+import static care.smith.fts.util.selfassessment.DownstreamExtractor.extract;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DownstreamExtractorTest {
+
+  @Test
+  void extractsTopLevelBaseUrl() {
+    var result = extract(Map.of("baseUrl", "http://x:1"));
+    assertThat(result)
+        .extracting("label", "baseUrl")
+        .containsExactly(tuple("baseUrl", "http://x:1"));
+  }
+
+  @Test
+  void extractsNestedBaseUrl() {
+    var root =
+        Map.of("deidentificator", Map.of("foo", Map.of("server", Map.of("baseUrl", "http://x:1"))));
+    var result = extract(root);
+    assertThat(result)
+        .extracting("label", "baseUrl")
+        .containsExactly(tuple("deidentificator.foo.server", "http://x:1"));
+  }
+
+  @Test
+  void extractsMultipleBaseUrls() {
+    var root =
+        Map.of(
+            "a", Map.of("baseUrl", "http://a"),
+            "b", Map.of("nested", Map.of("baseUrl", "http://b")));
+    var result = extract(root);
+    assertThat(result).extracting("baseUrl").containsExactlyInAnyOrder("http://a", "http://b");
+  }
+
+  @Test
+  void emptyMapReturnsEmpty() {
+    assertThat(extract(Map.of())).isEmpty();
+  }
+
+  @Test
+  void blankBaseUrlIgnored() {
+    var result = extract(Map.of("server", Map.of("baseUrl", "")));
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void walksInsideLists() {
+    var root =
+        Map.of("items", List.of(Map.of("baseUrl", "http://x"), Map.of("baseUrl", "http://y")));
+    var result = extract(root);
+    assertThat(result).extracting("baseUrl").containsExactlyInAnyOrder("http://x", "http://y");
+  }
+
+  @Test
+  void ignoresNonCollectionLeaves() {
+    var root = Map.of("count", 42, "server", Map.of("baseUrl", "http://x"));
+    var result = extract(root);
+    assertThat(result).extracting("baseUrl").containsExactly("http://x");
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/ProbesTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/ProbesTest.java
@@ -1,0 +1,287 @@
+package care.smith.fts.util.selfassessment;
+
+import static care.smith.fts.util.selfassessment.Probes.probeActuatorHealth;
+import static care.smith.fts.util.selfassessment.Probes.probeFhirCapability;
+import static care.smith.fts.util.selfassessment.Probes.probeGet;
+import static care.smith.fts.util.selfassessment.Probes.probeReachable;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ca.uhn.fhir.context.FhirContext;
+import care.smith.fts.util.fhir.FhirDecoder;
+import care.smith.fts.util.fhir.FhirEncoder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.test.StepVerifier;
+
+class ProbesTest {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private static final FhirContext FHIR = FhirContext.forR4();
+  private static final String FHIR_CAPABILITY_JSON =
+      """
+      {
+        "resourceType": "CapabilityStatement",
+        "rest": [
+          { "operation": [ { "name": "$op-required" }, { "name": "$op-extra" } ] }
+        ]
+      }
+      """;
+
+  @RegisterExtension static WireMockExtension wm = WireMockExtension.newInstance().build();
+
+  private static WebClient fhirClient(WireMockRuntimeInfo info) {
+    return WebClient.builder()
+        .baseUrl(info.getHttpBaseUrl())
+        .codecs(c -> c.customCodecs().register(new FhirDecoder(FHIR)))
+        .codecs(c -> c.customCodecs().register(new FhirEncoder(FHIR)))
+        .build();
+  }
+
+  private static WebClient jsonClient(WireMockRuntimeInfo info) {
+    return WebClient.builder().baseUrl(info.getHttpBaseUrl()).build();
+  }
+
+  @Test
+  void fhirCapabilityUpWhenAllOpsPresent() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(FHIR_CAPABILITY_JSON)));
+    StepVerifier.create(
+            probeFhirCapability(
+                fhirClient(wm.getRuntimeInfo()),
+                "gpas",
+                "http://x",
+                TIMEOUT,
+                List.of("$op-required")))
+        .assertNext(
+            s -> {
+              assertThat(s.name()).isEqualTo("gpas");
+              assertThat(s.kind()).isEqualTo("fhir");
+              assertThat(s.status()).isEqualTo(Status.UP);
+              assertThat(s.latencyMs()).isNotNull();
+              assertThat(s.reason()).isNull();
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void fhirCapabilityUpWhenNoOpsRequired() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(FHIR_CAPABILITY_JSON)));
+    StepVerifier.create(
+            probeFhirCapability(
+                fhirClient(wm.getRuntimeInfo()), "gics", "http://x", TIMEOUT, List.of()))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+
+  @Test
+  void fhirCapabilityUpWhenRequiredOpsNull() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(FHIR_CAPABILITY_JSON)));
+    StepVerifier.create(
+            probeFhirCapability(fhirClient(wm.getRuntimeInfo()), "gics", "http://x", TIMEOUT, null))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+
+  @Test
+  void fhirCapabilityDegradedWhenOpMissing() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(FHIR_CAPABILITY_JSON)));
+    StepVerifier.create(
+            probeFhirCapability(
+                fhirClient(wm.getRuntimeInfo()), "gpas", "http://x", TIMEOUT, List.of("$missing")))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.DEGRADED);
+              assertThat(s.reason()).contains("$missing");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void fhirCapabilityDownOn5xx() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata")).willReturn(aResponse().withStatus(500).withBody("boom")));
+    StepVerifier.create(
+            probeFhirCapability(
+                fhirClient(wm.getRuntimeInfo()), "gpas", "http://x", TIMEOUT, List.of()))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.DOWN);
+              assertThat(s.reason()).isNotEmpty();
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void fhirCapabilityDownOnTimeout() {
+    wm.stubFor(
+        get(urlPathEqualTo("/metadata"))
+            .willReturn(
+                aResponse()
+                    .withFixedDelay(500)
+                    .withHeader("Content-Type", "application/fhir+json")
+                    .withBody(FHIR_CAPABILITY_JSON)));
+    StepVerifier.create(
+            probeFhirCapability(
+                fhirClient(wm.getRuntimeInfo()),
+                "gpas",
+                "http://x",
+                Duration.ofMillis(50),
+                List.of()))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.DOWN))
+        .verifyComplete();
+  }
+
+  @Test
+  void actuatorHealthUp() {
+    wm.stubFor(
+        get(urlPathEqualTo("/actuator/health"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"status\":\"UP\"}")));
+    StepVerifier.create(
+            probeActuatorHealth(
+                jsonClient(wm.getRuntimeInfo()), "tca", "rd-agent", "http://x", TIMEOUT))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+
+  @Test
+  void actuatorHealthDegradedWhenStatusNotUp() {
+    wm.stubFor(
+        get(urlPathEqualTo("/actuator/health"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"status\":\"OUT_OF_SERVICE\"}")));
+    StepVerifier.create(
+            probeActuatorHealth(
+                jsonClient(wm.getRuntimeInfo()), "tca", "rd-agent", "http://x", TIMEOUT))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.DEGRADED);
+              assertThat(s.reason()).contains("OUT_OF_SERVICE");
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void actuatorHealthDownOnError() {
+    wm.stubFor(get(urlPathEqualTo("/actuator/health")).willReturn(aResponse().withStatus(500)));
+    StepVerifier.create(
+            probeActuatorHealth(
+                jsonClient(wm.getRuntimeInfo()), "tca", "rd-agent", "http://x", TIMEOUT))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.DOWN))
+        .verifyComplete();
+  }
+
+  @Test
+  void probeGetUpOn2xx() {
+    wm.stubFor(
+        get(urlPathEqualTo("/.well-known/openid-configuration"))
+            .willReturn(aResponse().withStatus(200)));
+    StepVerifier.create(
+            probeGet(
+                jsonClient(wm.getRuntimeInfo()),
+                "/.well-known/openid-configuration",
+                "keycloak",
+                "oauth2",
+                "http://x",
+                TIMEOUT))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+
+  @Test
+  void probeGetDownOnError() {
+    wm.stubFor(get(urlPathEqualTo("/x")).willReturn(aResponse().withStatus(500)));
+    StepVerifier.create(
+            probeGet(
+                jsonClient(wm.getRuntimeInfo()), "/x", "keycloak", "oauth2", "http://x", TIMEOUT))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.DOWN))
+        .verifyComplete();
+  }
+
+  @Test
+  void probeReachableUpOn2xx() {
+    wm.stubFor(get(urlPathEqualTo("/")).willReturn(aResponse().withStatus(200)));
+    StepVerifier.create(
+            probeReachable(
+                jsonClient(wm.getRuntimeInfo()), "downstream", "http", "http://x", TIMEOUT))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.UP);
+              assertThat(s.kind()).isEqualTo("http");
+              assertThat(s.latencyMs()).isNotNull();
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void probeReachableUpOn4xx() {
+    wm.stubFor(get(urlPathEqualTo("/")).willReturn(aResponse().withStatus(401)));
+    StepVerifier.create(
+            probeReachable(
+                jsonClient(wm.getRuntimeInfo()), "downstream", "http", "http://x", TIMEOUT))
+        .assertNext(s -> assertThat(s.status()).isEqualTo(Status.UP))
+        .verifyComplete();
+  }
+
+  @Test
+  void probeReachableDownOnConnectionRefused() {
+    var dead = WebClient.builder().baseUrl("http://localhost:1").build();
+    StepVerifier.create(probeReachable(dead, "downstream", "http", "http://x", TIMEOUT))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.DOWN);
+              assertThat(s.reason()).isNotEmpty();
+            })
+        .verifyComplete();
+  }
+
+  @Test
+  void probeReachableDownOnTimeoutFallsBackToClassName() {
+    wm.stubFor(
+        get(urlPathEqualTo("/")).willReturn(aResponse().withFixedDelay(500).withStatus(200)));
+    StepVerifier.create(
+            probeReachable(
+                jsonClient(wm.getRuntimeInfo()),
+                "downstream",
+                "http",
+                "http://x",
+                Duration.ofMillis(50)))
+        .assertNext(
+            s -> {
+              assertThat(s.status()).isEqualTo(Status.DOWN);
+              assertThat(s.reason()).isNotEmpty();
+            })
+        .verifyComplete();
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/ProjectStatusTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/ProjectStatusTest.java
@@ -1,0 +1,26 @@
+package care.smith.fts.util.selfassessment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProjectStatusTest {
+
+  @Test
+  void exposesConstructorComponents() {
+    var comp = ComponentStatus.up("c", "http", "http://x", 1L);
+    var ps = new ProjectStatus("project-1", true, Status.UP, List.of(comp));
+    assertThat(ps.name()).isEqualTo("project-1");
+    assertThat(ps.valid()).isTrue();
+    assertThat(ps.status()).isEqualTo(Status.UP);
+    assertThat(ps.downstream()).containsExactly(comp);
+  }
+
+  @Test
+  void supportsInvalidProject() {
+    var ps = new ProjectStatus("broken", false, Status.DOWN, List.of());
+    assertThat(ps.valid()).isFalse();
+    assertThat(ps.downstream()).isEmpty();
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/SelfAssessmentReportTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/SelfAssessmentReportTest.java
@@ -1,0 +1,20 @@
+package care.smith.fts.util.selfassessment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SelfAssessmentReportTest {
+
+  @Test
+  void exposesComponentsAndProjects() {
+    var comp = ComponentStatus.up("redis", "redis", "redis://x", 5L);
+    var proj = new ProjectStatus("p1", true, Status.UP, List.of());
+    var r = new SelfAssessmentReport("agent", Status.UP, List.of(comp), List.of(proj));
+    assertThat(r.agent()).isEqualTo("agent");
+    assertThat(r.overall()).isEqualTo(Status.UP);
+    assertThat(r.components()).containsExactly(comp);
+    assertThat(r.projects()).containsExactly(proj);
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/selfassessment/StatusAggregatorTest.java
+++ b/util/src/test/java/care/smith/fts/util/selfassessment/StatusAggregatorTest.java
@@ -1,0 +1,44 @@
+package care.smith.fts.util.selfassessment;
+
+import static care.smith.fts.util.selfassessment.Status.DEGRADED;
+import static care.smith.fts.util.selfassessment.Status.DOWN;
+import static care.smith.fts.util.selfassessment.Status.SKIPPED;
+import static care.smith.fts.util.selfassessment.Status.UP;
+import static care.smith.fts.util.selfassessment.StatusAggregator.worstOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class StatusAggregatorTest {
+
+  @Test
+  void emptyStreamIsUp() {
+    assertThat(worstOf(Stream.empty())).isEqualTo(UP);
+  }
+
+  @Test
+  void allUpIsUp() {
+    assertThat(worstOf(Stream.of(UP, UP))).isEqualTo(UP);
+  }
+
+  @Test
+  void upMixedWithSkippedIsUp() {
+    assertThat(worstOf(Stream.of(UP, SKIPPED))).isEqualTo(UP);
+  }
+
+  @Test
+  void anyDegradedWinsOverUp() {
+    assertThat(worstOf(Stream.of(UP, DEGRADED, SKIPPED))).isEqualTo(DEGRADED);
+  }
+
+  @Test
+  void anyDownWinsOverDegraded() {
+    assertThat(worstOf(Stream.of(UP, DEGRADED, DOWN))).isEqualTo(DOWN);
+  }
+
+  @Test
+  void allSkippedIsSkipped() {
+    assertThat(worstOf(Stream.of(SKIPPED, SKIPPED))).isEqualTo(SKIPPED);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/self-assessment` per agent that reports configuration validity and live reachability of every configured external dependency. Always 200, status in body, decoupled from `/actuator/health` so deep probing never affects Kubernetes liveness/readiness.
- TCA probes its fixed deps in parallel: gPAS (FHIR capability + `pseudonymizeAllowCreate`), gICS (capability + required ops, `SKIPPED` if not configured), Redis (Redisson bucket lookup), Keycloak (`/.well-known/openid-configuration` on `issuer-uri`, `SKIPPED` otherwise). CDA/RDA walk every loaded project, extract each `baseUrl` from the raw config via a recursive ``DownstreamExtractor``, and run host-reachability probes (any HTTP response = ``UP``; only connect failures / timeouts = ``DOWN``) so auth-protected endpoints don't require credentials to verify reachability.
- Shared response shape, ``Probes`` helpers, ``DownstreamExtractor`` and ``StatusAggregator`` live in ``util/selfassessment/``. Tunable via ``selfassessment.timeout`` (default ``PT3S``) and ``selfassessment.concurrency`` (default ``8``). Docs in ``docs/details/self-assessment.md``.

Closes #1667