### PR TITLE
Fix make start creating root-owned ssl/ directory

### DIFF
--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -21,7 +21,10 @@ generate-certs:
 	  | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out server-rd-agent.crt -days 30 && \
 	  chmod +r server-rd-agent.key)
 
-start:
+ssl/server.crt:
+	$(MAKE) generate-certs
+
+start: ssl/server.crt
 	docker compose ${COMPOSE_FILES} up --wait --pull missing ${SERVICES}
 
 download-test-data-checksums:


### PR DESCRIPTION
## Summary

- Add lazy file-target `ssl/server.crt` as prerequisite of `start` in `.github/test/Makefile`.
- `make start` now runs `generate-certs` automatically when certs are missing, avoiding the root-owned `ssl/` directory created by docker's bind-mount auto-creation.
- Idempotent: when `ssl/server.crt` already exists, no regeneration occurs, so `make all` chain (`pull generate-certs start ...`) does not double-run cert generation.

Closes #1675