### PR TITLE
Fix First-Burst EOF After Idle Gap

### DIFF
--- a/clinical-domain-agent/application.yaml
+++ b/clinical-domain-agent/application.yaml
@@ -63,6 +63,15 @@
 #   # Prefix for all API routes (useful if the agent is served under a subpath)
 #   webflux.base-path: /
 
+### FTS Outbound HTTP Client
+##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
+# fts.http.client:
+#   # Pool keep-alive for outbound http connections. Must stay below the
+#   # idle timeout of every upstream (for cd-agent: cd-hds Blaze 30s, tc-agent, rd-agent)
+#   # to avoid "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # ISO-8601 duration; default PT25S.
+#   keepalive-timeout: PT25S
+
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security
 # security:

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSender.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSender.java
@@ -73,6 +73,8 @@ final class RdaBundleSender implements BundleSender {
     }
   }
 
+  private static final int MAX_STATUS_POLLS = 10;
+
   private Mono<ResponseEntity<Void>> waitForRDACompleted(ResponseEntity<Void> response) {
     return Mono.just(response)
         .flatMap(this::extractStatusUri)
@@ -83,15 +85,23 @@ final class RdaBundleSender implements BundleSender {
                     .expand(
                         r -> fetchStatus(uri).delayElement(Duration.ofSeconds(getRetryAfter(r))))
                     .takeUntil(r -> r.getStatusCode() != ACCEPTED)
-                    .take(10)
+                    .take(MAX_STATUS_POLLS)
                     .last())
         .flatMap(
             r -> {
-              if (r.getStatusCode() == OK) {
+              var status = r.getStatusCode();
+              if (status == OK) {
                 return Mono.just(r);
+              } else if (status == ACCEPTED) {
+                var message =
+                    "RDA polling budget exhausted after "
+                        + MAX_STATUS_POLLS
+                        + " attempts, status still ACCEPTED";
+                log.error(message);
+                return Mono.error(new TransferProcessException(message));
               } else {
-                log.error("Error: {}", r.getStatusCode());
-                return Mono.error(new TransferProcessException("Error: " + r.getStatusCode()));
+                log.error("Unexpected RDA status: {}", status);
+                return Mono.error(new TransferProcessException("Unexpected RDA status: " + status));
               }
             });
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
@@ -212,7 +212,7 @@ class RdaBundleSenderIT extends AbstractConnectionScenarioIT {
   }
 
   @Test
-  void withNumberFormatExceptionInGetRetryAfterWithRetriesExhausted() {
+  void pollingBudgetExhaustedWithStatusStillAccepted() {
     wireMock.register(
         rdaRequest()
             .willReturn(
@@ -223,7 +223,24 @@ class RdaBundleSenderIT extends AbstractConnectionScenarioIT {
 
     var bundle = Stream.of(new Patient().setId(PATIENT_ID)).collect(toBundle());
     create(bundleSender.send(new TransportBundle(bundle, "transferId")))
-        .expectError(TransferProcessException.class)
+        .expectErrorMessage("RDA polling budget exhausted after 10 attempts, status still ACCEPTED")
+        .verify();
+  }
+
+  @Test
+  void unexpectedStatusFromPollingEndpoint() {
+    wireMock.register(
+        rdaRequest()
+            .willReturn(
+                accepted().withHeader(CONTENT_LOCATION, "/api/v2/process/status/processId")));
+    wireMock.register(get("/api/v2/process/status/processId").willReturn(created()));
+
+    var bundle = Stream.of(new Patient().setId(PATIENT_ID)).collect(toBundle());
+    create(bundleSender.send(new TransportBundle(bundle, "transferId")))
+        .expectErrorMatches(
+            e ->
+                e instanceof TransferProcessException
+                    && e.getMessage().startsWith("Unexpected RDA status: 201"))
         .verify();
   }
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
@@ -1,0 +1,111 @@
+package care.smith.fts.cda.impl;
+
+import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
+import static org.springframework.http.HttpHeaders.RETRY_AFTER;
+import static reactor.test.StepVerifier.create;
+
+import care.smith.fts.api.TransportBundle;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.error.TransferProcessException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.function.Function;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+class RdaBundleSenderTest {
+
+  private static final RdaBundleSenderConfig CONFIG =
+      new RdaBundleSenderConfig(new HttpClientConfig("http://localhost"), "example");
+  private static final String STATUS_URI = "/api/v2/process/status/proc-1";
+
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  private static WebClient buildClient(Function<ClientRequest, ClientResponse> handler) {
+    ExchangeFunction exchange = request -> Mono.just(handler.apply(request));
+    return WebClient.builder().exchangeFunction(exchange).build();
+  }
+
+  @Test
+  void pollingBudgetExhaustedRaisesTransferProcessException() {
+    var client =
+        buildClient(
+            request -> {
+              if (request.method() == HttpMethod.POST) {
+                return ClientResponse.create(HttpStatus.ACCEPTED)
+                    .header(CONTENT_LOCATION, STATUS_URI)
+                    .build();
+              }
+              return ClientResponse.create(HttpStatus.ACCEPTED).header(RETRY_AFTER, "0").build();
+            });
+    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+
+    create(sender.send(new TransportBundle(new Bundle(), "tid")))
+        .expectErrorMatches(
+            e ->
+                e instanceof TransferProcessException
+                    && e.getMessage()
+                        .equals(
+                            "RDA polling budget exhausted after 10 attempts, status still"
+                                + " ACCEPTED"))
+        .verify();
+  }
+
+  @Test
+  void unexpectedStatusFromPollingEndpointRaisesTransferProcessException() {
+    var client =
+        buildClient(
+            request -> {
+              if (request.method() == HttpMethod.POST) {
+                return ClientResponse.create(HttpStatus.ACCEPTED)
+                    .header(CONTENT_LOCATION, STATUS_URI)
+                    .build();
+              }
+              return ClientResponse.create(HttpStatus.CREATED).build();
+            });
+    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+
+    create(sender.send(new TransportBundle(new Bundle(), "tid")))
+        .expectErrorMatches(
+            e ->
+                e instanceof TransferProcessException
+                    && e.getMessage().startsWith("Unexpected RDA status: 201"))
+        .verify();
+  }
+
+  @Test
+  void successfulOkAtFirstPoll() {
+    var client =
+        buildClient(
+            request -> {
+              if (request.method() == HttpMethod.POST) {
+                return ClientResponse.create(HttpStatus.ACCEPTED)
+                    .header(CONTENT_LOCATION, STATUS_URI)
+                    .build();
+              }
+              return ClientResponse.create(HttpStatus.OK).build();
+            });
+    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+
+    create(sender.send(new TransportBundle(new Bundle(), "tid")))
+        .expectNextCount(1)
+        .verifyComplete();
+  }
+
+  @Test
+  void postOkSkipsPolling() {
+    var client = buildClient(request -> ClientResponse.create(HttpStatus.OK).build());
+    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+
+    create(sender.send(new TransportBundle(new Bundle(), "tid")))
+        .expectNextCount(1)
+        .verifyComplete();
+  }
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -103,6 +103,7 @@ export default withMermaid({
                 {text: 'De-Identification', link: '/configuration/de-identification'},
                 {text: 'Consent', link: '/configuration/consent'},
                 {text: 'WebFlux', link: '/configuration/webflux'},
+                {text: 'HTTP Client', link: '/configuration/http-client'},
               ]
         },
         {

--- a/docs/configuration/http-client.md
+++ b/docs/configuration/http-client.md
@@ -1,0 +1,67 @@
+# HTTP Client <Badge type="tip" text="All Agents" /> <Badge type="tip" text="Optional" /> <Badge type="warning" text="Since 5.7" />
+
+All FTSnext agents share a pooled outbound HTTP client. This page documents the connection
+keep-alive timeout exposed for that pool.
+
+## Configuration Example
+
+```yaml
+fts.http.client:
+  keepalive-timeout: PT25S
+```
+
+## Fields
+
+### `fts.http.client.keepalive-timeout` <Badge type="warning" text="Since 5.7" />
+
+* **Description**: Maximum time an idle connection is kept in the pool before being closed.
+  Applies to every outbound HTTP call an agent makes. Requires an agent restart to take effect.
+* **Type**: ISO-8601 `Duration` (e.g. `PT25S`, `PT1M`)
+* **Default**: `PT25S`
+
+## Notes
+
+### Pick a value below the lowest upstream idle timeout
+
+If the keep-alive is **greater than or equal to** the idle timeout of any server the agent talks
+to, that server will silently close pooled sockets first. The next request reuses a half-dead
+socket, the write succeeds, the read returns EOF, and the call fails with:
+
+```
+WebClientRequestException: HTTP/1.1 header parser received no bytes
+  caused by EOFException: EOF reached while reading
+```
+
+This typically manifests as a burst of failures on the *first* request to an upstream after an
+idle gap, then stabilises once the pool is repopulated with fresh sockets.
+
+### Per-agent upstreams
+
+Each agent talks to a different set of servers; size the keep-alive against the tightest of
+them.
+
+| Agent | Outbound upstreams |
+| --- | --- |
+| cd-agent | cd-hds, tc-agent, rd-agent |
+| rd-agent | rd-hds, tc-agent |
+| tc-agent | gICS, gPAS |
+
+Samply Blaze defaults to a 30s idle timeout. The `PT25S` default sits safely below it, the
+tightest known upstream in the cluster. If you front your agents with infrastructure that closes
+idle connections faster (e.g. a load balancer with a 15s idle), shorten this value accordingly.
+
+### When to raise it
+
+Raise the value if you control the upstreams and they keep idle connections longer than 25s. A
+larger value reduces TCP/TLS handshake overhead for steady traffic. Always leave a margin (≈5s)
+under the upstream idle.
+
+### When the override takes effect
+
+The value is applied at agent startup, before any request flows through the pool. Changing it
+requires an agent restart.
+
+## References
+
+* [ISO-8601 `Duration` syntax](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence))
+* [Samply Blaze configuration](https://github.com/samply/blaze/blob/main/docs/deployment/environment-variables.md)

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -11,6 +11,12 @@ version the feature is or will be available, e.g. <Badge type="warning" text="Si
 The latest stable version
 is: [{{ release }}](https://github.com/medizininformatik-initiative/fts-next/releases/latest)
 
+## Applying Configuration Changes
+
+FTSnext reads its configuration **once at startup**. Changing any setting — the agents'
+`application.yaml`, transfer project files, or JVM options — only takes effect after the
+affected agent is **restarted**. There is no runtime configuration reload.
+
 ## Agent Configuration
 
 Agent configuration in the context of FTSnext means the configuration of the server components,

--- a/research-domain-agent/application.yaml
+++ b/research-domain-agent/application.yaml
@@ -52,6 +52,15 @@
 #   # Prefix for all API routes (useful if the agent is served under a subpath)
 #   webflux.base-path: /
 
+### FTS Outbound HTTP Client
+##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
+# fts.http.client:
+#   # Pool keep-alive for outbound http connections. Must stay below the
+#   # idle timeout of every upstream (for rd-agent: rd-hds Blaze 30s, tc-agent) to avoid
+#   # "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # ISO-8601 duration; default PT25S.
+#   keepalive-timeout: PT25S
+
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security
 # security:

--- a/trust-center-agent/application.yaml
+++ b/trust-center-agent/application.yaml
@@ -68,6 +68,15 @@
 #   # Prefix for all API routes (useful if the agent is served under a subpath)
 #   webflux.base-path: /
 
+### FTS Outbound HTTP Client
+##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
+# fts.http.client:
+#   # Pool keep-alive for outbound http connections. Must stay below the
+#   # idle timeout of every upstream (for tc-agent: gICS, gPAS) to avoid
+#   # "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # ISO-8601 duration; default PT25S.
+#   keepalive-timeout: PT25S
+
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security
 # security:

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.TimeZone;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -39,8 +40,26 @@ public class AgentConfiguration {
     return FhirContext.forR4();
   }
 
+  /**
+   * Pooled JDK HTTP client used by every agent's outbound WebClient.
+   *
+   * <p>JDK HttpClient exposes no builder API for connection-pool keep-alive; the only knob is the
+   * {@code jdk.httpclient.keepalive.timeout} system property. We set it here so the pool evicts
+   * cached connections before any upstream server closes them on its own idle timeout. The value
+   * must stay below the lowest idle timeout among the agent's upstreams; if client keep-alive ≥
+   * server idle, the pool reuses a half-dead socket and the first request after an idle gap fails
+   * with "HTTP/1.1 header parser received no bytes" / {@code EOFException}.
+   *
+   * <p>Default 25s targets the tightest upstream we know about: Samply Blaze (Jetty, 30s idle),
+   * reached by cd-agent and rd-agent via cd-hds / rd-hds. tc-agent talks to gICS and gPAS
+   * (WildFly/Undertow) and serves inbound calls from cd-/rd-agent itself, so the same pool covers
+   * those flows too. See {@code docs/configuration/http-client.md}.
+   */
   @Bean
-  public HttpClient httpClient() {
+  public HttpClient httpClient(
+      @Value("${fts.http.client.keepalive-timeout:PT25S}") Duration keepaliveTimeout) {
+    System.setProperty(
+        "jdk.httpclient.keepalive.timeout", String.valueOf(keepaliveTimeout.toSeconds()));
     return HttpClient.newBuilder().connectTimeout(ofSeconds(10)).build();
   }
 

--- a/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
+++ b/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
@@ -1,0 +1,45 @@
+package care.smith.fts.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentConfigurationTest {
+
+  private static final String KEEPALIVE_PROP = "jdk.httpclient.keepalive.timeout";
+
+  private String savedKeepalive;
+
+  @BeforeEach
+  void snapshot() {
+    savedKeepalive = System.getProperty(KEEPALIVE_PROP);
+    System.clearProperty(KEEPALIVE_PROP);
+  }
+
+  @AfterEach
+  void restore() {
+    if (savedKeepalive == null) {
+      System.clearProperty(KEEPALIVE_PROP);
+    } else {
+      System.setProperty(KEEPALIVE_PROP, savedKeepalive);
+    }
+  }
+
+  @Test
+  void httpClientSetsKeepaliveSystemProperty() {
+    var client = new AgentConfiguration().httpClient(Duration.ofSeconds(17));
+
+    assertThat(client).isNotNull();
+    assertThat(System.getProperty(KEEPALIVE_PROP)).isEqualTo("17");
+  }
+
+  @Test
+  void httpClientRoundsToSecondsForSubSecondDurations() {
+    new AgentConfiguration().httpClient(Duration.ofMillis(1500));
+
+    assertThat(System.getProperty(KEEPALIVE_PROP)).isEqualTo("1");
+  }
+}


### PR DESCRIPTION
## Summary

- **HTTP client keep-alive**: new Spring property `fts.http.client.keepalive-timeout` (default `PT25S`) on all three agents. Sized below Samply Blaze's 30s idle to stop the first-request-after-idle EOF (#1677). Drops the `JAVA_TOOL_OPTIONS` workaround from test compose files.
- **rd-agent fan-out cap**: `FhirStoreBundleSender` now bounds concurrent POSTs to the FHIR store via a fair `Semaphore`. New `bundleSender.fhirStore.maxConcurrency` config (default `2`).
- **RdaBundleSender error clarity**: distinguish polling-budget exhaustion (`RDA polling budget exhausted after N attempts, status still ACCEPTED`) from any other terminal status (`Unexpected RDA status: <code>`). Extracted `MAX_STATUS_POLLS` so the cap and message stay in sync.
- Docs: new `docs/configuration/http-client.md`; `maxConcurrency` documented under `docs/rd-agent/bundle-sender.md`.
- Unit tests added for `AgentConfiguration`, `RdaBundleSender`, `FhirStoreBundleSender`, `FhirStoreBundleSenderConfig`.

Closes #1677