### PR TITLE
Refactor RetryStrategy into injectable interface

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStep.java
@@ -1,7 +1,6 @@
 package care.smith.fts.cda.impl;
 
 import static care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils.buildRegistry;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.ConsentedPatientBundle;
@@ -10,6 +9,7 @@ import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.Deidentificator;
 import care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils;
 import care.smith.fts.cda.services.deidentifhir.GeneratingReplacementProvider;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.error.TransferProcessException;
 import care.smith.fts.util.tca.TcaDomains;
 import care.smith.fts.util.tca.TransportMappingRequest;
@@ -33,6 +33,7 @@ class DeidentifhirStep implements Deidentificator {
   private final DateShiftPreserve preserve;
   private final com.typesafe.config.Config config;
   private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public DeidentifhirStep(
       WebClient tcaClient,
@@ -40,13 +41,15 @@ class DeidentifhirStep implements Deidentificator {
       Duration maxDateShift,
       DateShiftPreserve preserve,
       com.typesafe.config.Config config,
-      MeterRegistry meterRegistry) {
+      MeterRegistry meterRegistry,
+      RetryStrategy retryStrategy) {
     this.tcaClient = tcaClient;
     this.domains = domains;
     this.maxDateShift = maxDateShift;
     this.preserve = preserve;
     this.config = config;
     this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -94,7 +97,7 @@ class DeidentifhirStep implements Deidentificator {
         .onStatus(r -> r.equals(HttpStatus.BAD_REQUEST), DeidentifhirStep::handleBadRequest)
         .bodyToMono(TransportMappingResponse.class)
         .timeout(Duration.ofSeconds(30))
-        .retryWhen(defaultRetryStrategy(meterRegistry, "sendMappingsToTca"))
+        .retryWhen(retryStrategy.forRequest("sendMappingsToTca"))
         .doOnError(DeidentifhirStep::handleError)
         .map(TransportMappingResponse::transferId);
   }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStepFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/DeidentifhirStepFactory.java
@@ -4,6 +4,7 @@ import static com.typesafe.config.ConfigFactory.parseFile;
 import static java.util.Objects.requireNonNull;
 
 import care.smith.fts.api.cda.Deidentificator;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
@@ -13,10 +14,13 @@ public class DeidentifhirStepFactory implements Deidentificator.Factory<Deidenti
 
   private final WebClientFactory clientFactory;
   private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public DeidentifhirStepFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public DeidentifhirStepFactory(
+      WebClientFactory clientFactory, MeterRegistry meterRegistry, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
     this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -36,6 +40,7 @@ public class DeidentifhirStepFactory implements Deidentificator.Factory<Deidenti
         implConfig.maxDateShift(),
         implConfig.dateShiftPreserve(),
         config,
-        meterRegistry);
+        meterRegistry,
+        retryStrategy);
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/EverythingDataSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/EverythingDataSelector.java
@@ -1,14 +1,13 @@
 package care.smith.fts.cda.impl;
 
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.ConsentedPatientBundle;
 import care.smith.fts.api.cda.DataSelector;
 import care.smith.fts.cda.services.PatientIdResolver;
-import io.micrometer.core.instrument.MeterRegistry;
+import care.smith.fts.util.RetryStrategy;
 import java.net.URI;
 import java.time.Duration;
 import java.time.ZoneId;
@@ -30,19 +29,19 @@ public class EverythingDataSelector implements DataSelector {
   private final Config common;
   private final WebClient hdsClient;
   private final PatientIdResolver pidResolver;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
   private final int pageSize;
 
   public EverythingDataSelector(
       Config common,
       WebClient hdsClient,
       PatientIdResolver patientIdResolver,
-      MeterRegistry meterRegistry,
+      RetryStrategy retryStrategy,
       int pageSize) {
     this.common = common;
     this.hdsClient = hdsClient;
     this.pidResolver = patientIdResolver;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
     this.pageSize = pageSize;
   }
 
@@ -69,7 +68,7 @@ public class EverythingDataSelector implements DataSelector {
         .headers(h -> h.setAccept(List.of(APPLICATION_FHIR_JSON)))
         .retrieve()
         .bodyToMono(Bundle.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchEverything"))
+        .retryWhen(retryStrategy.forRequest("fetchEverything"))
         .timeout(Duration.ofSeconds(30))
         .doOnNext(b -> log.trace("Fetched Bundle with {} resources", b.getEntry().size()));
   }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/EverythingDataSelectorFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/EverythingDataSelectorFactory.java
@@ -2,8 +2,8 @@ package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.DataSelector;
 import care.smith.fts.cda.services.FhirResolveService;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("everythingDataSelector")
@@ -11,12 +11,12 @@ public class EverythingDataSelectorFactory
     implements DataSelector.Factory<EverythingDataSelectorConfig> {
 
   private final WebClientFactory clientFactory;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public EverythingDataSelectorFactory(
-      WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+      WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -27,7 +27,7 @@ public class EverythingDataSelectorFactory
   @Override
   public DataSelector create(DataSelector.Config common, EverythingDataSelectorConfig config) {
     var client = clientFactory.create(config.fhirServer());
-    var resolver = new FhirResolveService(client, meterRegistry);
-    return new EverythingDataSelector(common, client, resolver, meterRegistry, config.pageSize());
+    var resolver = new FhirResolveService(client, retryStrategy);
+    return new EverythingDataSelector(common, client, resolver, retryStrategy, config.pageSize());
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
@@ -2,15 +2,14 @@ package care.smith.fts.cda.impl;
 
 import static care.smith.fts.util.ConsentedPatientExtractor.*;
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.fhir.FhirUtils.typedResourceStream;
 import static java.util.stream.Collectors.joining;
 import static org.springframework.web.util.UriComponentsBuilder.*;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.error.TransferProcessException;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -32,13 +31,13 @@ import reactor.core.publisher.Mono;
 class FhirCohortSelector implements CohortSelector {
   private final FhirCohortSelectorConfig config;
   private final WebClient fhirClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public FhirCohortSelector(
-      FhirCohortSelectorConfig config, WebClient fhirClient, MeterRegistry meterRegistry) {
+      FhirCohortSelectorConfig config, WebClient fhirClient, RetryStrategy retryStrategy) {
     this.config = config;
     this.fhirClient = fhirClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -71,7 +70,7 @@ class FhirCohortSelector implements CohortSelector {
         .headers(h -> h.setAccept(List.of(APPLICATION_FHIR_JSON)))
         .retrieve()
         .bodyToMono(Bundle.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchFhirBundle"));
+        .retryWhen(retryStrategy.forRequest("fetchFhirBundle"));
   }
 
   private Mono<Bundle> fetchNextPage(Bundle bundle) {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
@@ -1,19 +1,19 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("fhirCohortSelector")
 public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCohortSelectorConfig> {
 
   private final WebClientFactory clientFactory;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public FhirCohortSelectorFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public FhirCohortSelectorFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -24,6 +24,6 @@ public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCoh
   @Override
   public CohortSelector create(CohortSelector.Config ignored, FhirCohortSelectorConfig config) {
     var client = clientFactory.create(config.server());
-    return new FhirCohortSelector(config, client, meterRegistry);
+    return new FhirCohortSelector(config, client, retryStrategy);
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSender.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSender.java
@@ -1,6 +1,5 @@
 package care.smith.fts.cda.impl;
 
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.fhir.FhirUtils.resourceStream;
 import static care.smith.fts.util.fhir.FhirUtils.toBundle;
 import static java.util.Objects.requireNonNull;
@@ -14,8 +13,8 @@ import static org.springframework.http.HttpStatus.OK;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender;
 import care.smith.fts.util.MediaTypes;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.error.TransferProcessException;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
@@ -31,13 +30,13 @@ import reactor.core.publisher.Mono;
 final class RdaBundleSender implements BundleSender {
   private final RdaBundleSenderConfig config;
   private final WebClient rdaClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public RdaBundleSender(
-      RdaBundleSenderConfig config, WebClient rdaClient, MeterRegistry meterRegistry) {
+      RdaBundleSenderConfig config, WebClient rdaClient, RetryStrategy retryStrategy) {
     this.config = config;
     this.rdaClient = rdaClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -61,7 +60,7 @@ final class RdaBundleSender implements BundleSender {
         .retrieve()
         .toBodilessEntity()
         .flatMap(this::processOrWaitForRDACompleted)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "sendBundleToRda"))
+        .retryWhen(retryStrategy.forRequest("sendBundleToRda"))
         .doOnError(e -> log.error("Unable to send Bundle to RDA: {}", e.getMessage()));
   }
 

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/RdaBundleSenderFactory.java
@@ -1,19 +1,19 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.BundleSender;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("researchDomainAgentBundleSender")
 public class RdaBundleSenderFactory implements BundleSender.Factory<RdaBundleSenderConfig> {
 
   private final WebClientFactory clientFactory;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public RdaBundleSenderFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public RdaBundleSenderFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -24,6 +24,6 @@ public class RdaBundleSenderFactory implements BundleSender.Factory<RdaBundleSen
   @Override
   public BundleSender create(BundleSender.Config commonConfig, RdaBundleSenderConfig implConfig) {
     return new RdaBundleSender(
-        implConfig, clientFactory.create(implConfig.server()), meterRegistry);
+        implConfig, clientFactory.create(implConfig.server()), retryStrategy);
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelector.java
@@ -3,17 +3,16 @@ package care.smith.fts.cda.impl;
 import static care.smith.fts.util.ConsentedPatientExtractor.getPatientIdentifier;
 import static care.smith.fts.util.ConsentedPatientExtractor.processConsentedPatients;
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.fhir.FhirUtils.typedResourceStream;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.error.TransferProcessException;
 import care.smith.fts.util.error.fhir.FhirException;
 import com.google.common.collect.ImmutableMap;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -31,13 +30,13 @@ import reactor.core.publisher.Mono;
 class TcaCohortSelector implements CohortSelector {
   private final TcaCohortSelectorConfig config;
   private final WebClient tcaClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public TcaCohortSelector(
-      TcaCohortSelectorConfig config, WebClient tcaClient, MeterRegistry meterRegistry) {
+      TcaCohortSelectorConfig config, WebClient tcaClient, RetryStrategy retryStrategy) {
     this.config = config;
     this.tcaClient = tcaClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   private String getGicsIdentifierSystem() {
@@ -71,7 +70,7 @@ class TcaCohortSelector implements CohortSelector {
         .retrieve()
         .onStatus(r -> r.equals(BAD_REQUEST), TcaCohortSelector::handleBadRequest)
         .bodyToMono(Bundle.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchBundle"));
+        .retryWhen(retryStrategy.forRequest("fetchBundle"));
   }
 
   private Mono<Bundle> fetchNextPage(Bundle bundle, List<String> identifiers) {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelectorFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/TcaCohortSelectorFactory.java
@@ -1,19 +1,19 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("trustCenterAgentCohortSelector")
 public class TcaCohortSelectorFactory implements CohortSelector.Factory<TcaCohortSelectorConfig> {
 
   private final WebClientFactory clientFactory;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public TcaCohortSelectorFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public TcaCohortSelectorFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -24,6 +24,6 @@ public class TcaCohortSelectorFactory implements CohortSelector.Factory<TcaCohor
   @Override
   public CohortSelector create(CohortSelector.Config ignored, TcaCohortSelectorConfig config) {
     var client = clientFactory.create(config.server());
-    return new TcaCohortSelector(config, client, meterRegistry);
+    return new TcaCohortSelector(config, client, retryStrategy);
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/FhirResolveService.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/FhirResolveService.java
@@ -1,13 +1,12 @@
 package care.smith.fts.cda.services;
 
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static com.google.common.base.Strings.emptyToNull;
 import static java.util.Objects.requireNonNull;
 
 import care.smith.fts.api.ConsentedPatient;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.error.TransferProcessException;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.net.URI;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +23,11 @@ import reactor.core.publisher.Mono;
 public class FhirResolveService implements PatientIdResolver {
 
   private final WebClient hdsClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public FhirResolveService(WebClient hdsClient, MeterRegistry meterRegistry) {
+  public FhirResolveService(WebClient hdsClient, RetryStrategy retryStrategy) {
     this.hdsClient = hdsClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   /**
@@ -61,7 +60,7 @@ public class FhirResolveService implements PatientIdResolver {
         .headers(h -> h.setAccept(List.of(APPLICATION_FHIR_JSON)))
         .retrieve()
         .bodyToMono(Bundle.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchPatientBundleResolvePID"))
+        .retryWhen(retryStrategy.forRequest("fetchPatientBundleResolvePID"))
         .doOnError(
             e -> log.error("Unable to fetch patient identifier from HDS: {}", e.getMessage()))
         .onErrorResume(

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepFactoryIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.api.cda.Deidentificator;
 import care.smith.fts.cda.impl.DeidentifhirStepConfig.TCAConfig;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.tca.TcaDomains;
@@ -25,7 +26,9 @@ class DeidentifhirStepFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new DeidentifhirStepFactory(clientFactory, meterRegistry);
+    factory =
+        new DeidentifhirStepFactory(
+            clientFactory, meterRegistry, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/DeidentifhirStepIT.java
@@ -25,6 +25,7 @@ import care.smith.fts.api.TransportBundle;
 import care.smith.fts.cda.ClinicalDomainAgent;
 import care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.tca.TcaDomains;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
@@ -62,7 +63,15 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
     var domains = new TcaDomains("domain", "domain", "domain");
     var client = clientFactory.create(clientConfig(wireMockRuntime));
     wireMock = wireMockRuntime.getWireMock();
-    step = new DeidentifhirStep(client, domains, ofDays(14), NONE, config, meterRegistry);
+    step =
+        new DeidentifhirStep(
+            client,
+            domains,
+            ofDays(14),
+            NONE,
+            config,
+            meterRegistry,
+            new DefaultRetryStrategy(meterRegistry));
 
     var bundle = generateOnePatient("id1", "2024", "identifierSystem", "identifier1");
     var consentedPatient = new ConsentedPatient("id1", "system");
@@ -180,7 +189,8 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
             ofDays(14),
             NONE,
             dateOnlyConfig,
-            meterRegistry);
+            meterRegistry,
+            new DefaultRetryStrategy(meterRegistry));
 
     var patient = new Patient();
     patient.setId("test-patient");

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -17,7 +18,8 @@ class EverythingDataSelectorFactoryIT {
 
   @BeforeEach
   void setUp(@Autowired MeterRegistry meterRegistry, @Autowired WebClientFactory clientFactory) {
-    factory = new EverythingDataSelectorFactory(clientFactory, meterRegistry);
+    factory =
+        new EverythingDataSelectorFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/EverythingDataSelectorIT.java
@@ -19,6 +19,7 @@ import care.smith.fts.api.cda.DataSelector;
 import care.smith.fts.cda.ClinicalDomainAgent;
 import care.smith.fts.cda.services.PatientIdResolver;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -65,7 +66,11 @@ class EverythingDataSelectorIT extends AbstractConnectionScenarioIT {
     EverythingDataSelectorIT.meterRegistry = meterRegistry;
     dataSelector =
         new EverythingDataSelector(
-            common, client, pidResolver, EverythingDataSelectorIT.meterRegistry, PAGE_SIZE);
+            common,
+            client,
+            pidResolver,
+            new DefaultRetryStrategy(meterRegistry),
+            PAGE_SIZE);
 
     var consentedPolicies = new ConsentedPolicies();
     consentedPolicies.put("pol", new Period(ZonedDateTime.now(), ZonedDateTime.now().plusYears(5)));
@@ -116,7 +121,9 @@ class EverythingDataSelectorIT extends AbstractConnectionScenarioIT {
   @Test
   void noConsentSucceedsIfConsentIgnored() {
     DataSelector.Config common = new DataSelector.Config(true);
-    var dataSelector = new EverythingDataSelector(common, client, pidResolver, meterRegistry, 500);
+    var dataSelector =
+        new EverythingDataSelector(
+            common, client, pidResolver, new DefaultRetryStrategy(meterRegistry), 500);
 
     wireMock.register(fhirStoreRequestWithoutConsent().willReturn(fhirResponse(new Bundle())));
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,7 +21,7 @@ class FhirCohortSelectorFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new FhirCohortSelectorFactory(clientFactory, meterRegistry);
+    factory = new FhirCohortSelectorFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
@@ -12,6 +12,7 @@ import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.test.FhirCohortGenerator;
 import care.smith.fts.test.MockServerUtil;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
@@ -60,7 +61,8 @@ class FhirCohortSelectorIT {
     var config = new FhirCohortSelectorConfig(ignored, PID_SYSTEM, POLICY_SYSTEM, POLICIES);
     this.config = MockServerUtil.clientConfig(wireMockRuntime);
     var fhirClient = clientFactory.create(this.config);
-    cohortSelector = new FhirCohortSelector(config, fhirClient, meterRegistry);
+    cohortSelector =
+        new FhirCohortSelector(config, fhirClient, new DefaultRetryStrategy(meterRegistry));
     wireMock = wireMockRuntime.getWireMock();
     cohortGenerator = new FhirCohortGenerator(PID_SYSTEM, POLICY_SYSTEM, POLICIES);
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,7 +21,7 @@ class RdaBundleSenderFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new RdaBundleSenderFactory(clientFactory, meterRegistry);
+    factory = new RdaBundleSenderFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderIT.java
@@ -22,6 +22,7 @@ import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender;
 import care.smith.fts.api.cda.BundleSender.Result;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.error.TransferProcessException;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
@@ -61,7 +62,7 @@ class RdaBundleSenderIT extends AbstractConnectionScenarioIT {
     wireMock = wireMockRuntime.getWireMock();
 
     var config = new RdaBundleSenderConfig(server, "example");
-    bundleSender = new RdaBundleSender(config, client, meterRegistry);
+    bundleSender = new RdaBundleSender(config, client, new DefaultRetryStrategy(meterRegistry));
   }
 
   private static MappingBuilder rdaRequest() {

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/RdaBundleSenderTest.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.api.TransportBundle;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.error.TransferProcessException;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -45,7 +46,7 @@ class RdaBundleSenderTest {
               }
               return ClientResponse.create(HttpStatus.ACCEPTED).header(RETRY_AFTER, "0").build();
             });
-    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+    var sender = new RdaBundleSender(CONFIG, client, new DefaultRetryStrategy(meterRegistry));
 
     create(sender.send(new TransportBundle(new Bundle(), "tid")))
         .expectErrorMatches(
@@ -70,7 +71,7 @@ class RdaBundleSenderTest {
               }
               return ClientResponse.create(HttpStatus.CREATED).build();
             });
-    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+    var sender = new RdaBundleSender(CONFIG, client, new DefaultRetryStrategy(meterRegistry));
 
     create(sender.send(new TransportBundle(new Bundle(), "tid")))
         .expectErrorMatches(
@@ -92,7 +93,7 @@ class RdaBundleSenderTest {
               }
               return ClientResponse.create(HttpStatus.OK).build();
             });
-    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+    var sender = new RdaBundleSender(CONFIG, client, new DefaultRetryStrategy(meterRegistry));
 
     create(sender.send(new TransportBundle(new Bundle(), "tid")))
         .expectNextCount(1)
@@ -102,7 +103,7 @@ class RdaBundleSenderTest {
   @Test
   void postOkSkipsPolling() {
     var client = buildClient(request -> ClientResponse.create(HttpStatus.OK).build());
-    var sender = new RdaBundleSender(CONFIG, client, meterRegistry);
+    var sender = new RdaBundleSender(CONFIG, client, new DefaultRetryStrategy(meterRegistry));
 
     create(sender.send(new TransportBundle(new Bundle(), "tid")))
         .expectNextCount(1)

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,7 +21,7 @@ class TcaCohortSelectorFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new TcaCohortSelectorFactory(clientFactory, meterRegistry);
+    factory = new TcaCohortSelectorFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorIT.java
@@ -16,6 +16,7 @@ import static reactor.test.StepVerifier.create;
 import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.cda.impl.mock.MockCohortSelector;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.error.TransferProcessException;
@@ -65,7 +66,9 @@ class TcaCohortSelectorIT {
         new TcaCohortSelectorConfig(server, PID_SYSTEM, POLICY_SYSTEM, POLICIES, "MII", null);
     cohortSelector =
         new TcaCohortSelector(
-            config, clientFactory.create(clientConfig(wireMockRuntime)), meterRegistry);
+            config,
+            clientFactory.create(clientConfig(wireMockRuntime)),
+            new DefaultRetryStrategy(meterRegistry));
     wireMock = wireMockRuntime.getWireMock();
     allCohortSelector = MockCohortSelector.fetchAll(wireMock);
     listCohortSelector = MockCohortSelector.fetch(wireMock);
@@ -212,12 +215,14 @@ class TcaCohortSelectorIT {
 
     var selectorWithNull =
         new TcaCohortSelector(
-            configWithNull, clientFactory.create(clientConfig(wireMockRuntime)), meterRegistry);
+            configWithNull,
+            clientFactory.create(clientConfig(wireMockRuntime)),
+            new DefaultRetryStrategy(meterRegistry));
     var selectorWithPseudonym =
         new TcaCohortSelector(
             configWithPseudonym,
             clientFactory.create(clientConfig(wireMockRuntime)),
-            meterRegistry);
+            new DefaultRetryStrategy(meterRegistry));
 
     // Both should behave identically
     var selector = MockCohortSelector.fetchAll(wireMock);

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/FhirResolveServiceIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/FhirResolveServiceIT.java
@@ -20,6 +20,7 @@ import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.cda.ClinicalDomainAgent;
 import care.smith.fts.test.MockServerUtil;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -57,7 +58,7 @@ class FhirResolveServiceIT extends AbstractConnectionScenarioIT {
   void setUp(WireMockRuntimeInfo wiremockRuntime, @Autowired WebClientFactory clientFactory)
       throws Exception {
     client = clientFactory.create(clientConfig(wiremockRuntime));
-    this.service = new FhirResolveService(client, meterRegistry);
+    this.service = new FhirResolveService(client, new DefaultRetryStrategy(meterRegistry));
     wireMock = wiremockRuntime.getWireMock();
     try (var inStream = MockServerUtil.getResourceAsStream("metadata.json")) {
       var capStatement = new String(requireNonNull(inStream).readAllBytes(), UTF_8);

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStep.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStep.java
@@ -1,11 +1,11 @@
 package care.smith.fts.rda.impl;
 
 import static care.smith.fts.rda.services.deidentifhir.DeidentifhirUtil.generateRegistry;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.services.deidentifhir.DeidentifhirUtil;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.tca.SecureMappingResponse;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +20,17 @@ class DeidentifhirStep implements Deidentificator {
   private final WebClient tcaClient;
   private final com.typesafe.config.Config deidentifhirConfig;
   private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   public DeidentifhirStep(
-      com.typesafe.config.Config config, WebClient tcaClient, MeterRegistry meterRegistry) {
+      com.typesafe.config.Config config,
+      WebClient tcaClient,
+      MeterRegistry meterRegistry,
+      RetryStrategy retryStrategy) {
     this.tcaClient = tcaClient;
     this.deidentifhirConfig = config;
     this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -55,7 +60,7 @@ class DeidentifhirStep implements Deidentificator {
         .bodyValue(transferId)
         .retrieve()
         .bodyToMono(SecureMappingResponse.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchSecureMapping"))
+        .retryWhen(retryStrategy.forRequest("fetchSecureMapping"))
         .doOnError(e -> log.error("Unable to resolve transport IDs: {}", e.getMessage()));
   }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStepFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStepFactory.java
@@ -3,6 +3,7 @@ package care.smith.fts.rda.impl;
 import static java.util.Objects.requireNonNull;
 
 import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.typesafe.config.ConfigFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -16,10 +17,13 @@ public class DeidentifhirStepFactory implements Deidentificator.Factory<Deidenti
 
   private final WebClientFactory clientFactory;
   private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public DeidentifhirStepFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public DeidentifhirStepFactory(
+      WebClientFactory clientFactory, MeterRegistry meterRegistry, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
     this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -35,6 +39,6 @@ public class DeidentifhirStepFactory implements Deidentificator.Factory<Deidenti
             + " 'deidentifhirConfig' and 'dateShift' fields will be removed in a future release.");
     var httpClient = clientFactory.create(implConfig.trustCenterAgent().server());
     var config = ConfigFactory.parseFile(requireNonNull(implConfig.deidentifhirConfig()));
-    return new DeidentifhirStep(config, httpClient, meterRegistry);
+    return new DeidentifhirStep(config, httpClient, meterRegistry, retryStrategy);
   }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSender.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSender.java
@@ -1,12 +1,11 @@
 package care.smith.fts.rda.impl;
 
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.fhir.FhirUtils.resourceStream;
 import static org.hl7.fhir.r4.model.Bundle.BundleType.TRANSACTION;
 
 import care.smith.fts.api.rda.BundleSender;
-import io.micrometer.core.instrument.MeterRegistry;
+import care.smith.fts.util.RetryStrategy;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -17,11 +16,11 @@ import reactor.core.publisher.Mono;
 @Slf4j
 final class FhirStoreBundleSender implements BundleSender {
   private final WebClient hdsClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public FhirStoreBundleSender(WebClient hdsClient, MeterRegistry meterRegistry) {
+  public FhirStoreBundleSender(WebClient hdsClient, RetryStrategy retryStrategy) {
     this.hdsClient = hdsClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -34,7 +33,7 @@ final class FhirStoreBundleSender implements BundleSender {
         .bodyValue(toTransactionBundle(bundle))
         .retrieve()
         .toBodilessEntity()
-        .retryWhen(defaultRetryStrategy(meterRegistry, "sendBundleToHds"))
+        .retryWhen(retryStrategy.forRequest("sendBundleToHds"))
         .doOnNext(res -> log.trace("Response received: {}", res))
         .doOnError(err -> log.debug("Error received", err))
         .map(b -> new Result());

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactory.java
@@ -1,20 +1,20 @@
 package care.smith.fts.rda.impl;
 
 import care.smith.fts.api.rda.BundleSender;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("fhirStoreBundleSender")
 public class FhirStoreBundleSenderFactory
     implements BundleSender.Factory<FhirStoreBundleSenderConfig> {
 
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
   private final WebClientFactory clientFactory;
 
-  public FhirStoreBundleSenderFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public FhirStoreBundleSenderFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -26,6 +26,6 @@ public class FhirStoreBundleSenderFactory
   public BundleSender create(
       BundleSender.Config commonConfig, FhirStoreBundleSenderConfig implConfig) {
     var client = clientFactory.create(implConfig.server());
-    return new FhirStoreBundleSender(client, meterRegistry);
+    return new FhirStoreBundleSender(client, retryStrategy);
   }
 }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/IdMapperStep.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/IdMapperStep.java
@@ -1,12 +1,11 @@
 package care.smith.fts.rda.impl;
 
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
 
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.tca.SecureMappingResponse;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,11 +25,11 @@ import reactor.core.publisher.Mono;
 @Slf4j
 class IdMapperStep implements Deidentificator {
   private final WebClient tcaClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  IdMapperStep(WebClient tcaClient, MeterRegistry meterRegistry) {
+  IdMapperStep(WebClient tcaClient, RetryStrategy retryStrategy) {
     this.tcaClient = tcaClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -60,7 +59,7 @@ class IdMapperStep implements Deidentificator {
         .bodyValue(transferId)
         .retrieve()
         .bodyToMono(SecureMappingResponse.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchSecureMapping"))
+        .retryWhen(retryStrategy.forRequest("fetchSecureMapping"))
         .doOnError(
             e -> log.error("Unable to resolve transport IDs for transferId={}", transferId, e));
   }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/IdMapperStepFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/IdMapperStepFactory.java
@@ -3,19 +3,19 @@ package care.smith.fts.rda.impl;
 import static java.util.Objects.requireNonNull;
 
 import care.smith.fts.api.rda.Deidentificator;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Component;
 
 @Component("idMapperDeidentificator")
 public class IdMapperStepFactory implements Deidentificator.Factory<IdMapperStepConfig> {
 
   private final WebClientFactory clientFactory;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
-  public IdMapperStepFactory(WebClientFactory clientFactory, MeterRegistry meterRegistry) {
+  public IdMapperStepFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
     this.clientFactory = clientFactory;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -31,6 +31,6 @@ public class IdMapperStepFactory implements Deidentificator.Factory<IdMapperStep
     var httpClient =
         clientFactory.create(
             requireNonNull(tcaConfig.server(), "trustCenterAgent.server config is required"));
-    return new IdMapperStep(httpClient, meterRegistry);
+    return new IdMapperStep(httpClient, retryStrategy);
   }
 }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepFactoryIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepFactoryIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.impl.DeidentifhirStepConfig.TCAConfig;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -22,7 +23,9 @@ class DeidentifhirStepFactoryIT {
 
   @BeforeEach
   void setUp(@Autowired WebClientFactory clientFactory) {
-    factory = new DeidentifhirStepFactory(clientFactory, meterRegistry);
+    factory =
+        new DeidentifhirStepFactory(
+            clientFactory, meterRegistry, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepIT.java
@@ -17,6 +17,7 @@ import static reactor.test.StepVerifier.create;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.rda.services.deidentifhir.DeidentifhirUtil;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -68,7 +69,9 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
       throws IOException {
     var config = parseResources(DeidentifhirUtil.class, "TransportToRD.profile");
     var client = clientFactory.create(clientConfig(wireMockRuntime));
-    step = new DeidentifhirStep(config, client, meterRegistry);
+    step =
+        new DeidentifhirStep(
+            config, client, meterRegistry, new DefaultRetryStrategy(meterRegistry));
     wireMock = wireMockRuntime.getWireMock();
     bundle = generateOnePatient("tid1", "2024", "identifierSystem", "tidentifier1");
   }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactoryIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.rda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,7 +21,8 @@ class FhirStoreBundleSenderFactoryIT {
 
   @BeforeEach
   void setUp() {
-    factory = new FhirStoreBundleSenderFactory(clientFactory, meterRegistry);
+    factory =
+        new FhirStoreBundleSenderFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/FhirStoreBundleSenderIT.java
@@ -13,6 +13,7 @@ import static reactor.test.StepVerifier.create;
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.BundleSender.Result;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -59,7 +60,7 @@ class FhirStoreBundleSenderIT extends AbstractConnectionScenarioIT {
   @BeforeEach
   void setUp(WireMockRuntimeInfo wireMockRuntime, @Autowired WebClientFactory clientFactory) {
     var client = clientFactory.create(clientConfig(wireMockRuntime));
-    bundleSender = new FhirStoreBundleSender(client, meterRegistry);
+    bundleSender = new FhirStoreBundleSender(client, new DefaultRetryStrategy(meterRegistry));
     wireMock = wireMockRuntime.getWireMock();
   }
 

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/IdMapperStepFactoryIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/IdMapperStepFactoryIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.impl.IdMapperStepConfig.TCAConfig;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,7 +21,7 @@ class IdMapperStepFactoryIT {
 
   @BeforeEach
   void setUp(@Autowired WebClientFactory clientFactory) {
-    factory = new IdMapperStepFactory(clientFactory, meterRegistry);
+    factory = new IdMapperStepFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
   }
 
   @Test

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/IdMapperStepIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/IdMapperStepIT.java
@@ -16,6 +16,7 @@ import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.test.connection_scenario.AbstractConnectionScenarioIT;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -75,7 +76,7 @@ class IdMapperStepIT extends AbstractConnectionScenarioIT {
   void setUp(WireMockRuntimeInfo wireMockRuntime, @Autowired WebClientFactory clientFactory)
       throws IOException {
     var client = clientFactory.create(clientConfig(wireMockRuntime));
-    step = new IdMapperStep(client, meterRegistry);
+    step = new IdMapperStep(client, new DefaultRetryStrategy(meterRegistry));
     wireMock = wireMockRuntime.getWireMock();
     bundle = generateOnePatient("tid1", "2024", "identifierSystem", "tidentifier1");
   }

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProvider.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProvider.java
@@ -5,12 +5,11 @@ import static care.smith.fts.tca.TtpFhirGatewayUtil.handleError;
 import static care.smith.fts.tca.consent.GicsFhirUtil.GICS_OPERATIONS;
 import static care.smith.fts.tca.consent.GicsFhirUtil.filterOuterBundle;
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.tca.ConsentFetchAllRequest;
 import care.smith.fts.util.tca.ConsentFetchRequest;
 import care.smith.fts.util.tca.ConsentRequest;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.*;
@@ -23,16 +22,16 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class GicsFhirConsentedPatientsProvider implements ConsentedPatientsProvider {
   private final WebClient gicsClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
 
   /**
    * Constructs a FhirConsentProvider with the specified parameters.
    *
    * @param gicsClient the WebClient used for HTTP requests
    */
-  public GicsFhirConsentedPatientsProvider(WebClient gicsClient, MeterRegistry meterRegistry) {
+  public GicsFhirConsentedPatientsProvider(WebClient gicsClient, RetryStrategy retryStrategy) {
     this.gicsClient = gicsClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
   }
 
   @Override
@@ -81,7 +80,7 @@ public class GicsFhirConsentedPatientsProvider implements ConsentedPatientsProvi
             r -> handle4xxError("gICS", gicsClient, GICS_OPERATIONS, r))
         .bodyToMono(Bundle.class)
         .doOnNext(b -> log.trace("body(n: {})", b.getEntry().size()))
-        .retryWhen(defaultRetryStrategy(meterRegistry, helper.requestName()))
+        .retryWhen(retryStrategy.forRequest(helper.requestName()))
         .onErrorResume(e -> handleError("gICS", e))
         .doOnError(b -> log.error("Unable to fetch consent from gICS", b))
         .map(outerBundle -> filterOuterBundle(req.policySystem(), req.policies(), outerBundle))

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/consent/configuration/GicsConfiguration.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/consent/configuration/GicsConfiguration.java
@@ -8,8 +8,8 @@ import care.smith.fts.tca.consent.GicsConfigured;
 import care.smith.fts.tca.consent.GicsFhirConsentedPatientsProvider;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.LogUtil;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -63,7 +63,7 @@ public class GicsConfiguration {
 
   @Bean
   public GicsFhirConsentedPatientsProvider fhirConsentedPatientsProvider(
-      @Qualifier("gicsFhirHttpClient") WebClient gicsClient, MeterRegistry meterRegistry) {
-    return new GicsFhirConsentedPatientsProvider(gicsClient, meterRegistry);
+      @Qualifier("gicsFhirHttpClient") WebClient gicsClient, RetryStrategy retryStrategy) {
+    return new GicsFhirConsentedPatientsProvider(gicsClient, retryStrategy);
   }
 }

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/deidentification/FhirMappingProvider.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/deidentification/FhirMappingProvider.java
@@ -2,12 +2,12 @@ package care.smith.fts.tca.deidentification;
 
 import static care.smith.fts.tca.deidentification.DateShiftUtil.generate;
 import static care.smith.fts.tca.deidentification.DateShiftUtil.shiftDate;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_PREFIX;
 import static java.util.Set.of;
 import static java.util.stream.Collectors.toMap;
 
 import care.smith.fts.tca.deidentification.configuration.TransportMappingConfiguration;
+import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.deidentifhir.NamespacingReplacementProvider;
 import care.smith.fts.util.tca.SecureMappingResponse;
 import care.smith.fts.util.tca.TcaDomains;
@@ -16,7 +16,6 @@ import care.smith.fts.util.tca.TransportMappingResponse;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
@@ -38,19 +37,19 @@ public class FhirMappingProvider implements MappingProvider {
   private final GpasClient gpasClient;
   private final TransportMappingConfiguration configuration;
   private final RedissonClient redisClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
   private final RandomStringGenerator randomStringGenerator;
 
   public FhirMappingProvider(
       GpasClient gpasClient,
       RedissonClient redisClient,
       TransportMappingConfiguration configuration,
-      MeterRegistry meterRegistry,
+      RetryStrategy retryStrategy,
       RandomStringGenerator randomStringGenerator) {
     this.gpasClient = gpasClient;
     this.configuration = configuration;
     this.redisClient = redisClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
     this.randomStringGenerator = randomStringGenerator;
   }
 
@@ -178,7 +177,7 @@ public class FhirMappingProvider implements MappingProvider {
     RedissonReactiveClient redis = redisClient.reactive();
     return Mono.just(transferId)
         .flatMap(name -> redis.<String, String>getMapCache(name).readAllMap())
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchSecureMapping"))
+        .retryWhen(retryStrategy.forRequest("fetchSecureMapping"))
         .map(SecureMappingResponse::buildResolveResponse);
   }
 }

--- a/trust-center-agent/src/main/java/care/smith/fts/tca/deidentification/GpasClient.java
+++ b/trust-center-agent/src/main/java/care/smith/fts/tca/deidentification/GpasClient.java
@@ -4,12 +4,11 @@ import static care.smith.fts.tca.TtpFhirGatewayUtil.handle4xxError;
 import static care.smith.fts.tca.TtpFhirGatewayUtil.handleError;
 import static care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration.GPAS_OPERATIONS;
 import static care.smith.fts.util.MediaTypes.APPLICATION_FHIR_JSON;
-import static care.smith.fts.util.RetryStrategies.defaultRetryStrategy;
 import static java.util.List.of;
 
 import care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration;
+import care.smith.fts.util.RetryStrategy;
 import com.google.common.collect.Lists;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,16 +26,16 @@ import reactor.core.publisher.Mono;
 @Component
 public class GpasClient {
   private final WebClient gpasClient;
-  private final MeterRegistry meterRegistry;
+  private final RetryStrategy retryStrategy;
   private final int batchSize;
   private final int concurrency;
 
   public GpasClient(
       @Qualifier("gpasFhirHttpClient") WebClient gpasClient,
-      MeterRegistry meterRegistry,
+      RetryStrategy retryStrategy,
       GpasDeIdentificationConfiguration config) {
     this.gpasClient = gpasClient;
-    this.meterRegistry = meterRegistry;
+    this.retryStrategy = retryStrategy;
     this.batchSize = config.getBatchSize();
     this.concurrency = config.getConcurrency();
   }
@@ -91,7 +90,7 @@ public class GpasClient {
             HttpStatusCode::is4xxClientError,
             r -> handle4xxError("gPAS", gpasClient, GPAS_OPERATIONS, r))
         .bodyToMono(GpasParameterResponse.class)
-        .retryWhen(defaultRetryStrategy(meterRegistry, "fetchOrCreatePseudonymsOnGpas"))
+        .retryWhen(retryStrategy.forRequest("fetchOrCreatePseudonymsOnGpas"))
         .onErrorResume(e -> handleError("gPAS", e))
         .doOnError(e -> log.error("Unable to fetch pseudonyms from gPAS: {}", e.getMessage()))
         .doOnNext(r -> log.trace("$pseudonymizeAllowCreate batch response: {}", r.parameter()))

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProviderFetchAllIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProviderFetchAllIT.java
@@ -14,6 +14,7 @@ import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.tca.consent.ConsentedPatientsProvider.PagingParams;
 import care.smith.fts.test.TestWebClientFactory;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.tca.ConsentFetchAllRequest;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -62,7 +63,7 @@ class GicsFhirConsentedPatientsProviderFetchAllIT
   @Override
   protected GicsFhirConsentedPatientsProvider createClient(String baseUrl) {
     return new GicsFhirConsentedPatientsProvider(
-        httpClientBuilder.baseUrl(baseUrl).build(), meterRegistry);
+        httpClientBuilder.baseUrl(baseUrl).build(), new DefaultRetryStrategy(meterRegistry));
   }
 
   @Override

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProviderFetchIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/consent/GicsFhirConsentedPatientsProviderFetchIT.java
@@ -13,6 +13,7 @@ import static reactor.test.StepVerifier.create;
 import care.smith.fts.tca.consent.ConsentedPatientsProvider.PagingParams;
 import care.smith.fts.test.FhirGenerators;
 import care.smith.fts.test.TestWebClientFactory;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.tca.ConsentFetchRequest;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -93,7 +94,7 @@ class GicsFhirConsentedPatientsProviderFetchIT
   @Override
   protected GicsFhirConsentedPatientsProvider createClient(String baseUrl) {
     return new GicsFhirConsentedPatientsProvider(
-        httpClientBuilder.baseUrl(baseUrl).build(), meterRegistry);
+        httpClientBuilder.baseUrl(baseUrl).build(), new DefaultRetryStrategy(meterRegistry));
   }
 
   @Override

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/FhirMappingProviderTest.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/FhirMappingProviderTest.java
@@ -27,6 +27,7 @@ import care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationCon
 import care.smith.fts.tca.deidentification.configuration.TransportMappingConfiguration;
 import care.smith.fts.test.FhirGenerators;
 import care.smith.fts.test.TestWebClientFactory;
+import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.error.fhir.FhirException;
 import care.smith.fts.util.tca.TcaDomains;
 import care.smith.fts.util.tca.TransportMappingRequest;
@@ -99,14 +100,17 @@ class FhirMappingProviderTest {
 
     var gpasConfig = new GpasDeIdentificationConfiguration();
     var gpasClient =
-        new GpasClient(httpClientBuilder.baseUrl(address).build(), meterRegistry, gpasConfig);
+        new GpasClient(
+            httpClientBuilder.baseUrl(address).build(),
+            new DefaultRetryStrategy(meterRegistry),
+            gpasConfig);
 
     mappingProvider =
         new FhirMappingProvider(
             gpasClient,
             redisClient,
             transportMappingConfiguration,
-            meterRegistry,
+            new DefaultRetryStrategy(meterRegistry),
             new RandomStringGenerator(new Random(0)));
   }
 

--- a/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/GpasClientIT.java
+++ b/trust-center-agent/src/test/java/care/smith/fts/tca/deidentification/GpasClientIT.java
@@ -9,6 +9,7 @@ import static reactor.test.StepVerifier.create;
 
 import care.smith.fts.tca.AbstractFhirClientIT;
 import care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration;
+import care.smith.fts.util.DefaultRetryStrategy;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
@@ -52,7 +53,10 @@ public class GpasClientIT extends AbstractFhirClientIT<GpasClient, String, Map<S
   @Override
   protected GpasClient createClient(String baseUrl) {
     var config = new GpasDeIdentificationConfiguration();
-    return new GpasClient(httpClientBuilder.baseUrl(baseUrl).build(), meterRegistry, config);
+    return new GpasClient(
+        httpClientBuilder.baseUrl(baseUrl).build(),
+        new DefaultRetryStrategy(meterRegistry),
+        config);
   }
 
   @Override

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -9,6 +9,7 @@ import care.smith.fts.util.fhir.FhirCodecConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.TimeZone;
@@ -38,6 +39,11 @@ public class AgentConfiguration {
   @Bean
   public FhirContext fhirContext() {
     return FhirContext.forR4();
+  }
+
+  @Bean
+  public RetryStrategy retryStrategy(MeterRegistry meterRegistry) {
+    return new DefaultRetryStrategy(meterRegistry);
   }
 
   /**

--- a/util/src/main/java/care/smith/fts/util/DefaultRetryStrategy.java
+++ b/util/src/main/java/care/smith/fts/util/DefaultRetryStrategy.java
@@ -6,31 +6,42 @@ import static java.lang.Boolean.parseBoolean;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.util.retry.Retry;
-import reactor.util.retry.RetryBackoffSpec;
 
-public interface RetryStrategies {
-  Logger log = LoggerFactory.getLogger(RetryStrategies.class);
-  boolean RETRY_TIMEOUT = parseBoolean(System.getProperty("fts.retryTimeout", "true"));
+/** Default {@link RetryStrategy}: 3 attempts, 1s backoff, retrying 5xx / timeout / connect. */
+@Slf4j
+public class DefaultRetryStrategy implements RetryStrategy {
 
-  static RetryBackoffSpec defaultRetryStrategy(MeterRegistry meterRegistry, String name) {
+  private final MeterRegistry meterRegistry;
+  private final boolean retryTimeout;
+
+  public DefaultRetryStrategy(MeterRegistry meterRegistry) {
+    this(meterRegistry, parseBoolean(System.getProperty("fts.retryTimeout", "true")));
+  }
+
+  public DefaultRetryStrategy(MeterRegistry meterRegistry, boolean retryTimeout) {
+    this.meterRegistry = meterRegistry;
+    this.retryTimeout = retryTimeout;
+  }
+
+  @Override
+  public Retry forRequest(String name) {
     var counter = meterRegistry.counter("http.client.requests.retries", "request_name", name);
     return Retry.backoff(3, Duration.ofSeconds(1))
         .doBeforeRetry(retry -> log.debug("RetrySignal {}", retry))
         .filter(
             or(
-                RetryStrategies::is5xxServerError,
-                RetryStrategies::isTimeout,
-                RetryStrategies::isConnectException))
+                DefaultRetryStrategy::is5xxServerError,
+                this::isTimeout,
+                DefaultRetryStrategy::isConnectException))
         .doAfterRetry(i -> counter.increment());
   }
 
-  static boolean isTimeout(Throwable e) {
-    return RETRY_TIMEOUT && e instanceof TimeoutException;
+  private boolean isTimeout(Throwable e) {
+    return retryTimeout && e instanceof TimeoutException;
   }
 
   private static boolean is5xxServerError(Throwable e) {

--- a/util/src/main/java/care/smith/fts/util/RetryStrategy.java
+++ b/util/src/main/java/care/smith/fts/util/RetryStrategy.java
@@ -1,0 +1,10 @@
+package care.smith.fts.util;
+
+import reactor.util.retry.Retry;
+
+/** Builds the reactor {@link Retry} spec for a named outbound request. */
+public interface RetryStrategy {
+
+  /** Returns the retry spec for call-site {@code name} (used as the {@code request_name} tag). */
+  Retry forRequest(String name);
+}

--- a/util/src/test/java/care/smith/fts/util/DefaultRetryStrategyTest.java
+++ b/util/src/test/java/care/smith/fts/util/DefaultRetryStrategyTest.java
@@ -1,0 +1,135 @@
+package care.smith.fts.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class DefaultRetryStrategyTest {
+
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final RetryStrategy retryStrategy = new DefaultRetryStrategy(meterRegistry);
+
+  private double retryCount(String name) {
+    return meterRegistry.counter("http.client.requests.retries", "request_name", name).count();
+  }
+
+  private Mono<String> withRetry(AtomicInteger calls, int failures, Throwable error, String name) {
+    return withRetry(retryStrategy, calls, failures, error, name);
+  }
+
+  private Mono<String> withRetry(
+      RetryStrategy strategy, AtomicInteger calls, int failures, Throwable error, String name) {
+    return Mono.defer(
+            () -> calls.getAndIncrement() < failures ? Mono.error(error) : Mono.just("ok"))
+        .retryWhen(strategy.forRequest(name));
+  }
+
+  private static WebClientResponseException responseException(int status) {
+    return new WebClientResponseException(
+        status, "status " + status, new HttpHeaders(), new byte[0], StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void retriesOn5xxThenSucceeds() {
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(() -> withRetry(calls, 2, responseException(503), "fiveXX"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectNext("ok")
+        .verifyComplete();
+    assertThat(retryCount("fiveXX")).isEqualTo(2.0);
+  }
+
+  @Test
+  void retriesOnConnectExceptionThenSucceeds() {
+    var calls = new AtomicInteger();
+    var error =
+        new WebClientRequestException(
+            new RuntimeException("connect"),
+            HttpMethod.GET,
+            URI.create("http://example"),
+            new HttpHeaders());
+    StepVerifier.withVirtualTime(() -> withRetry(calls, 1, error, "connect"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectNext("ok")
+        .verifyComplete();
+    assertThat(retryCount("connect")).isEqualTo(1.0);
+  }
+
+  @Test
+  void retriesOnTimeoutThenSucceeds() {
+    // Built with retryTimeout=true explicitly so the assertion holds regardless of the
+    // build-wide -Dfts.retryTimeout flag (set to false during connection-scenario ITs).
+    var strategy = new DefaultRetryStrategy(meterRegistry, true);
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(
+            () -> withRetry(strategy, calls, 1, new TimeoutException("timeout"), "timeout"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectNext("ok")
+        .verifyComplete();
+    assertThat(retryCount("timeout")).isEqualTo(1.0);
+  }
+
+  @Test
+  void doesNotRetryTimeoutWhenDisabled() {
+    var strategy = new DefaultRetryStrategy(meterRegistry, false);
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(
+            () -> withRetry(strategy, calls, 1, new TimeoutException("timeout"), "noTimeout"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectError(TimeoutException.class)
+        .verify();
+    assertThat(calls.get()).isEqualTo(1);
+    assertThat(retryCount("noTimeout")).isZero();
+  }
+
+  @Test
+  void doesNotRetryNonTimeoutWhenTimeoutEnabled() {
+    // retryTimeout=true but the error is not a TimeoutException, exercising the
+    // `e instanceof TimeoutException` false branch independent of the build-wide flag.
+    var strategy = new DefaultRetryStrategy(meterRegistry, true);
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(
+            () -> withRetry(strategy, calls, 1, responseException(400), "nonTimeout"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectError(WebClientResponseException.class)
+        .verify();
+    assertThat(calls.get()).isEqualTo(1);
+    assertThat(retryCount("nonTimeout")).isZero();
+  }
+
+  @Test
+  void doesNotRetryOn4xx() {
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(() -> withRetry(calls, 1, responseException(400), "fourXX"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectError(WebClientResponseException.class)
+        .verify();
+    assertThat(calls.get()).isEqualTo(1);
+    assertThat(retryCount("fourXX")).isZero();
+  }
+
+  @Test
+  void exhaustsAfterThreeRetries() {
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(
+            () -> withRetry(calls, Integer.MAX_VALUE, responseException(500), "exhaust"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectErrorMatches(Exceptions::isRetryExhausted)
+        .verify();
+    assertThat(calls.get()).isEqualTo(4);
+    assertThat(retryCount("exhaust")).isEqualTo(3.0);
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the static `RetryStrategies.defaultRetryStrategy(MeterRegistry, name)` util (which returned a reactor `RetryBackoffSpec`) with a polymorphic, injectable abstraction, as proposed in #1714 (Alt 1):

```java
public interface RetryStrategy {
  Retry forRequest(String name);
}
```

- `DefaultRetryStrategy(MeterRegistry)` is a singleton `@Bean` (wired in `AgentConfiguration`) holding the `MeterRegistry` and implementing the existing logic: 5xx / timeout / connect, 3 attempts, 1s backoff, `http.client.requests.retries` counter.
- `name` stays a per-call method argument (metric tag `request_name`), so one shared default bean serves every call site.
- The old static `RetryStrategies` class is deleted.

## What changed

- **`util`**: new `RetryStrategy` interface + `DefaultRetryStrategy` impl + `@Bean` in `AgentConfiguration`; `RetryStrategies` removed.
- **Consumers (CDA/RDA/TCA)**: the 10 classes that held a `MeterRegistry` field *solely* to build a retry spec now inject `RetryStrategy` instead. The two `DeidentifhirStep` steps keep `MeterRegistry` (still used by the deidentify util) and additionally take `RetryStrategy`.
- **Factories / config**: the 8 step factories and `GicsConfiguration` rewired accordingly.
- Behaviour is unchanged — same attempt count, backoff, retried error types, and retry counter.

## Why

A static method can't be swapped per consumer. This unblocks a future RDA backpressure strategy (429 / `Retry-After`, uncapped backpressure wait — branch `1710-rda-send-concurrency-backpressure`) that needs different retry behaviour, without threading a `MeterRegistry` into every consumer just to build a spec.

## Out of scope

The `RdaBackpressureRetryStrategy` impl and its wiring land later with branch 1710.

## Verification

- New `DefaultRetryStrategyTest` (added TDD; covers retry-on-5xx/timeout/connect, no-retry-on-4xx, exhaustion after 3 retries, and counter increments) — green.
- `mvn clean verify` green across `util`, `clinical-domain-agent`, `research-domain-agent`, `trust-center-agent` (the only failures are the pre-existing `OAuth2AuthIT` errors expected in local dev without OAuth2 infrastructure).
- `mvn checkstyle:check` passes.

Closes #1714