### PR TITLE
RDA Send Concurrency + Backpressure

### DIFF
--- a/api/src/main/java/care/smith/fts/api/rda/BundleSender.java
+++ b/api/src/main/java/care/smith/fts/api/rda/BundleSender.java
@@ -9,6 +9,24 @@ public interface BundleSender extends TransferProcessStep {
 
   Mono<Result> send(Bundle bundles);
 
+  /**
+   * Identifies the downstream HDS (FHIR store) this sender targets. Senders sharing the same
+   * destination must report an identical id so the runner can group them behind a single per-HDS
+   * drainer. The default returns a per-instance-unique value so senders without a real destination
+   * (e.g. test stubs) stay ungrouped.
+   */
+  default String destinationId() {
+    return "ungrouped-" + System.identityHashCode(this);
+  }
+
+  /**
+   * The maximum number of concurrent sends this sender's HDS can tolerate. Used by the runner to
+   * size the per-HDS drain concurrency. Matches {@code FhirStoreBundleSenderConfig}'s default.
+   */
+  default int sendConcurrency() {
+    return 2;
+  }
+
   interface Factory<C> extends TransferProcessStepFactory<BundleSender, Config, C> {}
 
   record Config() {}

--- a/api/src/test/java/care/smith/fts/api/rda/BundleSenderTest.java
+++ b/api/src/test/java/care/smith/fts/api/rda/BundleSenderTest.java
@@ -5,9 +5,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.hl7.fhir.r4.model.Bundle;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 class BundleSenderTest {
+
+  /**
+   * A sender that overrides nothing, exercising the interface's default methods. Uses an anonymous
+   * class (not a lambda) so each call yields a distinct instance — lambdas with no captured state
+   * are cached by the JVM and would share one identity.
+   */
+  private static BundleSender defaultSender() {
+    return new BundleSender() {
+      @Override
+      public Mono<Result> send(Bundle bundles) {
+        return Mono.just(new Result());
+      }
+    };
+  }
+
+  @Test
+  void defaultDestinationIdIsUngroupedAndPerInstance() {
+    var a = defaultSender();
+    var b = defaultSender();
+
+    assertThat(a.destinationId()).startsWith("ungrouped-");
+    assertThat(a.destinationId()).isEqualTo(a.destinationId());
+    assertThat(a.destinationId()).isNotEqualTo(b.destinationId());
+  }
+
+  @Test
+  void defaultSendConcurrencyMatchesConfigDefault() {
+    assertThat(defaultSender().sendConcurrency()).isEqualTo(2);
+  }
+
+  @Test
+  void defaultSenderSends() {
+    assertThat(defaultSender().send(new Bundle()).block()).isNotNull();
+  }
 
   @Test
   void deserialization() throws JsonProcessingException {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderConfig.java
@@ -2,10 +2,27 @@ package care.smith.fts.cda.impl;
 
 import care.smith.fts.util.HttpClientConfig;
 import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 
 public record RdaBundleSenderConfig(
     /* */
     @NotNull HttpClientConfig server,
 
     /* */
-    String project) {}
+    String project,
+
+    /* Total time a single bundle may spend waiting on RDA 429 backpressure before giving up. */
+    Duration maxBackpressureWait) {
+
+  private static final Duration DEFAULT_MAX_BACKPRESSURE_WAIT = Duration.ofMinutes(10);
+
+  public RdaBundleSenderConfig {
+    if (maxBackpressureWait == null) {
+      maxBackpressureWait = DEFAULT_MAX_BACKPRESSURE_WAIT;
+    }
+  }
+
+  public RdaBundleSenderConfig(HttpClientConfig server, String project) {
+    this(server, project, DEFAULT_MAX_BACKPRESSURE_WAIT);
+  }
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderFactory.java
@@ -1,19 +1,20 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.BundleSender;
-import care.smith.fts.util.RetryStrategy;
+import care.smith.fts.util.RdaBackpressureRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("researchDomainAgentBundleSender")
 public class RdaBundleSenderFactory implements BundleSender.Factory<RdaBundleSenderConfig> {
 
   private final WebClientFactory clientFactory;
-  private final RetryStrategy retryStrategy;
+  private final MeterRegistry meterRegistry;
 
-  public RdaBundleSenderFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
+  public RdaBundleSenderFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
     this.clientFactory = clientFactory;
-    this.retryStrategy = retryStrategy;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -23,6 +24,10 @@ public class RdaBundleSenderFactory implements BundleSender.Factory<RdaBundleSen
 
   @Override
   public BundleSender create(BundleSender.Config commonConfig, RdaBundleSenderConfig implConfig) {
+    // The CDA->RDA path retries 429 backpressure indefinitely (up to maxBackpressureWait), so it
+    // needs the per-config backpressure strategy rather than the shared DefaultRetryStrategy bean.
+    var retryStrategy =
+        new RdaBackpressureRetryStrategy(meterRegistry, implConfig.maxBackpressureWait());
     return new RdaBundleSender(
         implConfig, clientFactory.create(implConfig.server()), retryStrategy);
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderConfigTest.java
@@ -1,0 +1,35 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import care.smith.fts.util.HttpClientConfig;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RdaBundleSenderConfigTest {
+
+  private static final HttpClientConfig SERVER = new HttpClientConfig("http://localhost");
+
+  @Test
+  void nullMaxBackpressureWaitUsesDefault() {
+    assertThat(new RdaBundleSenderConfig(SERVER, "project", null))
+        .extracting(RdaBundleSenderConfig::maxBackpressureWait)
+        .isEqualTo(Duration.ofMinutes(10));
+  }
+
+  @Test
+  void explicitMaxBackpressureWaitIsKept() {
+    var wait = Duration.ofSeconds(30);
+    assertThat(new RdaBundleSenderConfig(SERVER, "project", wait))
+        .extracting(RdaBundleSenderConfig::maxBackpressureWait)
+        .isEqualTo(wait);
+  }
+
+  @Test
+  void twoArgConstructorUsesDefaultMaxBackpressureWait() {
+    var config = new RdaBundleSenderConfig(SERVER, "project");
+    assertThat(config.server()).isEqualTo(SERVER);
+    assertThat(config.project()).isEqualTo("project");
+    assertThat(config.maxBackpressureWait()).isEqualTo(Duration.ofMinutes(10));
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryIT.java
@@ -2,7 +2,6 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -21,7 +20,7 @@ class RdaBundleSenderFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new RdaBundleSenderFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
+    factory = new RdaBundleSenderFactory(clientFactory, meterRegistry);
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryTest.java
@@ -1,0 +1,42 @@
+package care.smith.fts.cda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import care.smith.fts.api.cda.BundleSender;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class RdaBundleSenderFactoryTest {
+
+  @Mock WebClientFactory clientFactory;
+  @Mock WebClient webClient;
+
+  @Test
+  void getConfigTypeReturnsImplConfig() {
+    var factory = new RdaBundleSenderFactory(clientFactory, new SimpleMeterRegistry());
+    assertThat(factory.getConfigType()).isEqualTo(RdaBundleSenderConfig.class);
+  }
+
+  @Test
+  void createBuildsSenderFromConfig() {
+    var server = new HttpClientConfig("http://rda:8080");
+    var implConfig = new RdaBundleSenderConfig(server, "project", Duration.ofMinutes(5));
+    given(clientFactory.create(server)).willReturn(webClient);
+
+    var factory = new RdaBundleSenderFactory(clientFactory, new SimpleMeterRegistry());
+    BundleSender sender = factory.create(new BundleSender.Config(), implConfig);
+
+    assertThat(sender).isNotNull();
+    verify(clientFactory).create(server);
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
@@ -11,6 +11,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.status;
 import static com.github.tomakehurst.wiremock.matching.UrlPattern.ANY;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
@@ -22,7 +23,7 @@ import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender;
 import care.smith.fts.api.cda.BundleSender.Result;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
-import care.smith.fts.util.DefaultRetryStrategy;
+import care.smith.fts.util.RdaBackpressureRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.error.TransferProcessException;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
@@ -62,7 +63,8 @@ class RdaBundleSenderIT extends AbstractConnectionScenarioIT {
     wireMock = wireMockRuntime.getWireMock();
 
     var config = new RdaBundleSenderConfig(server, "example");
-    bundleSender = new RdaBundleSender(config, client, new DefaultRetryStrategy(meterRegistry));
+    bundleSender =
+        new RdaBundleSender(config, client, new RdaBackpressureRetryStrategy(meterRegistry));
   }
 
   private static MappingBuilder rdaRequest() {
@@ -243,6 +245,30 @@ class RdaBundleSenderIT extends AbstractConnectionScenarioIT {
                 e instanceof TransferProcessException
                     && e.getMessage().startsWith("Unexpected RDA status: 201"))
         .verify();
+  }
+
+  @Test
+  void tooManyRequestsIsRetried() {
+    wireMock.register(
+        rdaRequest()
+            .inScenario("Backpressure")
+            .whenScenarioStateIs(FIRST)
+            .willReturn(status(429).withHeader(RETRY_AFTER, "1"))
+            .willSetStateTo(REST));
+
+    wireMock.register(
+        rdaRequest()
+            .inScenario("Backpressure")
+            .whenScenarioStateIs(REST)
+            .willReturn(
+                accepted().withHeader(CONTENT_LOCATION, "/api/v2/process/status/processId")));
+
+    wireMock.register(get("/api/v2/process/status/processId").willReturn(ok()));
+
+    var bundle = Stream.of(new Patient().setId(PATIENT_ID)).collect(toBundle());
+    create(bundleSender.send(new TransportBundle(bundle, "transferId")))
+        .expectNext(new BundleSender.Result())
+        .verifyComplete();
   }
 
   @AfterEach

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
@@ -106,4 +106,17 @@ class RdaBundleSenderTest {
         .expectNextCount(1)
         .verifyComplete();
   }
+
+  @Test
+  void acceptedWithoutContentLocationErrors() {
+    var client = buildClient(request -> ClientResponse.create(HttpStatus.ACCEPTED).build());
+    var sender = new RdaBundleSender(CONFIG, client, new DefaultRetryStrategy(meterRegistry));
+
+    create(sender.send(new TransportBundle(new Bundle(), "tid")))
+        .expectErrorMatches(
+            e ->
+                e instanceof TransferProcessException
+                    && e.getMessage().equals("Missing Content-Location"))
+        .verify();
+  }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/AdmissionController.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/AdmissionController.java
@@ -1,0 +1,79 @@
+package care.smith.fts.rda;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+/**
+ * Implements tier-1 (global hard cap) and tier-2 (elastic, work-conserving per-project fair share)
+ * of the RDA admission policy.
+ *
+ * <p>The fair share is not a static cap: it is recomputed at every admission against the number of
+ * currently-active projects, so a lone project may fill the whole buffer while two active projects
+ * each get half. In-flight bundles above a newly-shrunk share are never evicted; they drain
+ * naturally.
+ *
+ * <p>Invariant: {@code permitsInUse() == totalUsage() == Σ usage[P]}. The {@link #release} call
+ * must fire exactly once per admitted bundle on its terminal signal.
+ */
+final class AdmissionController {
+
+  private final int globalBufferMax;
+  private final Semaphore globalSem;
+  private final Map<String, Integer> usage = new HashMap<>();
+
+  AdmissionController(int globalBufferMax) {
+    this.globalBufferMax = globalBufferMax;
+    this.globalSem = new Semaphore(globalBufferMax);
+  }
+
+  enum AdmitResult {
+    ACCEPT,
+    REJECT
+  }
+
+  synchronized AdmitResult admit(String project) {
+    if (!globalSem.tryAcquire()) {
+      return AdmitResult.REJECT; // tier-1: global hard cap reached
+    }
+    int current = usage.getOrDefault(project, 0);
+    int active = usage.size();
+    if (current == 0) {
+      active++; // include the arriving project itself
+    }
+    int fairShare = Math.ceilDiv(globalBufferMax, active);
+    if (current >= fairShare) {
+      globalSem.release(); // tier-2: over your elastic share, give the permit back
+      return AdmitResult.REJECT;
+    }
+    usage.put(project, current + 1);
+    return AdmitResult.ACCEPT;
+  }
+
+  synchronized void release(String project) {
+    // usage only ever holds values >= 1 (keys are removed at count 1), so an absent key (null) is
+    // the sole "no matching admit" case; a stored 0 is unreachable.
+    Integer current = usage.get(project);
+    if (current == null) {
+      throw new IllegalStateException("release without matching admit for project: " + project);
+    }
+    if (current == 1) {
+      usage.remove(project);
+    } else {
+      usage.put(project, current - 1);
+    }
+    globalSem.release();
+  }
+
+  synchronized int usage(String project) {
+    return usage.getOrDefault(project, 0);
+  }
+
+  synchronized int totalUsage() {
+    return usage.values().stream().mapToInt(Integer::intValue).sum();
+  }
+
+  int permitsInUse() {
+    return globalBufferMax - globalSem.availablePermits();
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/DefaultTransferProcessRunner.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/DefaultTransferProcessRunner.java
@@ -1,89 +1,175 @@
 package care.smith.fts.rda;
 
 import static care.smith.fts.util.JsonLogFormatter.asJson;
+import static java.util.stream.Collectors.groupingBy;
 
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.rda.AdmissionController.AdmitResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+/**
+ * Backpressure-aware runner.
+ *
+ * <p>Three tiers protect the system:
+ *
+ * <ol>
+ *   <li>a global hard cap and an elastic per-project fair share (see {@link AdmissionController});
+ *   <li>a per-HDS drain concurrency: bundles for a given FHIR store are funnelled through one
+ *       {@link reactor.core.publisher.Sinks.Many sink} drained by a single {@code flatMap(N_H)}
+ *       subscribed once at construction. {@code N_H} is the conservative minimum of {@code
+ *       sendConcurrency()} across the projects sharing that destination.
+ * </ol>
+ *
+ * The drainer is subscribed exactly once and must never terminate: each item's pipeline isolates
+ * its own error via {@code onErrorResume}, and the sink is never completed.
+ */
 @Slf4j
 @Component
 public class DefaultTransferProcessRunner implements TransferProcessRunner {
 
-  private final Map<String, TransferProcessInstance> instances = new ConcurrentHashMap<>();
+  private final Map<String, ProcessStatus> statuses = new ConcurrentHashMap<>();
+  private final Map<String, HdsDrainer> drainersByProject = new ConcurrentHashMap<>();
   private final ObjectMapper om;
+  private final AdmissionController admission;
 
-  public DefaultTransferProcessRunner(@Autowired ObjectMapper om) {
+  public DefaultTransferProcessRunner(
+      ObjectMapper om, List<TransferProcessDefinition> processes, RdaRunnerConfig config) {
     this.om = om;
+    this.admission = new AdmissionController(config.getGlobalBufferMax());
+    buildDrainers(processes);
+  }
+
+  /** Group definitions by HDS destination, compute N_H per HDS, and wire one drainer per HDS. */
+  private void buildDrainers(List<TransferProcessDefinition> processes) {
+    Map<String, List<TransferProcessDefinition>> byDestination =
+        processes.stream().collect(groupingBy(p -> p.bundleSender().destinationId()));
+
+    byDestination.forEach(
+        (destination, defs) -> {
+          int nH = resolveSendConcurrency(destination, defs);
+          var drainer = new HdsDrainer(destination, nH, admission);
+          defs.forEach(def -> drainersByProject.put(def.project(), drainer));
+        });
+  }
+
+  /** N_H = min(sendConcurrency) across the destination's projects; WARN on a mismatch. */
+  private static int resolveSendConcurrency(
+      String destination, List<TransferProcessDefinition> defs) {
+    var concurrencies = defs.stream().map(d -> d.bundleSender().sendConcurrency()).toList();
+    int min = concurrencies.stream().mapToInt(Integer::intValue).min().orElse(1);
+    if (concurrencies.stream().distinct().count() > 1) {
+      log.warn(
+          "Projects sharing HDS '{}' declare different sendConcurrency values {}; "
+              + "using the conservative minimum {}",
+          destination,
+          concurrencies,
+          min);
+    }
+    return min;
   }
 
   @Override
-  public String start(TransferProcessDefinition process, Mono<TransportBundle> data) {
+  public StartResult start(TransferProcessDefinition process, Mono<TransportBundle> data) {
+    var project = process.project();
+    if (admission.admit(project) == AdmitResult.REJECT) {
+      log.debug("Rejected bundle for project '{}' (backpressure)", project);
+      return StartResult.rejected();
+    }
+
     var processId = UUID.randomUUID().toString();
     log.info("Run process with processId: {}", processId);
     log.info("Project configuration: {}", asJson(om, process.rawConfig()));
-    TransferProcessInstance transferProcessInstance = new TransferProcessInstance(process);
-    transferProcessInstance.execute(data);
-    instances.put(processId, transferProcessInstance);
-    return processId;
+
+    var status = new ProcessStatus();
+    statuses.put(processId, status);
+
+    var item =
+        new DrainItem(project, status, process.deidentificator(), process.bundleSender(), data);
+
+    HdsDrainer drainer = drainersByProject.get(project);
+    if (drainer == null) {
+      // Should not happen: every configured project is wired at construction. Release the permit so
+      // the invariant holds, and report rejection rather than leaking.
+      log.error("No drainer for project '{}'; releasing admission permit", project);
+      admission.release(project);
+      statuses.remove(processId);
+      return StartResult.rejected();
+    }
+    drainer.submit(item);
+    return StartResult.accepted(processId);
+  }
+
+  /** Test/maintenance hook: number of admission permits currently in use across all projects. */
+  int permitsInUse() {
+    return admission.permitsInUse();
+  }
+
+  /** Test hook: per-HDS drain concurrency resolved for the given project. */
+  int drainerConcurrencyFor(String project) {
+    return drainersByProject.get(project).sendConcurrency();
+  }
+
+  /** Cancels every drainer's subscription, propagating cancellation to in-flight sends. */
+  void disposeAllDrainers() {
+    drainersByProject.values().stream().distinct().forEach(HdsDrainer::dispose);
   }
 
   @Override
   public Mono<Status> status(String processId) {
-    TransferProcessInstance transferProcessInstance = instances.get(processId);
-    if (transferProcessInstance != null) {
-      return Mono.just(transferProcessInstance.status(processId));
+    ProcessStatus status = statuses.get(processId);
+    if (status != null) {
+      return Mono.just(status.snapshot(processId));
     } else {
       return Mono.error(new IllegalArgumentException());
     }
   }
 
-  public static class TransferProcessInstance {
-    private final Deidentificator deidentificator;
-    private final BundleSender bundleSender;
-    private final AtomicReference<Phase> phase;
-    private final AtomicLong receivedResources;
-    private final AtomicLong sentResources;
+  /** Mutable per-process status carried by the drained item and read by {@link #status}. */
+  static final class ProcessStatus {
+    private final AtomicReference<Phase> phase = new AtomicReference<>(Phase.RUNNING);
+    private final AtomicLong receivedResources = new AtomicLong();
+    private final AtomicLong sentResources = new AtomicLong();
 
-    public TransferProcessInstance(TransferProcessDefinition process) {
-      deidentificator = process.deidentificator();
-      bundleSender = process.bundleSender();
-
-      phase = new AtomicReference<>(Phase.RUNNING);
-      receivedResources = new AtomicLong();
-      sentResources = new AtomicLong();
+    void addReceived(long n) {
+      receivedResources.getAndAdd(n);
     }
 
-    public void execute(Mono<TransportBundle> data) {
-      data.doOnNext(
-              b ->
-                  log.debug(
-                      "processing patient bundle, resources: {}", b.bundle().getEntry().size()))
-          .doOnNext(b -> receivedResources.getAndAdd(b.bundle().getEntry().size()))
-          .flatMap(deidentificator::deidentify)
-          .doOnNext(b -> sentResources.getAndAdd(b.getEntry().size()))
-          .flatMap(bundleSender::send)
-          .doOnError(err -> log.info("Could not process patient: {}", err.getMessage()))
-          .doOnError(err -> log.trace("The exception:", err))
-          .doOnError(err -> phase.set(Phase.ERROR))
-          .map(r -> new Result(receivedResources.get(), sentResources.get()))
-          .doOnNext(b -> phase.set(Phase.COMPLETED))
-          .onErrorComplete()
-          .subscribe();
+    void addSent(long n) {
+      sentResources.getAndAdd(n);
     }
 
-    public Status status(String processId) {
+    void setPhase(Phase p) {
+      phase.set(p);
+    }
+
+    Status snapshot(String processId) {
       return new Status(processId, phase.get(), receivedResources.get(), sentResources.get());
+    }
+  }
+
+  /** One unit of work funnelled to an HDS drainer. */
+  record DrainItem(
+      String project,
+      ProcessStatus status,
+      Deidentificator deidentificator,
+      BundleSender bundleSender,
+      Mono<TransportBundle> data) {
+
+    Mono<Bundle> deidentify() {
+      return data.doOnNext(b -> status.addReceived(b.bundle().getEntry().size()))
+          .flatMap(deidentificator::deidentify);
     }
   }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/HdsDrainer.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/HdsDrainer.java
@@ -1,0 +1,93 @@
+package care.smith.fts.rda;
+
+import care.smith.fts.rda.DefaultTransferProcessRunner.DrainItem;
+import care.smith.fts.rda.TransferProcessRunner.Phase;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Drains the work queued for a single HDS (FHIR store) at a bounded concurrency {@code N_H}.
+ *
+ * <p>Design constraints:
+ *
+ * <ul>
+ *   <li>The drain is subscribed exactly once (at construction) and must never terminate. Each
+ *       item's pipeline isolates its own error with {@code onErrorResume}, and the sink is never
+ *       completed, so the outer flux stays alive for the lifetime of the agent.
+ *   <li>{@code release} fires on every terminal signal (success, error and cancel) via {@code
+ *       doFinally}, so an admitted bundle releases its admission permit exactly once.
+ *   <li>Concurrent POSTs from multiple CDAs emit to this sink from different threads. {@code
+ *       unicast().onBackpressureBuffer()} is not concurrency-safe for emission, so we serialise
+ *       with a busy-looping emit handler that retries on {@code FAIL_NON_SERIALIZED}.
+ * </ul>
+ */
+@Slf4j
+final class HdsDrainer {
+
+  /** Retry emit on transient non-serialized contention; never retry on terminated/cancelled. */
+  private static final Sinks.EmitFailureHandler EMIT_BUSY_LOOP =
+      Sinks.EmitFailureHandler.busyLooping(Duration.ofSeconds(5));
+
+  private final String destinationId;
+  private final int sendConcurrency;
+  private final Sinks.Many<DrainItem> sink;
+  private final Disposable subscription;
+
+  HdsDrainer(String destinationId, int sendConcurrency, AdmissionController admission) {
+    this.destinationId = destinationId;
+    this.sendConcurrency = sendConcurrency;
+    this.sink = Sinks.many().unicast().onBackpressureBuffer();
+    // Each item's pipeline yields Mono<Void>, so the drain never emits a value — only the two
+    // "should not happen" terminal signals are observable. They are logged via lifecycle operators
+    // (rather than subscribe's value/error consumers) so no unreachable value-consumer remains;
+    // onErrorComplete keeps a stray error from reaching the global onErrorDropped hook.
+    this.subscription =
+        sink.asFlux()
+            .flatMap(item -> process(item, admission), sendConcurrency)
+            .doOnError(
+                error ->
+                    log.error("HDS '{}' drainer terminated unexpectedly", destinationId, error))
+            .doOnComplete(() -> log.error("HDS '{}' drainer completed unexpectedly", destinationId))
+            .onErrorComplete()
+            .subscribe();
+  }
+
+  /**
+   * Per-item pipeline. Errors are confined here so the drainer never terminates. {@code release}
+   * runs in {@code doFinally} so it fires on success, error, and cancellation alike.
+   */
+  private Mono<Void> process(DrainItem item, AdmissionController admission) {
+    return item.deidentify()
+        .doOnNext(b -> item.status().addSent(b.getEntry().size()))
+        .flatMap(item.bundleSender()::send)
+        .doOnNext(r -> item.status().setPhase(Phase.COMPLETED))
+        .then()
+        .onErrorResume(
+            e -> {
+              log.info("Could not process patient: {}", e.getMessage());
+              log.trace("The exception:", e);
+              item.status().setPhase(Phase.ERROR);
+              return Mono.empty();
+            })
+        .doFinally(signal -> admission.release(item.project()));
+  }
+
+  void submit(DrainItem item) {
+    sink.emitNext(item, EMIT_BUSY_LOOP);
+  }
+
+  int sendConcurrency() {
+    return sendConcurrency;
+  }
+
+  String destinationId() {
+    return destinationId;
+  }
+
+  void dispose() {
+    subscription.dispose();
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/RdaRunnerConfig.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/RdaRunnerConfig.java
@@ -1,0 +1,28 @@
+package care.smith.fts.rda;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Tunables for the RDA backpressure runner.
+ *
+ * <ul>
+ *   <li>{@code globalBufferMax} bounds the total number of bundles in the system (queued +
+ *       in-flight) across all projects — tier-1 of the admission policy.
+ *   <li>{@code retryAfterSeconds} is the {@code Retry-After} hint returned with a 429 when
+ *       admission rejects a bundle.
+ * </ul>
+ */
+@Configuration
+@ConfigurationProperties("rda")
+@Getter
+@Setter
+public class RdaRunnerConfig {
+
+  @NotNull int globalBufferMax = 256;
+
+  @NotNull int retryAfterSeconds = 5;
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/TransferProcessRunner.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/TransferProcessRunner.java
@@ -4,7 +4,31 @@ import care.smith.fts.api.TransportBundle;
 import reactor.core.publisher.Mono;
 
 public interface TransferProcessRunner {
-  String start(TransferProcessDefinition process, Mono<TransportBundle> data);
+
+  /**
+   * Attempts to admit a transfer process. Admission applies backpressure: it may reject the bundle
+   * if the system is at capacity (global hard cap) or the project is over its elastic fair share.
+   *
+   * @return {@link StartResult.Accepted} carrying the new processId on admission, otherwise {@link
+   *     StartResult.Rejected}.
+   */
+  StartResult start(TransferProcessDefinition process, Mono<TransportBundle> data);
+
+  /** Outcome of an admission attempt. */
+  sealed interface StartResult permits StartResult.Accepted, StartResult.Rejected {
+
+    record Accepted(String processId) implements StartResult {}
+
+    record Rejected() implements StartResult {}
+
+    static StartResult accepted(String processId) {
+      return new Accepted(processId);
+    }
+
+    static StartResult rejected() {
+      return new Rejected();
+    }
+  }
 
   record Result(long receivedResources, long sentResources) {}
 

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSender.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSender.java
@@ -6,6 +6,9 @@ import static org.hl7.fhir.r4.model.Bundle.BundleType.TRANSACTION;
 
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.util.RetryStrategy;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -17,10 +20,54 @@ import reactor.core.publisher.Mono;
 final class FhirStoreBundleSender implements BundleSender {
   private final WebClient hdsClient;
   private final RetryStrategy retryStrategy;
+  private final String destinationId;
+  private final int sendConcurrency;
 
-  public FhirStoreBundleSender(WebClient hdsClient, RetryStrategy retryStrategy) {
+  public FhirStoreBundleSender(
+      WebClient hdsClient, RetryStrategy retryStrategy, String baseUrl, int sendConcurrency) {
     this.hdsClient = hdsClient;
     this.retryStrategy = retryStrategy;
+    this.destinationId = normalizeBaseUrl(baseUrl);
+    this.sendConcurrency = sendConcurrency;
+  }
+
+  /**
+   * HDS grouping key. Normalises the case-insensitive parts of the URL (scheme + host) and trailing
+   * slashes so projects pointing at the same Blaze (modulo cosmetic URL differences) share one
+   * drainer. The path is left untouched, since path segments are case-sensitive per RFC 3986.
+   */
+  @Override
+  public String destinationId() {
+    return destinationId;
+  }
+
+  @Override
+  public int sendConcurrency() {
+    return sendConcurrency;
+  }
+
+  private static String normalizeBaseUrl(String baseUrl) {
+    var trimmed = baseUrl.strip();
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.substring(0, trimmed.length() - 1);
+    }
+    try {
+      var uri = URI.create(trimmed);
+      if (uri.getScheme() != null && uri.getHost() != null) {
+        return new URI(
+                uri.getScheme().toLowerCase(Locale.ROOT),
+                uri.getUserInfo(),
+                uri.getHost().toLowerCase(Locale.ROOT),
+                uri.getPort(),
+                uri.getPath(),
+                uri.getQuery(),
+                uri.getFragment())
+            .toString();
+      }
+    } catch (IllegalArgumentException | URISyntaxException e) {
+      log.warn("Could not parse HDS base URL '{}' for grouping; using the raw value", baseUrl);
+    }
+    return trimmed;
   }
 
   @Override

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderConfig.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderConfig.java
@@ -8,4 +8,20 @@ public record FhirStoreBundleSenderConfig(
     @NotNull HttpClientConfig server,
 
     /* */
-    String project) {}
+    String project,
+
+    /* Maximum concurrent sends this RDA performs against the HDS (per-HDS drain concurrency). */
+    Integer maxConcurrency) {
+
+  private static final int DEFAULT_MAX_CONCURRENCY = 2;
+
+  public FhirStoreBundleSenderConfig {
+    if (maxConcurrency == null) {
+      maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+    }
+  }
+
+  public FhirStoreBundleSenderConfig(HttpClientConfig server, String project) {
+    this(server, project, DEFAULT_MAX_CONCURRENCY);
+  }
+}

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactory.java
@@ -26,6 +26,7 @@ public class FhirStoreBundleSenderFactory
   public BundleSender create(
       BundleSender.Config commonConfig, FhirStoreBundleSenderConfig implConfig) {
     var client = clientFactory.create(implConfig.server());
-    return new FhirStoreBundleSender(client, retryStrategy);
+    return new FhirStoreBundleSender(
+        client, retryStrategy, implConfig.server().baseUrl(), implConfig.maxConcurrency());
   }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/rest/TransferProcessController.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/rest/TransferProcessController.java
@@ -12,9 +12,13 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import care.smith.fts.api.TransportBundle;
+import care.smith.fts.rda.RdaRunnerConfig;
 import care.smith.fts.rda.TransferProcessConfig;
 import care.smith.fts.rda.TransferProcessDefinition;
 import care.smith.fts.rda.TransferProcessRunner;
+import care.smith.fts.rda.TransferProcessRunner.StartResult;
+import care.smith.fts.rda.TransferProcessRunner.StartResult.Accepted;
+import care.smith.fts.rda.TransferProcessRunner.StartResult.Rejected;
 import care.smith.fts.rda.TransferProcessRunner.Status;
 import care.smith.fts.util.error.ErrorResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +39,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.StringType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -51,11 +56,15 @@ public class TransferProcessController {
 
   private final TransferProcessRunner processRunner;
   private final List<TransferProcessDefinition> processes;
+  private final RdaRunnerConfig runnerConfig;
 
   public TransferProcessController(
-      TransferProcessRunner runner, List<TransferProcessDefinition> processes) {
+      TransferProcessRunner runner,
+      List<TransferProcessDefinition> processes,
+      RdaRunnerConfig runnerConfig) {
     this.processRunner = runner;
     this.processes = processes;
+    this.runnerConfig = runnerConfig;
   }
 
   @PostMapping(
@@ -111,14 +120,25 @@ public class TransferProcessController {
     return data.map(TransferProcessController::fromPlainBundle)
         .doOnNext(b -> log.debug("Running process: {}", transferProcessDefinition))
         .map(tb -> processRunner.start(transferProcessDefinition, Mono.just(tb)))
-        .doOnNext(id -> log.trace("projectId {}", id))
-        .map(id -> generateJobUri(uriBuilder, id))
-        .doOnNext(jobUri -> log.trace("jobUri {}", jobUri))
-        .map(
-            jobUri ->
-                ResponseEntity.accepted()
-                    .headers(h -> h.add(CONTENT_LOCATION, jobUri.toString()))
-                    .build());
+        .map(result -> toResponse(result, uriBuilder));
+  }
+
+  private ResponseEntity<Object> toResponse(StartResult result, UriComponentsBuilder uriBuilder) {
+    return switch (result) {
+      case Accepted accepted -> {
+        var jobUri = generateJobUri(uriBuilder, accepted.processId());
+        log.trace("jobUri {}", jobUri);
+        yield ResponseEntity.accepted()
+            .headers(h -> h.add(CONTENT_LOCATION, jobUri.toString()))
+            .build();
+      }
+      case Rejected() -> {
+        log.debug("Admission rejected; responding 429");
+        yield ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+            .headers(h -> h.add(RETRY_AFTER, String.valueOf(runnerConfig.getRetryAfterSeconds())))
+            .build();
+      }
+    };
   }
 
   static TransportBundle fromPlainBundle(Bundle bundle) {

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/AdmissionControllerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/AdmissionControllerTest.java
@@ -1,0 +1,161 @@
+package care.smith.fts.rda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import care.smith.fts.rda.AdmissionController.AdmitResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic tests for the three-tier admission's tier-1 (global hard cap) and tier-2 (elastic
+ * per-project fair share). No Reactor involved.
+ */
+class AdmissionControllerTest {
+
+  @Test
+  void loneProjectFillsWholeBuffer() {
+    var ac = new AdmissionController(4);
+
+    for (int i = 0; i < 4; i++) {
+      assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    }
+    // 5th over the global cap
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertThat(ac.usage("A")).isEqualTo(4);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void secondActiveProjectHalvesFairShare() {
+    var ac = new AdmissionController(4);
+
+    // A grabs 2 (its fair share once B becomes active is 2)
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    // B becomes active: with 2 active, fairShare = ceil(4/2) = 2
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.ACCEPT);
+    // both at fair share now -> further admits rejected (over share)
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.REJECT);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void projectOverShareIsRejectedWhileOtherIsUnder() {
+    var ac = new AdmissionController(4);
+
+    // A fills the whole buffer while alone
+    for (int i = 0; i < 4; i++) {
+      assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    }
+    // B arrives: active becomes 2, fairShare = 2. A is at 4 (over), but B is under.
+    // B cannot get in because the global cap is full (A holds all permits).
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.REJECT);
+    // A is over its new share of 2, so A is also rejected.
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void releasingFreesPermitsToUnderServedProject() {
+    var ac = new AdmissionController(4);
+
+    for (int i = 0; i < 4; i++) {
+      ac.admit("A");
+    }
+    // A drains two -> two global permits freed
+    ac.release("A");
+    ac.release("A");
+    assertThat(ac.usage("A")).isEqualTo(2);
+
+    // B now arrives, active = 2, fairShare = 2, B under share, global permits available
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.ACCEPT);
+    // both at share
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.REJECT);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void projectDrainingToZeroLetsOtherReclaimWholeBuffer() {
+    var ac = new AdmissionController(4);
+
+    ac.admit("A");
+    ac.admit("A");
+    ac.admit("B");
+    ac.admit("B");
+
+    // B drains fully to 0
+    ac.release("B");
+    ac.release("B");
+    assertThat(ac.usage("B")).isEqualTo(0);
+
+    // A is now the lone active project: fairShare = 4, can reclaim the freed permits
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.usage("A")).isEqualTo(4);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void invariantHoldsAcrossInterleavedAdmitRelease() {
+    var ac = new AdmissionController(8);
+
+    ac.admit("A");
+    ac.admit("B");
+    ac.admit("A");
+    ac.admit("C");
+    ac.release("A");
+    ac.admit("B");
+    ac.admit("C");
+    ac.release("C");
+    ac.admit("A");
+
+    assertInvariant(ac);
+  }
+
+  @Test
+  void overShareRejectedWhileGlobalPermitsRemain() {
+    // Buffer 4, two active projects -> fair share 2. A is at its share but a global permit is still
+    // free, so the rejection is tier-2 (over share), not tier-1 (global cap). The permit A briefly
+    // acquired must be handed back.
+    var ac = new AdmissionController(4);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.ACCEPT);
+    assertThat(ac.admit("B")).isEqualTo(AdmitResult.ACCEPT);
+
+    int before = ac.permitsInUse();
+    // A is at fair share (2) with one global permit still free -> tier-2 reject, permit returned.
+    assertThat(ac.admit("A")).isEqualTo(AdmitResult.REJECT);
+    assertThat(ac.permitsInUse()).isEqualTo(before);
+    assertInvariant(ac);
+  }
+
+  @Test
+  void releasingMoreThanAdmittedThrows() {
+    // Admit once then release twice: the first release removes the key, so the second finds no
+    // matching admit (usage.get -> null) and must fail rather than drive usage negative.
+    var ac = new AdmissionController(4);
+    ac.admit("A");
+    ac.release("A");
+
+    assertThatThrownBy(() -> ac.release("A"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("release without matching admit");
+  }
+
+  @Test
+  void releasingNeverAdmittedProjectThrows() {
+    var ac = new AdmissionController(4);
+    assertThatThrownBy(() -> ac.release("never-admitted"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("release without matching admit");
+  }
+
+  private static void assertInvariant(AdmissionController ac) {
+    assertThat(ac.permitsInUse()).isEqualTo(ac.totalUsage());
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/DefaultTransferProcessRunnerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/DefaultTransferProcessRunnerTest.java
@@ -1,53 +1,277 @@
 package care.smith.fts.rda;
 
 import static care.smith.fts.api.rda.BundleSender.*;
-import static java.lang.Thread.sleep;
+import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static reactor.core.publisher.Mono.just;
-import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.BundleSender;
+import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.TransferProcessRunner.Phase;
+import care.smith.fts.rda.TransferProcessRunner.StartResult;
+import care.smith.fts.rda.TransferProcessRunner.StartResult.Accepted;
+import care.smith.fts.rda.TransferProcessRunner.Status;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import org.hl7.fhir.r4.model.Bundle;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
 
 class DefaultTransferProcessRunnerTest {
 
-  private DefaultTransferProcessRunner runner;
+  private static final Duration TIMEOUT = Duration.ofSeconds(2);
 
-  @BeforeEach
-  void setUp() {
-    runner = new DefaultTransferProcessRunner(new ObjectMapper());
+  private static RdaRunnerConfig config(int globalBufferMax) {
+    var c = new RdaRunnerConfig();
+    c.setGlobalBufferMax(globalBufferMax);
+    return c;
+  }
+
+  private static Bundle oneEntryBundle() {
+    return new Bundle().addEntry(new Bundle().getEntryFirstRep());
+  }
+
+  private static TransportBundle transport() {
+    return new TransportBundle(oneEntryBundle(), "transferId");
+  }
+
+  private static TransferProcessDefinition process(
+      String project, Deidentificator deid, BundleSender sender) {
+    return new TransferProcessDefinition(
+        project, new TransferProcessConfig(null, null), deid, sender);
+  }
+
+  private static void await(BooleanSupplier condition) {
+    var deadline = System.nanoTime() + TIMEOUT.toNanos();
+    while (!condition.getAsBoolean()) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError("condition not met within " + TIMEOUT);
+      }
+      Thread.onSpinWait();
+    }
+  }
+
+  private static void awaitPhase(
+      DefaultTransferProcessRunner runner, String processId, Predicate<Status> p) {
+    await(() -> p.test(runner.status(processId).block()));
   }
 
   @Test
-  void runMockTestSuccessfully() throws InterruptedException {
+  void runMockTestSuccessfully() {
     BundleSender.Result result = new Result();
-    TransferProcessDefinition process =
-        new TransferProcessDefinition(
-            "test",
-            new TransferProcessConfig(null, null),
-            (b) -> Mono.just(new Bundle().addEntry(new Bundle().getEntryFirstRep())),
-            (b) -> just(result));
+    var proc = process("test", (b) -> just(oneEntryBundle()), (b) -> just(result));
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(proc), config(256));
 
-    String processId =
-        runner.start(
-            process,
-            Mono.just(
-                new TransportBundle(
-                    new Bundle().addEntry(new Bundle().getEntryFirstRep()), "transferId")));
-    sleep(500L);
-    create(runner.status(processId))
-        .assertNext(
-            r -> {
-              assertThat(r.phase()).isEqualTo(Phase.COMPLETED);
-              assertThat(r.receivedResources()).isEqualTo(1);
-              assertThat(r.sentResources()).isEqualTo(1);
-            })
-        .verifyComplete();
+    var start = runner.start(proc, Mono.just(transport()));
+    assertThat(start).isInstanceOf(Accepted.class);
+    var processId = ((Accepted) start).processId();
+
+    awaitPhase(runner, processId, s -> s.phase() == Phase.COMPLETED);
+    var status = runner.status(processId).block();
+    assertThat(status.receivedResources()).isEqualTo(1);
+    assertThat(status.sentResources()).isEqualTo(1);
+  }
+
+  @Test
+  void startWithUnconfiguredProjectReleasesPermitAndRejects() {
+    // The runner only wires drainers for the projects present at construction. Starting a process
+    // whose project was never configured passes admission (global) but finds no drainer; the
+    // defensive path must release the permit and reject rather than leak.
+    var known = process("known", (b) -> just(oneEntryBundle()), (b) -> just(new Result()));
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(known), config(4));
+
+    var unknown = process("unknown", (b) -> just(oneEntryBundle()), (b) -> just(new Result()));
+    var result = runner.start(unknown, Mono.just(transport()));
+
+    assertThat(result).isInstanceOf(StartResult.Rejected.class);
+    assertThat(runner.permitsInUse()).isZero();
+  }
+
+  @Test
+  void statusForUnknownProcessErrors() {
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(), config(4));
+    assertThatThrownBy(() -> runner.status("does-not-exist").block())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void admissionRejectsWhenBufferFull() {
+    // globalBufferMax = 1: one in-flight bundle that never completes saturates the buffer.
+    var blocking = new BlockingSender();
+    var proc = process("test", (b) -> just(oneEntryBundle()), blocking);
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(proc), config(1));
+
+    var first = runner.start(proc, Mono.just(transport()));
+    assertThat(first).isInstanceOf(Accepted.class);
+    await(() -> blocking.inFlight.get() == 1);
+
+    var second = runner.start(proc, Mono.just(transport()));
+    assertThat(second).isInstanceOf(StartResult.Rejected.class);
+
+    blocking.complete();
+    await(() -> runner.start(proc, Mono.just(transport())) instanceof Accepted);
+    blocking.complete();
+  }
+
+  @Test
+  void permitReleasedOnSendError() {
+    // globalBufferMax = 1: if the permit leaked on error, the follow-up admission would be
+    // rejected.
+    BundleSender failing = (b) -> Mono.error(new RuntimeException("boom"));
+    var proc = process("test", (b) -> just(oneEntryBundle()), failing);
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(proc), config(1));
+
+    var processId = ((Accepted) runner.start(proc, Mono.just(transport()))).processId();
+    awaitPhase(runner, processId, s -> s.phase() == Phase.ERROR);
+
+    assertThat(runner.start(proc, Mono.just(transport()))).isInstanceOf(Accepted.class);
+  }
+
+  @Test
+  void permitReleasedOnCancellation() {
+    // A send that never terminates; cancelling the drainer subscription must still release.
+    var blocking = new BlockingSender();
+    var proc = process("test", (b) -> just(oneEntryBundle()), blocking);
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), of(proc), config(1));
+
+    runner.start(proc, Mono.just(transport()));
+    await(() -> blocking.inFlight.get() == 1);
+
+    // Cancel the in-flight send via the drainer's subscription. doFinally(release) must fire.
+    runner.disposeAllDrainers();
+
+    await(() -> runner.permitsInUse() == 0);
+    assertThat(runner.permitsInUse()).isZero();
+  }
+
+  @Test
+  void sharedBaseUrlSharesOneDrainerWithMinConcurrency() {
+    var senderA = new FixedDestinationSender("http://blaze:8080/fhir", 4);
+    var senderB = new FixedDestinationSender("http://blaze:8080/fhir", 2);
+    var pA = process("a", (b) -> just(oneEntryBundle()), senderA);
+    var pB = process("b", (b) -> just(oneEntryBundle()), senderB);
+
+    var runner = new DefaultTransferProcessRunner(new ObjectMapper(), List.of(pA, pB), config(256));
+
+    assertThat(runner.drainerConcurrencyFor("a")).isEqualTo(2);
+    assertThat(runner.drainerConcurrencyFor("b")).isEqualTo(2);
+    assertThat(runner.drainerConcurrencyFor("a")).isEqualTo(runner.drainerConcurrencyFor("b"));
+    assertThat(runner.start(pA, Mono.just(transport()))).isInstanceOf(Accepted.class);
+    assertThat(runner.start(pB, Mono.just(transport()))).isInstanceOf(Accepted.class);
+  }
+
+  @Test
+  void mismatchedSendConcurrencyOnSharedHdsLogsWarn() {
+    var logger = (Logger) LoggerFactory.getLogger(DefaultTransferProcessRunner.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      var pA =
+          process(
+              "a",
+              (b) -> just(oneEntryBundle()),
+              new FixedDestinationSender("http://blaze:8080/fhir", 4));
+      var pB =
+          process(
+              "b",
+              (b) -> just(oneEntryBundle()),
+              new FixedDestinationSender("http://blaze:8080/fhir", 2));
+      new DefaultTransferProcessRunner(new ObjectMapper(), List.of(pA, pB), config(256));
+
+      assertThat(appender.list)
+          .anySatisfy(
+              e -> {
+                assertThat(e.getLevel()).isEqualTo(Level.WARN);
+                assertThat(e.getFormattedMessage()).contains("different sendConcurrency");
+              });
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  @Test
+  void matchedSendConcurrencyOnSharedHdsDoesNotWarn() {
+    var logger = (Logger) LoggerFactory.getLogger(DefaultTransferProcessRunner.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      var pA =
+          process(
+              "a",
+              (b) -> just(oneEntryBundle()),
+              new FixedDestinationSender("http://blaze:8080/fhir", 2));
+      var pB =
+          process(
+              "b",
+              (b) -> just(oneEntryBundle()),
+              new FixedDestinationSender("http://blaze:8080/fhir", 2));
+      new DefaultTransferProcessRunner(new ObjectMapper(), List.of(pA, pB), config(256));
+
+      assertThat(appender.list).noneSatisfy(e -> assertThat(e.getLevel()).isEqualTo(Level.WARN));
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  /** Sender that holds each send open until {@link #complete()} releases one. */
+  private static final class BlockingSender implements BundleSender {
+    final AtomicInteger inFlight = new AtomicInteger();
+    private volatile MonoSink<Result> pending;
+
+    @Override
+    public Mono<Result> send(Bundle bundles) {
+      return Mono.<Result>create(
+              sink -> {
+                pending = sink;
+                inFlight.incrementAndGet();
+              })
+          .doFinally(s -> inFlight.decrementAndGet());
+    }
+
+    void complete() {
+      await(() -> pending != null);
+      var p = pending;
+      pending = null;
+      p.success(new Result());
+    }
+  }
+
+  private static final class FixedDestinationSender implements BundleSender {
+    private final String destinationId;
+    private final int sendConcurrency;
+
+    FixedDestinationSender(String destinationId, int sendConcurrency) {
+      this.destinationId = destinationId;
+      this.sendConcurrency = sendConcurrency;
+    }
+
+    @Override
+    public String destinationId() {
+      return destinationId;
+    }
+
+    @Override
+    public int sendConcurrency() {
+      return sendConcurrency;
+    }
+
+    @Override
+    public Mono<Result> send(Bundle bundles) {
+      return just(new Result());
+    }
   }
 }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/HdsDrainerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/HdsDrainerTest.java
@@ -1,0 +1,221 @@
+package care.smith.fts.rda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.core.publisher.Mono.just;
+
+import care.smith.fts.api.TransportBundle;
+import care.smith.fts.api.rda.BundleSender;
+import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.rda.DefaultTransferProcessRunner.DrainItem;
+import care.smith.fts.rda.DefaultTransferProcessRunner.ProcessStatus;
+import care.smith.fts.rda.TransferProcessRunner.Phase;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
+import reactor.core.publisher.Sinks;
+
+class HdsDrainerTest {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+  private static void await(BooleanSupplier condition) {
+    var deadline = System.nanoTime() + TIMEOUT.toNanos();
+    while (!condition.getAsBoolean()) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError("condition not met within " + TIMEOUT);
+      }
+      Thread.onSpinWait();
+    }
+  }
+
+  private static Bundle oneEntryBundle() {
+    return new Bundle().addEntry(new Bundle().getEntryFirstRep());
+  }
+
+  private static final Deidentificator IDENTITY = (b) -> just(oneEntryBundle());
+
+  private static DrainItem item(String project, ProcessStatus status, BundleSender sender) {
+    return new DrainItem(
+        project, status, IDENTITY, sender, Mono.just(new TransportBundle(oneEntryBundle(), "tid")));
+  }
+
+  @Test
+  void concurrentInFlightNeverExceedsNh() {
+    int nH = 2;
+    var admission = new AdmissionController(100);
+    var sender = new GatedSender();
+    var drainer = new HdsDrainer("http://blaze/fhir", nH, admission);
+
+    // submit 5 items; only N_H may be in-flight at once
+    for (int i = 0; i < 5; i++) {
+      admission.admit("p");
+      drainer.submit(item("p", new ProcessStatus(), sender));
+    }
+
+    await(() -> sender.inFlight.get() == nH);
+    // give the drainer a chance to (wrongly) over-admit; it must stay at N_H
+    assertThat(sender.peakInFlight.get()).isEqualTo(nH);
+    assertThat(sender.inFlight.get()).isEqualTo(nH);
+
+    // drain everything; peak must never have exceeded N_H
+    sender.releaseAll(5);
+    await(() -> admission.permitsInUse() == 0);
+    assertThat(sender.peakInFlight.get()).isLessThanOrEqualTo(nH);
+
+    drainer.dispose();
+  }
+
+  @Test
+  void overflowBuffersWithoutBlockingSubmit() {
+    var admission = new AdmissionController(100);
+    var sender = new GatedSender();
+    var drainer = new HdsDrainer("http://blaze/fhir", 1, admission);
+
+    // Submitting many more than N_H must return immediately (non-blocking); extras buffer.
+    long start = System.nanoTime();
+    for (int i = 0; i < 20; i++) {
+      admission.admit("p");
+      drainer.submit(item("p", new ProcessStatus(), sender));
+    }
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertThat(elapsedMs).isLessThan(500);
+
+    await(() -> sender.inFlight.get() == 1);
+    assertThat(sender.peakInFlight.get()).isEqualTo(1);
+
+    sender.releaseAll(20);
+    await(() -> admission.permitsInUse() == 0);
+
+    drainer.dispose();
+  }
+
+  @Test
+  void errorOnOneItemDoesNotTerminateDrainer() {
+    var admission = new AdmissionController(100);
+    BundleSender failing = (b) -> Mono.error(new RuntimeException("boom"));
+    var drainer = new HdsDrainer("http://blaze/fhir", 1, admission);
+
+    var s1 = new ProcessStatus();
+    admission.admit("p");
+    drainer.submit(item("p", s1, failing));
+    await(() -> s1.snapshot("1").phase() == Phase.ERROR);
+
+    // drainer must still process subsequent items
+    var ok = new GatedSender();
+    var s2 = new ProcessStatus();
+    admission.admit("p");
+    drainer.submit(item("p", s2, ok));
+    await(() -> ok.inFlight.get() == 1);
+    ok.releaseAll(1);
+    await(() -> s2.snapshot("2").phase() == Phase.COMPLETED);
+    await(() -> admission.permitsInUse() == 0);
+
+    drainer.dispose();
+  }
+
+  @Test
+  void exposesDestinationId() {
+    var drainer = new HdsDrainer("http://blaze:8080/fhir", 1, new AdmissionController(1));
+    assertThat(drainer.destinationId()).isEqualTo("http://blaze:8080/fhir");
+    drainer.dispose();
+  }
+
+  /**
+   * The drain is designed never to terminate, so an upstream error is "should not happen". We force
+   * one through the sink (via reflection) to exercise the defensive error callback that logs it.
+   */
+  @Test
+  void unexpectedUpstreamErrorIsLogged() throws Exception {
+    var logger = (Logger) LoggerFactory.getLogger(HdsDrainer.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      var drainer = new HdsDrainer("http://blaze/fhir", 1, new AdmissionController(1));
+
+      Field sinkField = HdsDrainer.class.getDeclaredField("sink");
+      sinkField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Sinks.Many<DrainItem> sink = (Sinks.Many<DrainItem>) sinkField.get(drainer);
+      sink.tryEmitError(new RuntimeException("forced"));
+
+      await(
+          () ->
+              appender.list.stream()
+                  .anyMatch(e -> e.getFormattedMessage().contains("terminated unexpectedly")));
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  /** Completion is equally "should not happen"; forcing it exercises the complete callback. */
+  @Test
+  void unexpectedCompletionIsLogged() throws Exception {
+    var logger = (Logger) LoggerFactory.getLogger(HdsDrainer.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      var drainer = new HdsDrainer("http://blaze/fhir", 1, new AdmissionController(1));
+
+      Field sinkField = HdsDrainer.class.getDeclaredField("sink");
+      sinkField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Sinks.Many<DrainItem> sink = (Sinks.Many<DrainItem>) sinkField.get(drainer);
+      sink.tryEmitComplete();
+
+      await(
+          () ->
+              appender.list.stream()
+                  .anyMatch(e -> e.getFormattedMessage().contains("completed unexpectedly")));
+    } finally {
+      logger.detachAppender(appender);
+    }
+  }
+
+  /**
+   * Sender whose sends stay in-flight until explicitly released. In-flight is measured as the
+   * window from subscription (request issued) until just before the terminal signal is emitted,
+   * which is the semantically meaningful "concurrent requests against the HDS" window.
+   * (Decrementing in doFinally would race with flatMap subscribing the replacement inner,
+   * transiently reading N_H+1 even though only N_H requests are actually outstanding.)
+   */
+  private static final class GatedSender implements BundleSender {
+    final AtomicInteger inFlight = new AtomicInteger();
+    final AtomicInteger peakInFlight = new AtomicInteger();
+    private final java.util.concurrent.ConcurrentLinkedQueue<MonoSink<Result>> pending =
+        new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+    @Override
+    public Mono<Result> send(Bundle bundles) {
+      return Mono.create(
+          sink -> {
+            pending.add(sink);
+            int now = inFlight.incrementAndGet();
+            peakInFlight.accumulateAndGet(now, Math::max);
+          });
+    }
+
+    void releaseAll(int expected) {
+      for (int released = 0; released < expected; ) {
+        var sink = pending.poll();
+        if (sink != null) {
+          inFlight.decrementAndGet();
+          sink.success(new Result());
+          released++;
+        } else {
+          Thread.onSpinWait();
+        }
+      }
+    }
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderConfigTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderConfigTest.java
@@ -1,0 +1,33 @@
+package care.smith.fts.rda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import care.smith.fts.util.HttpClientConfig;
+import org.junit.jupiter.api.Test;
+
+class FhirStoreBundleSenderConfigTest {
+
+  private static final HttpClientConfig SERVER = new HttpClientConfig("http://localhost");
+
+  @Test
+  void nullMaxConcurrencyUsesDefault() {
+    assertThat(new FhirStoreBundleSenderConfig(SERVER, "project", null))
+        .extracting(FhirStoreBundleSenderConfig::maxConcurrency)
+        .isEqualTo(2);
+  }
+
+  @Test
+  void explicitMaxConcurrencyIsKept() {
+    assertThat(new FhirStoreBundleSenderConfig(SERVER, "project", 5))
+        .extracting(FhirStoreBundleSenderConfig::maxConcurrency)
+        .isEqualTo(5);
+  }
+
+  @Test
+  void twoArgConstructorUsesDefaultMaxConcurrency() {
+    var config = new FhirStoreBundleSenderConfig(SERVER, "project");
+    assertThat(config.server()).isEqualTo(SERVER);
+    assertThat(config.project()).isEqualTo("project");
+    assertThat(config.maxConcurrency()).isEqualTo(2);
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactoryTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactoryTest.java
@@ -1,0 +1,48 @@
+package care.smith.fts.rda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import care.smith.fts.api.rda.BundleSender;
+import care.smith.fts.util.DefaultRetryStrategy;
+import care.smith.fts.util.HttpClientConfig;
+import care.smith.fts.util.WebClientFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class FhirStoreBundleSenderFactoryTest {
+
+  @Mock WebClientFactory clientFactory;
+  @Mock WebClient webClient;
+
+  @Test
+  void getConfigTypeReturnsImplConfig() {
+    var factory =
+        new FhirStoreBundleSenderFactory(
+            clientFactory, new DefaultRetryStrategy(new SimpleMeterRegistry()));
+    assertThat(factory.getConfigType()).isEqualTo(FhirStoreBundleSenderConfig.class);
+  }
+
+  @Test
+  void createBuildsSenderFromConfig() {
+    var server = new HttpClientConfig("http://blaze:8080/fhir");
+    var implConfig = new FhirStoreBundleSenderConfig(server, "project", 4);
+    given(clientFactory.create(server)).willReturn(webClient);
+
+    var factory =
+        new FhirStoreBundleSenderFactory(
+            clientFactory, new DefaultRetryStrategy(new SimpleMeterRegistry()));
+    BundleSender sender = factory.create(new BundleSender.Config(), implConfig);
+
+    assertThat(sender).isNotNull();
+    assertThat(sender.destinationId()).isEqualTo("http://blaze:8080/fhir");
+    assertThat(sender.sendConcurrency()).isEqualTo(4);
+    verify(clientFactory).create(server);
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderIT.java
@@ -59,8 +59,11 @@ class FhirStoreBundleSenderIT extends AbstractConnectionScenarioIT {
 
   @BeforeEach
   void setUp(WireMockRuntimeInfo wireMockRuntime, @Autowired WebClientFactory clientFactory) {
-    var client = clientFactory.create(clientConfig(wireMockRuntime));
-    bundleSender = new FhirStoreBundleSender(client, new DefaultRetryStrategy(meterRegistry));
+    var clientConfig = clientConfig(wireMockRuntime);
+    var client = clientFactory.create(clientConfig);
+    bundleSender =
+        new FhirStoreBundleSender(
+            client, new DefaultRetryStrategy(meterRegistry), clientConfig.baseUrl(), 2);
     wireMock = wireMockRuntime.getWireMock();
   }
 

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderTest.java
@@ -1,0 +1,80 @@
+package care.smith.fts.rda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
+
+import care.smith.fts.util.DefaultRetryStrategy;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/** Unit tests for the HDS grouping key derived from the base URL. */
+class FhirStoreBundleSenderTest {
+
+  private static String destinationId(String baseUrl) {
+    return new FhirStoreBundleSender(
+            null, new DefaultRetryStrategy(new SimpleMeterRegistry()), baseUrl, 2)
+        .destinationId();
+  }
+
+  private static FhirStoreBundleSender sender(ExchangeFunction exchange) {
+    var client =
+        WebClient.builder().baseUrl("http://blaze/fhir").exchangeFunction(exchange).build();
+    return new FhirStoreBundleSender(
+        client, new DefaultRetryStrategy(new SimpleMeterRegistry()), "http://blaze/fhir", 2);
+  }
+
+  @Test
+  void sendPostsTransactionBundleAndReturnsResult() {
+    var sender = sender(req -> Mono.just(ClientResponse.create(OK).build()));
+    var bundle =
+        new Bundle().addEntry(new Bundle.BundleEntryComponent().setResource(new Patient()));
+
+    StepVerifier.create(sender.send(bundle)).expectNextCount(1).verifyComplete();
+  }
+
+  @Test
+  void lowercasesSchemeAndHostButPreservesPathCase() {
+    assertThat(destinationId("HTTP://Blaze:8080/FHIR/Base"))
+        .isEqualTo("http://blaze:8080/FHIR/Base");
+  }
+
+  @Test
+  void stripsTrailingSlashes() {
+    assertThat(destinationId("http://blaze:8080/fhir///")).isEqualTo("http://blaze:8080/fhir");
+  }
+
+  @Test
+  void hostCaseDifferencesShareOneKey() {
+    assertThat(destinationId("http://BLAZE/fhir")).isEqualTo(destinationId("http://blaze/fhir"));
+  }
+
+  @Test
+  void pathCaseDifferencesStayDistinct() {
+    assertThat(destinationId("http://blaze/Fhir")).isNotEqualTo(destinationId("http://blaze/fhir"));
+  }
+
+  @Test
+  void urlWithoutSchemeOrHostIsReturnedTrimmed() {
+    // No scheme/host -> the normalisation branch is skipped and the trimmed value is used as-is.
+    assertThat(destinationId("fhir-store")).isEqualTo("fhir-store");
+  }
+
+  @Test
+  void urlWithSchemeButNoHostIsReturnedTrimmed() {
+    // Scheme present but no authority/host -> the normalisation branch is skipped, trimmed as-is.
+    assertThat(destinationId("file:/var/fhir")).isEqualTo("file:/var/fhir");
+  }
+
+  @Test
+  void malformedUrlFallsBackToRawValue() {
+    // Illegal characters make URI parsing throw; the raw (trimmed) value is used for grouping.
+    assertThat(destinationId("http://h o s t/fhir")).isEqualTo("http://h o s t/fhir");
+  }
+}

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/rest/TransferProcessControllerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/rest/TransferProcessControllerTest.java
@@ -13,10 +13,12 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.api.TransportBundle;
+import care.smith.fts.rda.RdaRunnerConfig;
 import care.smith.fts.rda.TransferProcessConfig;
 import care.smith.fts.rda.TransferProcessDefinition;
 import care.smith.fts.rda.TransferProcessRunner;
 import care.smith.fts.rda.TransferProcessRunner.Phase;
+import care.smith.fts.rda.TransferProcessRunner.StartResult;
 import care.smith.fts.rda.TransferProcessRunner.Status;
 import java.util.stream.Stream;
 import org.hl7.fhir.r4.model.*;
@@ -48,7 +50,9 @@ class TransferProcessControllerTest {
   @BeforeEach
   void setUp() {
     mockRunner = mock(TransferProcessRunner.class);
-    api = new TransferProcessController(mockRunner, of(mockTransferProcess()));
+    var config = new RdaRunnerConfig();
+    config.setRetryAfterSeconds(5);
+    api = new TransferProcessController(mockRunner, of(mockTransferProcess()), config);
   }
 
   @Test
@@ -60,7 +64,7 @@ class TransferProcessControllerTest {
                 resourceStream(new Bundle()))
             .collect(toBundle());
     when(mockRunner.start(any(TransferProcessDefinition.class), any(Mono.class)))
-        .thenReturn(RUNNING_PROCESS_ID);
+        .thenReturn(StartResult.accepted(RUNNING_PROCESS_ID));
 
     var start =
         api.start(
@@ -81,10 +85,32 @@ class TransferProcessControllerTest {
   }
 
   @Test
-  void startNonExistingProjectErrors() {
+  void startRejectedReturns429WithRetryAfter() {
+    var bundle =
+        concat(
+                Stream.of(
+                    new Parameters().addParameter("id", "transfer-142609").setId("transfer-id")),
+                resourceStream(new Bundle()))
+            .collect(toBundle());
     when(mockRunner.start(any(TransferProcessDefinition.class), any(Mono.class)))
-        .thenThrow(new RuntimeException("Project 'non-existent' could not be found"));
+        .thenReturn(StartResult.rejected());
 
+    var start =
+        api.start(
+            "example",
+            Mono.just(bundle),
+            UriComponentsBuilder.fromUriString("http://localhost:1234"));
+
+    create(start)
+        .expectNext(
+            ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .headers(h -> h.add(RETRY_AFTER, "5"))
+                .build())
+        .verifyComplete();
+  }
+
+  @Test
+  void startNonExistingProjectErrors() {
     create(
             api.start(
                 "non-existent",

--- a/util/src/main/java/care/smith/fts/util/RdaBackpressureRetryStrategy.java
+++ b/util/src/main/java/care/smith/fts/util/RdaBackpressureRetryStrategy.java
@@ -1,0 +1,191 @@
+package care.smith.fts.util;
+
+import static java.lang.Boolean.parseBoolean;
+import static org.springframework.http.HttpHeaders.RETRY_AFTER;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+/**
+ * {@link RetryStrategy} for sending bundles to the research-domain-agent (RDA).
+ *
+ * <p>Retries on the same conditions as {@link DefaultRetryStrategy} (5xx, timeout, connect) plus
+ * HTTP 429 (Too Many Requests), which the RDA emits as backpressure when its bundle buffer is full.
+ * The two classes of failure are treated differently:
+ *
+ * <ul>
+ *   <li><b>Transient infra errors</b> (5xx, timeout, connect) keep the {@link #MAX_ATTEMPTS}
+ *       attempt cap — they signal a problem unlikely to clear by waiting longer.
+ *   <li><b>429 backpressure</b> is <em>not</em> capped by attempts: the RDA is explicitly asking
+ *       the CDA to slow down, so the bundle keeps retrying until the cumulative backpressure wait
+ *       would exceed {@code maxBackpressureWait}, then gives up. The {@code Retry-After} header
+ *       (integer seconds) is a <em>floor</em> on each wait ({@code max(exponentialBackoff,
+ *       retryAfter)}); the exponential backoff is capped at {@link #MAX_BACKOFF} so the retries
+ *       settle into a steady polling cadence rather than diverging.
+ * </ul>
+ *
+ * Every delay carries upward-only jitter (see {@link #JITTER_FACTOR}). An absent or unparseable
+ * {@code Retry-After} falls back to the (jittered) exponential backoff.
+ */
+@Slf4j
+public class RdaBackpressureRetryStrategy implements RetryStrategy {
+
+  static final long MAX_ATTEMPTS = 3;
+  static final Duration MIN_BACKOFF = Duration.ofSeconds(1);
+  static final double BACKOFF_MULTIPLIER = 2.0;
+
+  /**
+   * Caps the exponential backoff so indefinite 429 retries settle into a steady polling cadence.
+   */
+  static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
+
+  /**
+   * Additive jitter fraction applied on top of the computed delay. Upward-only (never shortens the
+   * wait) so a {@code Retry-After} floor stays a hard floor while concurrent CDAs retrying the same
+   * 429 desynchronise instead of stampeding the RDA in lockstep.
+   */
+  static final double JITTER_FACTOR = 0.5;
+
+  /** Total time a single bundle may spend waiting on 429 backpressure before the CDA gives up. */
+  static final Duration DEFAULT_MAX_BACKPRESSURE_WAIT = Duration.ofMinutes(10);
+
+  private final MeterRegistry meterRegistry;
+  private final Duration maxBackpressureWait;
+  private final boolean retryTimeout;
+
+  public RdaBackpressureRetryStrategy(MeterRegistry meterRegistry) {
+    this(meterRegistry, DEFAULT_MAX_BACKPRESSURE_WAIT);
+  }
+
+  public RdaBackpressureRetryStrategy(MeterRegistry meterRegistry, Duration maxBackpressureWait) {
+    this(
+        meterRegistry,
+        maxBackpressureWait,
+        parseBoolean(System.getProperty("fts.retryTimeout", "true")));
+  }
+
+  public RdaBackpressureRetryStrategy(
+      MeterRegistry meterRegistry, Duration maxBackpressureWait, boolean retryTimeout) {
+    this.meterRegistry = meterRegistry;
+    this.maxBackpressureWait = maxBackpressureWait;
+    this.retryTimeout = retryTimeout;
+  }
+
+  @Override
+  public Retry forRequest(String name) {
+    var counter = meterRegistry.counter("http.client.requests.retries", "request_name", name);
+    return Retry.from(
+        companion -> {
+          // Per-subscription cumulative 429 wait; bounds indefinite backpressure retries.
+          var backpressureWaitMillis = new AtomicLong();
+          return companion.flatMap(
+              retrySignal -> handleRetrySignal(retrySignal, counter, backpressureWaitMillis));
+        });
+  }
+
+  private Mono<Long> handleRetrySignal(
+      Retry.RetrySignal signal, Counter counter, AtomicLong backpressureWaitMillis) {
+    var failure = signal.failure();
+    if (!isRdaBackpressureRetryable(failure)) {
+      return Mono.error(failure);
+    }
+    var backpressure = isTooManyRequests(failure);
+    if (!backpressure && signal.totalRetries() >= MAX_ATTEMPTS) {
+      return Mono.error(
+          Exceptions.retryExhausted(
+              "Retries exhausted: " + signal.totalRetries() + "/" + MAX_ATTEMPTS, failure));
+    }
+
+    var delay = jitter(effectiveDelay(exponentialBackoff(signal.totalRetries()), failure));
+
+    if (backpressure
+        && backpressureWaitMillis.addAndGet(delay.toMillis()) > maxBackpressureWait.toMillis()) {
+      return Mono.error(
+          Exceptions.retryExhausted(
+              "RDA backpressure wait exceeded " + maxBackpressureWait, failure));
+    }
+
+    log.debug("RetrySignal {} (attempt {}, delay {})", failure, signal.totalRetries() + 1, delay);
+    return Mono.delay(delay).doOnNext(i -> counter.increment());
+  }
+
+  private static Duration exponentialBackoff(long retriesSoFar) {
+    var millis = MIN_BACKOFF.toMillis() * Math.pow(BACKOFF_MULTIPLIER, retriesSoFar);
+    return Duration.ofMillis((long) Math.min(millis, (double) MAX_BACKOFF.toMillis()));
+  }
+
+  /** Adds {@code U[0, delay * jitterFactor]} to the delay, never reducing it. */
+  private static Duration jitter(Duration delay) {
+    long span = (long) (delay.toMillis() * JITTER_FACTOR);
+    if (span <= 0) {
+      return delay;
+    }
+    return delay.plusMillis(ThreadLocalRandom.current().nextLong(span + 1));
+  }
+
+  /** Applies {@code Retry-After} as a floor on the backoff for 429 responses. */
+  private static Duration effectiveDelay(Duration backoff, Throwable failure) {
+    return retryAfterSeconds(failure)
+        .map(seconds -> max(backoff, Duration.ofSeconds(seconds)))
+        .orElse(backoff);
+  }
+
+  private static Duration max(Duration a, Duration b) {
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+
+  /**
+   * Extracts the {@code Retry-After} value (integer seconds) from a 429 response. HTTP-date form is
+   * out of scope; an absent or unparseable value yields {@link Optional#empty()}.
+   */
+  private static Optional<Long> retryAfterSeconds(Throwable failure) {
+    if (!isTooManyRequests(failure)) {
+      return Optional.empty();
+    }
+    var header = ((WebClientResponseException) failure).getHeaders().getFirst(RETRY_AFTER);
+    if (header == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(Long.parseLong(header.trim()));
+    } catch (NumberFormatException e) {
+      log.warn("Failed to parse Retry-After header: {}", header);
+      return Optional.empty();
+    }
+  }
+
+  private boolean isRdaBackpressureRetryable(Throwable e) {
+    return is5xxServerError(e) || isTimeout(e) || isConnectException(e) || isTooManyRequests(e);
+  }
+
+  private static boolean isTooManyRequests(Throwable e) {
+    return e instanceof WebClientResponseException
+        && ((WebClientResponseException) e).getStatusCode().value()
+            == HttpStatus.TOO_MANY_REQUESTS.value();
+  }
+
+  private boolean isTimeout(Throwable e) {
+    return retryTimeout && e instanceof TimeoutException;
+  }
+
+  private static boolean is5xxServerError(Throwable e) {
+    return e instanceof WebClientResponseException
+        && ((WebClientResponseException) e).getStatusCode().is5xxServerError();
+  }
+
+  private static boolean isConnectException(Throwable e) {
+    return e instanceof WebClientRequestException;
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/RdaBackpressureRetryStrategyTest.java
+++ b/util/src/test/java/care/smith/fts/util/RdaBackpressureRetryStrategyTest.java
@@ -1,0 +1,261 @@
+package care.smith.fts.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class RdaBackpressureRetryStrategyTest {
+
+  private static final String NAME = "testRequest";
+
+  private static reactor.util.retry.Retry backpressure(MeterRegistry registry) {
+    return new RdaBackpressureRetryStrategy(registry).forRequest(NAME);
+  }
+
+  private static reactor.util.retry.Retry backpressure(MeterRegistry registry, Duration maxWait) {
+    return new RdaBackpressureRetryStrategy(registry, maxWait).forRequest(NAME);
+  }
+
+  private static reactor.util.retry.Retry backpressure(
+      MeterRegistry registry, boolean retryTimeout) {
+    return new RdaBackpressureRetryStrategy(
+            registry, RdaBackpressureRetryStrategy.DEFAULT_MAX_BACKPRESSURE_WAIT, retryTimeout)
+        .forRequest(NAME);
+  }
+
+  private static WebClientResponseException responseException(
+      HttpStatusCode status, HttpHeaders headers) {
+    return new WebClientResponseException(
+        status, status.toString(), headers, new byte[0], StandardCharsets.UTF_8, null);
+  }
+
+  private static WebClientResponseException tooManyRequests(String retryAfter) {
+    var headers = new HttpHeaders();
+    if (retryAfter != null) {
+      headers.add(HttpHeaders.RETRY_AFTER, retryAfter);
+    }
+    return responseException(HttpStatus.TOO_MANY_REQUESTS, headers);
+  }
+
+  /** Emits the given failure for the first {@code failures} subscriptions, then succeeds. */
+  private static Mono<String> failingThenSucceeding(int failures, Throwable error) {
+    var attempts = new AtomicInteger();
+    return Mono.defer(
+        () -> attempts.getAndIncrement() < failures ? Mono.error(error) : Mono.just("ok"));
+  }
+
+  @Test
+  void backpressureRetryOn429ThenSucceeds() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono = failingThenSucceeding(1, tooManyRequests(null)).retryWhen(backpressure(registry));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofSeconds(10))
+        .expectNext("ok")
+        .verifyComplete();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void backpressureRetryAfterActsAsFloor() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono = failingThenSucceeding(1, tooManyRequests("5")).retryWhen(backpressure(registry));
+
+    // First retry exponential backoff is ~1s; Retry-After: 5 must lengthen it to >=5s. Upward-only
+    // jitter (<=50%) can stretch it to at most 7.5s, but must never fire before the 5s floor.
+    StepVerifier.withVirtualTime(() -> mono)
+        .expectSubscription()
+        .expectNoEvent(Duration.ofMillis(4999))
+        .thenAwait(Duration.ofSeconds(3))
+        .expectNext("ok")
+        .verifyComplete();
+  }
+
+  @Test
+  void backpressureNoRetryAfterFallsBackToBackoff() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono = failingThenSucceeding(1, tooManyRequests(null)).retryWhen(backpressure(registry));
+
+    // No Retry-After -> exponential backoff (~1s). Should not fire before the backoff elapses.
+    StepVerifier.withVirtualTime(() -> mono)
+        .expectSubscription()
+        .expectNoEvent(Duration.ofMillis(900))
+        .thenAwait(Duration.ofSeconds(2))
+        .expectNext("ok")
+        .verifyComplete();
+  }
+
+  @Test
+  void backpressureDoesNotRetryNonRetryableError() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var error = responseException(HttpStatus.BAD_REQUEST, new HttpHeaders());
+    var mono = failingThenSucceeding(1, error).retryWhen(backpressure(registry));
+
+    StepVerifier.withVirtualTime(() -> mono).expectErrorMatches(t -> t == error).verify();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isZero();
+  }
+
+  @Test
+  void backpressure429RetriesBeyondAttemptCap() {
+    // 429 must NOT be capped by MAX_ATTEMPTS: 5 backpressure responses still succeed.
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono = failingThenSucceeding(5, tooManyRequests("1")).retryWhen(backpressure(registry));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofMinutes(1))
+        .expectNext("ok")
+        .verifyComplete();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isEqualTo(5.0);
+  }
+
+  @Test
+  void backpressure429ExhaustsWhenMaxWaitExceeded() {
+    // With a 3s budget and a 1s Retry-After floor per retry, the cumulative wait soon exceeds it.
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono =
+        failingThenSucceeding(Integer.MAX_VALUE, tooManyRequests("1"))
+            .retryWhen(backpressure(registry, Duration.ofSeconds(3)));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofMinutes(1))
+        .expectErrorMatches(Exceptions::isRetryExhausted)
+        .verify();
+  }
+
+  @Test
+  void timeoutRetriedWhenRetryTimeoutEnabled() {
+    // retryTimeout=true: a TimeoutException is retryable (covers isTimeout's enabled+instanceof
+    // branches independently of the ambient fts.retryTimeout system property).
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono =
+        failingThenSucceeding(1, new TimeoutException("timeout"))
+            .retryWhen(backpressure(registry, true));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofSeconds(10))
+        .expectNext("ok")
+        .verifyComplete();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void timeoutNotRetriedWhenRetryTimeoutDisabled() {
+    // retryTimeout=false short-circuits isTimeout (covers the disabled branch): a TimeoutException
+    // is no longer retryable and propagates immediately, regardless of the ambient flag value.
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var error = new TimeoutException("timeout");
+    var mono = failingThenSucceeding(1, error).retryWhen(backpressure(registry, false));
+
+    StepVerifier.withVirtualTime(() -> mono).expectErrorMatches(t -> t == error).verify();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isZero();
+  }
+
+  @Test
+  void backpressureRetriesConnectException() {
+    // Connect failure is retryable (non-429): exercises the isConnectException predicate branch.
+    // Pinned to retryTimeout=true so isTimeout evaluates its instanceof check against a non-timeout
+    // error (covers the instanceof==false branch independently of the ambient fts.retryTimeout).
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var error =
+        new WebClientRequestException(
+            new IOException("connection refused"),
+            HttpMethod.POST,
+            URI.create("http://hds"),
+            new HttpHeaders());
+    var mono = failingThenSucceeding(1, error).retryWhen(backpressure(registry, true));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofSeconds(10))
+        .expectNext("ok")
+        .verifyComplete();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void transientErrorExhaustsAtAttemptCap() {
+    // 5xx keeps the attempt cap: persistent infra failure gives up after MAX_ATTEMPTS.
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var error = responseException(HttpStatus.SERVICE_UNAVAILABLE, new HttpHeaders());
+    var mono = failingThenSucceeding(Integer.MAX_VALUE, error).retryWhen(backpressure(registry));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofMinutes(1))
+        .expectErrorMatches(Exceptions::isRetryExhausted)
+        .verify();
+  }
+
+  @Test
+  void backpressureUnparseableRetryAfterFallsBackToBackoff() {
+    // A non-numeric Retry-After must be ignored (no floor), falling back to exponential backoff.
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono =
+        failingThenSucceeding(1, tooManyRequests("not-a-number")).retryWhen(backpressure(registry));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .expectSubscription()
+        .expectNoEvent(Duration.ofMillis(900))
+        .thenAwait(Duration.ofSeconds(2))
+        .expectNext("ok")
+        .verifyComplete();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void jitterIsANoOpForSubMillisecondDelays() throws Exception {
+    // Guard branch: when delay * jitterFactor rounds to <= 0 the delay is returned unchanged. The
+    // public strategy never produces so small a delay (min backoff is 1s), so exercise it directly.
+    Method jitter = RdaBackpressureRetryStrategy.class.getDeclaredMethod("jitter", Duration.class);
+    jitter.setAccessible(true);
+
+    assertThat(jitter.invoke(null, Duration.ZERO)).isEqualTo(Duration.ZERO);
+    assertThat(jitter.invoke(null, Duration.ofMillis(1))).isEqualTo(Duration.ofMillis(1));
+  }
+
+  @Test
+  void defaultStrategyStillDoesNotRetry429() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+    var mono =
+        failingThenSucceeding(1, tooManyRequests("1"))
+            .retryWhen(new DefaultRetryStrategy(registry).forRequest(NAME));
+
+    StepVerifier.withVirtualTime(() -> mono)
+        .thenAwait(Duration.ofSeconds(10))
+        .expectErrorMatches(t -> t instanceof WebClientResponseException)
+        .verify();
+
+    assertThat(registry.counter("http.client.requests.retries", "request_name", NAME).count())
+        .isZero();
+  }
+}


### PR DESCRIPTION
## Overview

Adds a three-tier backpressure system to the research-domain-agent (RDA) and teaches the clinical-domain-agent (CDA) to honor it.

**RDA side**
1. **Tier-1 global hard cap + Tier-2 elastic per-project fair share** (`AdmissionController`): a semaphore bounds total bundles in the system; each project's fair share is recomputed per admission against the active-project count, so a lone project may fill the buffer while N active projects each get `ceil(max/N)`.
2. **Tier-3 per-HDS drain concurrency** (`HdsDrainer`): all work for one FHIR store funnels through a single sink drained by `flatMap(N_H)`, where `N_H = min(sendConcurrency)` across projects sharing that destination. Permits release on every terminal signal (success/error/cancel).
3. Rejected admissions return `429 + Retry-After`.

**CDA side**
- `rdaBackpressureRetryStrategy` retries on HTTP 429, using `Retry-After` as a *floor* on exponential backoff.

## Review-driven refinements (latest commit)

- **429 not attempt-capped**: transient infra errors (5xx/timeout/connect) keep the 3-attempt cap; 429 retries until a configurable cumulative-wait budget (`RdaBundleSenderConfig.maxBackpressureWait`, default 10m) is exceeded — the CDA keeps slowing down instead of dropping a patient after ~7s.
- **Backoff capped at 30s** so indefinite 429 retries poll at a steady cadence.
- **Upward-only jitter** on every retry delay so concurrent CDAs desync instead of stampeding; jitter never shortens the wait, so `Retry-After` stays a hard floor.
- **HDS grouping key** lowercases only scheme + host (path case preserved, RFC 3986).
- **`sendConcurrency()` defaults to `2`**, matching `FhirStoreBundleSenderConfig`'s default `maxConcurrency` so unconfigured senders agree on the per-HDS drain width.

## Verification

- `RetryStrategiesTest` 8/8 · RDA suite 30/30 (incl. new `FhirStoreBundleSenderTest`) · CDA `RdaBundleSenderIT`/`FactoryIT` 18/18 (incl. `tooManyRequestsIsRetried`)
- Checkstyle: 0 violations across util, api, research-domain-agent, clinical-domain-agent
