### PR TITLE
Auto-detect expiring test certs before make start

### DIFF
--- a/.github/scripts/check-certs.sh
+++ b/.github/scripts/check-certs.sh
@@ -5,20 +5,42 @@ set -euo pipefail
 # CERT_TTL_SECONDS into the future. Exit 1 otherwise (cert missing or
 # expiring within the window).
 #
-# Usage: check-certs.sh <ssl-dir> [ttl-seconds]
+# Usage: check-certs.sh <ssl-dir> <ttl-seconds> --server <CN> [--server <CN> ...] --client <CN> [--client <CN> ...]
 
-SSL_DIR="${1:?usage: check-certs.sh <ssl-dir> [ttl-seconds]}"
-TTL="${2:-${CERT_TTL_SECONDS:-86400}}"
+SSL_DIR="${1:?usage: check-certs.sh <ssl-dir> <ttl-seconds> --server <CN> ... --client <CN> ...}"
+shift
+TTL="${1:?usage: check-certs.sh <ssl-dir> <ttl-seconds> --server <CN> ... --client <CN> ...}"
+shift
 
-CERTS=(
-  ca.crt
-  server.crt
-  server-rd-agent.crt
-  client-tca.crt
-  client-cd-agent.crt
-  client-rd-agent.crt
-  client-no-ca.crt
-)
+SERVERS=()
+CLIENTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server)
+      SERVERS+=("$2")
+      shift 2
+      ;;
+    --client)
+      CLIENTS+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Build the list of expected cert files
+CERTS=("ca.crt")
+for cn in "${SERVERS[@]}"; do
+  CERTS+=("server-${cn}.crt")
+done
+for cn in "${CLIENTS[@]}"; do
+  CERTS+=("client-${cn}.crt")
+done
+CERTS+=("client-no-ca.crt")
 
 for name in "${CERTS[@]}"; do
   path="$SSL_DIR/$name"

--- a/.github/scripts/check-certs.sh
+++ b/.github/scripts/check-certs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exit 0 if all expected test certs exist and are valid for at least
+# CERT_TTL_SECONDS into the future. Exit 1 otherwise (cert missing or
+# expiring within the window).
+#
+# Usage: check-certs.sh <ssl-dir> [ttl-seconds]
+
+SSL_DIR="${1:?usage: check-certs.sh <ssl-dir> [ttl-seconds]}"
+TTL="${2:-${CERT_TTL_SECONDS:-86400}}"
+
+CERTS=(
+  ca.crt
+  server.crt
+  server-rd-agent.crt
+  client-tca.crt
+  client-cd-agent.crt
+  client-rd-agent.crt
+  client-no-ca.crt
+)
+
+for name in "${CERTS[@]}"; do
+  path="$SSL_DIR/$name"
+  if [ ! -f "$path" ]; then
+    echo "Cert $path missing"
+    exit 1
+  fi
+  if ! openssl x509 -checkend "$TTL" -noout -in "$path" >/dev/null 2>&1; then
+    echo "Cert $path expiring within ${TTL}s"
+    exit 1
+  fi
+done

--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all pull generate-certs start upload-consents check-consent upload-test-data \
+.PHONY: all pull generate-certs check-certs start upload-consents check-consent upload-test-data \
 	transfer-all transfer-list transfer-with-fhir-consent-list wait  \
 	check-status check-resources check-pseudonymization show-status show-hds clean-dbs clean-rd-hds \
 	download-test-data download-test-data-checksums check-test-data \
@@ -8,6 +8,7 @@ all: pull generate-certs start upload-test-data transfer-all wait check-status c
 
 COMPOSE_FILES?=-f compose.yaml
 SERVICES?=
+CERT_TTL_SECONDS?=86400
 
 pull:
 	docker compose ${COMPOSE_FILES} pull -q --ignore-pull-failures ${SERVICES}
@@ -21,10 +22,10 @@ generate-certs:
 	  | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out server-rd-agent.crt -days 30 && \
 	  chmod +r server-rd-agent.key)
 
-ssl/server.crt:
-	$(MAKE) generate-certs
+check-certs:
+	@../scripts/check-certs.sh ./ssl $(CERT_TTL_SECONDS) || $(MAKE) generate-certs
 
-start: ssl/server.crt
+start: check-certs
 	docker compose ${COMPOSE_FILES} up --wait --pull missing ${SERVICES}
 
 download-test-data-checksums:

--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -10,77 +10,77 @@ COMPOSE_FILES?=-f compose.yaml
 SERVICES?=
 CERT_TTL_SECONDS?=86400
 
+SERVERS?=--server tc-agent --server rd-agent
+CLIENTS?=--client cd-agent --client rd-agent
+
+SCRIPTS:=../scripts
+GEN_CERTS:=../../util/src/main/bash/generate-certificates.sh
+
 pull:
 	docker compose ${COMPOSE_FILES} pull -q --ignore-pull-failures ${SERVICES}
 
 generate-certs:
-	mkdir -p ./ssl
-	(cd ./ssl && ../../../util/src/main/bash/generate-certificates.sh tc-agent tca cd-agent rd-agent && chmod +r *.key)
-	(cd ./ssl && \
-	  openssl genpkey -quiet -algorithm Ed25519 -out server-rd-agent.key && \
-	  openssl req -new -key server-rd-agent.key -subj "/CN=rd-agent/OU=Server/O=FTSnext" \
-	  | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out server-rd-agent.crt -days 30 && \
-	  chmod +r server-rd-agent.key)
+	$(GEN_CERTS) ./ssl ${SERVERS} ${CLIENTS}
 
 check-certs:
-	@../scripts/check-certs.sh ./ssl $(CERT_TTL_SECONDS) || $(MAKE) generate-certs
+	@$(SCRIPTS)/check-certs.sh ./ssl $(CERT_TTL_SECONDS) ${SERVERS} ${CLIENTS} || $(MAKE) generate-certs
 
 start: check-certs
 	docker compose ${COMPOSE_FILES} up --wait --pull missing ${SERVICES}
 
 download-test-data-checksums:
-	../scripts/download-test-data-checksums.sh MioAzTLMjzbPNyx
-	../scripts/download-test-data-checksums.sh 4p2JNfHa8mXmLSF
+	$(SCRIPTS)/download-test-data-checksums.sh MioAzTLMjzbPNyx
+	$(SCRIPTS)/download-test-data-checksums.sh 4p2JNfHa8mXmLSF
 
 download-test-data:
-	../scripts/download-test-data.sh MioAzTLMjzbPNyx ${TEST_SET_SIZE}
-	../scripts/download-test-data.sh 4p2JNfHa8mXmLSF ${TEST_SET_SIZE}
+	$(SCRIPTS)/download-test-data.sh MioAzTLMjzbPNyx ${TEST_SET_SIZE}
+	$(SCRIPTS)/download-test-data.sh 4p2JNfHa8mXmLSF ${TEST_SET_SIZE}
 
 check-test-data:
 	(cd ./test-data/MioAzTLMjzbPNyx && sha256sum -c checksums.sha256 --ignore-missing)
 	(cd ./test-data/4p2JNfHa8mXmLSF && sha256sum -c checksums.sha256 --ignore-missing)
 
 upload-consents:
-	../scripts/upload-consents.sh ${TEST_SET_SIZE}
+	$(SCRIPTS)/upload-consents.sh ${TEST_SET_SIZE}
 
 upload-test-data:
-	../scripts/upload-data.sh
+	$(SCRIPTS)/upload-data.sh
 
 transfer-all:
-	../scripts/start-transfer-all.sh ${PROJECT} >process.url
+	$(SCRIPTS)/start-transfer-all.sh ${PROJECT} >process.url
 
 transfer-list:
-	../scripts/start-transfer-list.sh ${PROJECT} MioAzTLMjzbPNyx ${TEST_SET_SIZE} >process.url
+	$(SCRIPTS)/start-transfer-list.sh ${PROJECT} MioAzTLMjzbPNyx ${TEST_SET_SIZE} >process.url
 
 transfer-with-fhir-consent-list:
-	../scripts/start-transfer-list.sh ${PROJECT} 4p2JNfHa8mXmLSF ${TEST_SET_SIZE} >process.url
+	$(SCRIPTS)/start-transfer-list.sh ${PROJECT} 4p2JNfHa8mXmLSF ${TEST_SET_SIZE} >process.url
 
 wait:
-	../scripts/await-transfer.sh "$(shell cat process.url)"
+	$(SCRIPTS)/await-transfer.sh "$(shell cat process.url)"
 
 check-consent:
-	../scripts/check-consent.sh ${TEST_SET_SIZE}
+	$(SCRIPTS)/check-consent.sh ${TEST_SET_SIZE}
 
 check-status:
-	../scripts/check-status.sh "$(shell cat process.url)" ${RESULTS_FILE}
+	$(SCRIPTS)/check-status.sh "$(shell cat process.url)" ${RESULTS_FILE}
 
 check-resources:
-	../scripts/check-resources.sh ${RESULTS_FILE}
+	$(SCRIPTS)/check-resources.sh ${RESULTS_FILE}
 
 check-pseudonymization:
-	../scripts/check-pseudonymization.sh
+	$(SCRIPTS)/check-pseudonymization.sh
 
 show-status:
 	curl -sSf "$(shell cat process.url)"
 
 list-projects:
-	../scripts/list-projects.sh
+	$(SCRIPTS)/list-projects.sh
 
 show-project:
-	../scripts/show-project.sh
+	$(SCRIPTS)/show-project.sh
 
 show-hds:
-	../scripts/show-hds.sh
+	$(SCRIPTS)/show-hds.sh
 
 clean-dbs:
 	docker compose ${COMPOSE_FILES} down cd-hds rd-hds gics-db gpas-db
@@ -95,4 +95,4 @@ clean-rd-hds-and-gpas-db:
 	docker compose ${COMPOSE_FILES} up --wait rd-hds gpas-db
 
 openapi-specs:
-	../scripts/openapi-specs.sh ${AGENT}
+	$(SCRIPTS)/openapi-specs.sh ${AGENT}

--- a/.github/test/mtls/tc-agent/application.yaml
+++ b/.github/test/mtls/tc-agent/application.yaml
@@ -7,8 +7,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: file:ssl/server.crt
-            private-key: file:ssl/server.key
+            certificate: file:ssl/server-tc-agent.crt
+            private-key: file:ssl/server-tc-agent.key
           truststore:
             certificate: file:ssl/ca.crt
   codec:

--- a/.github/test/tc-agent/application.yaml
+++ b/.github/test/tc-agent/application.yaml
@@ -7,8 +7,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: file:ssl/server.crt
-            private-key: file:ssl/server.key
+            certificate: file:ssl/server-tc-agent.crt
+            private-key: file:ssl/server-tc-agent.key
 
 server:
   ssl:

--- a/clinical-domain-agent/pom.xml
+++ b/clinical-domain-agent/pom.xml
@@ -146,10 +146,12 @@
                 ${project.basedir}/../util/src/main/bash/generate-certificates.sh
               </executable>
               <arguments>
+                <argument>${project.build.testOutputDirectory}</argument>
+                <argument>--server</argument>
                 <argument>localhost</argument>
+                <argument>--client</argument>
                 <argument>default</argument>
               </arguments>
-              <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
             </configuration>
           </execution>
         </executions>

--- a/clinical-domain-agent/src/test/resources/application.yaml
+++ b/clinical-domain-agent/src/test/resources/application.yaml
@@ -7,8 +7,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: classpath:/server.crt
-            private-key: classpath:/server.key
+            certificate: classpath:/server-localhost.crt
+            private-key: classpath:/server-localhost.key
           truststore:
             certificate: classpath:/ca.crt
         client:

--- a/research-domain-agent/pom.xml
+++ b/research-domain-agent/pom.xml
@@ -147,10 +147,12 @@
                 ${project.basedir}/../util/src/main/bash/generate-certificates.sh
               </executable>
               <arguments>
+                <argument>${project.build.testOutputDirectory}</argument>
+                <argument>--server</argument>
                 <argument>localhost</argument>
+                <argument>--client</argument>
                 <argument>default</argument>
               </arguments>
-              <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
             </configuration>
           </execution>
         </executions>

--- a/research-domain-agent/src/test/resources/application.yaml
+++ b/research-domain-agent/src/test/resources/application.yaml
@@ -7,8 +7,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: classpath:/server.crt
-            private-key: classpath:/server.key
+            certificate: classpath:/server-localhost.crt
+            private-key: classpath:/server-localhost.key
           truststore:
             certificate: classpath:/ca.crt
         client:

--- a/trust-center-agent/pom.xml
+++ b/trust-center-agent/pom.xml
@@ -169,11 +169,14 @@
                 ${project.basedir}/../util/src/main/bash/generate-certificates.sh
               </executable>
               <arguments>
+                <argument>${project.build.testOutputDirectory}</argument>
+                <argument>--server</argument>
                 <argument>localhost</argument>
+                <argument>--client</argument>
                 <argument>cd-agent</argument>
+                <argument>--client</argument>
                 <argument>rd-agent</argument>
               </arguments>
-              <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
             </configuration>
           </execution>
         </executions>

--- a/trust-center-agent/src/test/resources/application-no-gics.yaml
+++ b/trust-center-agent/src/test/resources/application-no-gics.yaml
@@ -30,8 +30,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: classpath:/server.crt
-            private-key: classpath:/server.key
+            certificate: classpath:/server-localhost.crt
+            private-key: classpath:/server-localhost.key
           truststore:
             certificate: classpath:/ca.crt
         client:

--- a/trust-center-agent/src/test/resources/application.yaml
+++ b/trust-center-agent/src/test/resources/application.yaml
@@ -33,8 +33,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: classpath:/server.crt
-            private-key: classpath:/server.key
+            certificate: classpath:/server-localhost.crt
+            private-key: classpath:/server-localhost.key
           truststore:
             certificate: classpath:/ca.crt
         client:

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -177,10 +177,12 @@
                 ${project.basedir}/../util/src/main/bash/generate-certificates.sh
               </executable>
               <arguments>
+                <argument>${project.build.testOutputDirectory}</argument>
+                <argument>--server</argument>
                 <argument>localhost</argument>
+                <argument>--client</argument>
                 <argument>default</argument>
               </arguments>
-              <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
             </configuration>
           </execution>
         </executions>

--- a/util/src/main/bash/generate-certificates.sh
+++ b/util/src/main/bash/generate-certificates.sh
@@ -1,24 +1,72 @@
 #!/bin/bash
 set -euo pipefail
 
-# Create CA
-echo "Creating CA..."
-openssl genpkey -quiet -algorithm Ed25519 -out "ca.key" >/dev/null
-openssl req -x509 -new -key "ca.key" -days 60 -out "ca.crt" -subj "/CN=fts.smith.care"
+# Generate a CA and a set of server/client certificates signed by it.
+#
+# Usage: generate-certificates.sh <dir> --server <CN> [--server <CN> ...] --client <CN> [--client <CN> ...]
+#
+# The special client "no-ca" is always added (self-signed, not CA-signed).
+#
+# Output files in <dir>:
+#   ca.key / ca.crt
+#   server-<CN>.key / server-<CN>.crt   (one per --server)
+#   client-<CN>.key / client-<CN>.crt   (one per --client)
+#   client-no-ca.key / client-no-ca.crt
 
-# Create server certificate
-echo "Creating server certificate..."
-openssl genpkey -quiet -algorithm Ed25519 -out "server.key" >/dev/null
-openssl req -new -key "server.key" -subj "/CN=${1:-server.example.com}/OU=Server/O=FTSnext" \
-  | openssl x509 -req -CA "ca.crt" -CAkey "ca.key" -CAcreateserial -out "server.crt" -days 30
+DIR="${1:?usage: generate-certificates.sh <dir> --server <CN> ... --client <CN> ...}"
+shift
 
-for CLIENT_CN in "${@:2}"; do
-  echo "Creating '$CLIENT_CN' client certificate for CN=$CLIENT_CN..."
-  openssl genpkey -quiet -algorithm Ed25519 -out "client-${CLIENT_CN}.key" >/dev/null
-  openssl req -new -key "client-${CLIENT_CN}.key" -subj "/CN=${CLIENT_CN}/OU=Client/O=FTSnext" \
-    | openssl x509 -req -CA "ca.crt" -CAkey "ca.key" -CAcreateserial -out "client-${CLIENT_CN}.crt" -days 30
+SERVERS=()
+CLIENTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server)
+      SERVERS+=("$2")
+      shift 2
+      ;;
+    --client)
+      CLIENTS+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
 done
 
+if [[ ${#SERVERS[@]} -eq 0 ]]; then
+  echo "Error: at least one --server is required" >&2
+  exit 1
+fi
+
+mkdir -p "$DIR"
+
+# Create CA (once)
+echo "Creating CA..."
+openssl genpkey -quiet -algorithm Ed25519 -out "${DIR}/ca.key" >/dev/null
+openssl req -x509 -new -key "${DIR}/ca.key" -days 60 -out "${DIR}/ca.crt" -subj "/CN=fts.smith.care"
+
+# Create server certificate(s)
+for SERVER_CN in "${SERVERS[@]}"; do
+  echo "Creating server certificate for CN=$SERVER_CN..."
+  openssl genpkey -quiet -algorithm Ed25519 -out "${DIR}/server-${SERVER_CN}.key" >/dev/null
+  openssl req -new -key "${DIR}/server-${SERVER_CN}.key" -subj "/CN=${SERVER_CN}/OU=Server/O=FTSnext" \
+    | openssl x509 -req -CA "${DIR}/ca.crt" -CAkey "${DIR}/ca.key" -CAcreateserial -out "${DIR}/server-${SERVER_CN}.crt" -days 30
+done
+
+# Create client certificate(s)
+for CLIENT_CN in "${CLIENTS[@]}"; do
+  echo "Creating client certificate for CN=$CLIENT_CN..."
+  openssl genpkey -quiet -algorithm Ed25519 -out "${DIR}/client-${CLIENT_CN}.key" >/dev/null
+  openssl req -new -key "${DIR}/client-${CLIENT_CN}.key" -subj "/CN=${CLIENT_CN}/OU=Client/O=FTSnext" \
+    | openssl x509 -req -CA "${DIR}/ca.crt" -CAkey "${DIR}/ca.key" -CAcreateserial -out "${DIR}/client-${CLIENT_CN}.crt" -days 30
+done
+
+# Always create 'no-ca' client certificate (self-signed)
 echo "Creating 'no-ca' client certificate for CN=no-ca..."
-openssl genpkey -quiet -algorithm Ed25519 -out "client-no-ca.key" >/dev/null
-openssl req -new -x509 -key "client-no-ca.key" -subj "/CN=no-ca" -out "client-no-ca.crt" -days 30
+openssl genpkey -quiet -algorithm Ed25519 -out "${DIR}/client-no-ca.key" >/dev/null
+openssl req -new -x509 -key "${DIR}/client-no-ca.key" -subj "/CN=no-ca" -out "${DIR}/client-no-ca.crt" -days 30
+
+chmod +r "${DIR}"/*.key

--- a/util/src/test/resources/application.yaml
+++ b/util/src/test/resources/application.yaml
@@ -4,8 +4,8 @@ spring:
       pem:
         server:
           keystore:
-            certificate: classpath:/server.crt
-            private-key: classpath:/server.key
+            certificate: classpath:/server-localhost.crt
+            private-key: classpath:/server-localhost.key
           truststore:
             certificate: classpath:/ca.crt
         client:


### PR DESCRIPTION
## Summary

- Replace the `ssl/server.crt` file-target prereq from #1678 with a `check-certs` phony target.
- `check-certs` iterates all expected certs (CA, server, server-rd-agent, all client certs) and runs `generate-certs` if any is missing or expires within `CERT_TTL_SECONDS` (default 86400s = 1 day).
- Covers both the missing-cert footgun (originally fixed in #1678) and silent TLS failures from expired certs that previously required manual `make generate-certs`.

## Notes

- **Stacked on #1678** — base branch is `1675-make-start-root-owned-ssl`. Will rebase onto `main` once #1678 merges.
- `openssl x509 -checkend` adds ~10ms per `make start`. Negligible.
- Regen replaces the CA → same trust-churn caveat as any cert regeneration; acceptable for an ephemeral test stack.
- Does not help containers already running with expired certs — only triggers on fresh `make start`. A runtime health-check would be a separate change.

Closes #1679