### PR TITLE
Log Cohort Selection Errors

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -146,7 +146,11 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
           .cohortSelector()
           .selectCohort(identifiers)
           .doOnNext(b -> status.updateAndGet(TransferProcessStatus::incTotalPatients))
-          .doOnError(e -> status.updateAndGet(s -> s.setPhase(Phase.FATAL)))
+          .doOnError(
+              e -> {
+                log.error("[Process {}] Cohort selection failed", processId(), e);
+                status.updateAndGet(s -> s.setPhase(Phase.FATAL));
+              })
           .onErrorComplete();
     }
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -105,6 +105,43 @@ class DefaultTransferProcessRunnerTest {
   }
 
   @Test
+  void cohortSelectorErrorIsLoggedWithStacktrace() {
+    var logger = (Logger) LoggerFactory.getLogger(DefaultTransferProcessRunner.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    var originalLevel = logger.getLevel();
+    logger.setLevel(Level.ERROR);
+
+    try {
+      var process =
+          new TransferProcessDefinition(
+              "test",
+              rawConfig,
+              pids -> Flux.error(new RuntimeException("Cohort fetch boom")),
+              p -> fromIterable(List.of(new ConsentedPatientBundle(new Bundle(), PATIENT))),
+              b -> just(new TransportBundle(new Bundle(), "tIDMapName")),
+              b -> Mono.just(new Result()));
+
+      var processId = runner.start(process, List.of());
+      waitForCompletion(processId);
+
+      var errorEvents =
+          appender.list.stream()
+              .filter(e -> e.getLevel() == Level.ERROR)
+              .filter(e -> e.getFormattedMessage().contains("Cohort selection failed"))
+              .toList();
+      assertThat(errorEvents).isNotEmpty();
+      var event = errorEvents.getFirst();
+      assertThat(event.getThrowableProxy()).isNotNull();
+      assertThat(event.getThrowableProxy().getMessage()).isEqualTo("Cohort fetch boom");
+    } finally {
+      logger.detachAppender(appender);
+      logger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
   void startMultipleProcessesWithQueueing() {
     var process =
         new TransferProcessDefinition(


### PR DESCRIPTION
## Summary

- `DefaultTransferProcessRunner.selectCohort` swallowed errors silently — operators saw only `[Process X] Finished with: FATAL` with no message or stacktrace.
- The existing `FhirCohortSelector.doOnError` is wired *before* `flatMap(extractConsentedPatients)`, so extraction-time failures (e.g. NPE on a `Coding`/`Identifier` without `system`) bypassed it.
- Now logs the throwable at ERROR before flipping the status to FATAL.

Closes #1683