### PR TITLE
Make Redirect Following Configurable Per Upstream

### DIFF
--- a/docs/configuration/http-client.md
+++ b/docs/configuration/http-client.md
@@ -75,6 +75,12 @@ under the upstream idle.
 The value is applied at agent startup, before any request flows through the pool. Changing it
 requires an agent restart.
 
+### Redirect following
+
+Whether redirects are followed is **not** an agent-wide setting; it is configured per upstream
+connection via [`HttpClientConfig.redirects`](../types/HttpClientConfig). See that page for the
+behaviour and the silent-empty-transfer guarantee.
+
 ## References
 
 * [ISO-8601 `Duration` syntax](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence))

--- a/docs/types/HttpClientConfig.md
+++ b/docs/types/HttpClientConfig.md
@@ -27,13 +27,31 @@ ssl:
 
 ## Fields
 
-| Field Name | Type                        | Required | Default | Description                   |
-|------------|-----------------------------|----------|---------|-------------------------------|
-| `baseUrl`  | `String`                    | Yes      |         | Server base URL.              |
-| `auth`     | [`AuthMethod`](#authmethod) | No       | `NONE`  | Authentication configuration. |
-| `ssl`      | [`SSL`](#ssl)               | No       |         | SSL Configuration.            |
+| Field Name  | Type                          | Required | Default                | Description                   |
+|-------------|-------------------------------|----------|------------------------|-------------------------------|
+| `baseUrl`   | `String`                      | Yes      |                        | Server base URL.              |
+| `auth`      | [`AuthMethod`](#authmethod)   | No       | `NONE`                 | Authentication configuration. |
+| `ssl`       | [`SSL`](#ssl)                 | No       |                        | SSL Configuration.            |
+| `redirects` | [`Redirects`](#redirects)     | No       | `FOLLOW_SAFE`          | Redirect-following policy.    |
 
 ## Other Types
+
+### Redirects <Badge type="warning" text="Since 5.7" />
+
+Controls whether HTTP redirects (3xx) are followed for this connection.
+
+| Value           | Behaviour                                                                                                                                                                            |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FOLLOW_SAFE`   | Follow redirects (e.g. an HDS behind a reverse proxy answering `307`), but refuse HTTPS&rarr;HTTP downgrades. **Default.**                                                          |
+| `ALWAYS_FOLLOW` | Follow all redirects, **including** HTTPS&rarr;HTTP downgrades. A downgrade exposes credentials and data over plaintext, so only use this for a trusted cross-scheme upstream.      |
+| `DONT_FOLLOW`   | Do not follow redirects.                                                                                                                                                            |
+
+A redirect that is **not** followed (every 3xx under `DONT_FOLLOW`, or an HTTPS&rarr;HTTP
+downgrade / unfollowed `POST` `307`/`308` under the follow modes) is turned into an **error**
+instead of passing through as an empty-bodied success — the failure mode that otherwise produces a
+silently empty transfer. Because a redirect is deterministic, it is treated as terminal and is
+**not retried**. Use `DONT_FOLLOW` to fail fast and force a misconfigured upstream `baseUrl` to be
+corrected so the server returns `200` directly.
 
 ### AuthMethod <Badge type="warning" text="Since 5.0" />
 

--- a/util/src/main/java/care/smith/fts/util/DefaultRetryStrategy.java
+++ b/util/src/main/java/care/smith/fts/util/DefaultRetryStrategy.java
@@ -1,6 +1,5 @@
 package care.smith.fts.util;
 
-import static com.google.common.base.Predicates.or;
 import static java.lang.Boolean.parseBoolean;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -32,16 +31,28 @@ public class DefaultRetryStrategy implements RetryStrategy {
     var counter = meterRegistry.counter("http.client.requests.retries", "request_name", name);
     return Retry.backoff(3, Duration.ofSeconds(1))
         .doBeforeRetry(retry -> log.debug("RetrySignal {}", retry))
-        .filter(
-            or(
-                DefaultRetryStrategy::is5xxServerError,
-                this::isTimeout,
-                DefaultRetryStrategy::isConnectException))
+        .filter(this::isRetryable)
         .doAfterRetry(i -> counter.increment());
+  }
+
+  private boolean isRetryable(Throwable e) {
+    // A 3xx that reaches here was not followed by the transport (policy DONT_FOLLOW, or an
+    // HTTPS->HTTP downgrade refused by FOLLOW_SAFE). Re-issuing the identical request only yields
+    // another redirect, not the resource, so it is terminal, never retryable; classified
+    // explicitly so it can never slip into a retry (#1706).
+    if (is3xxRedirection(e)) {
+      return false;
+    }
+    return is5xxServerError(e) || isTimeout(e) || isConnectException(e);
   }
 
   private boolean isTimeout(Throwable e) {
     return retryTimeout && e instanceof TimeoutException;
+  }
+
+  private static boolean is3xxRedirection(Throwable e) {
+    return e instanceof WebClientResponseException
+        && ((WebClientResponseException) e).getStatusCode().is3xxRedirection();
   }
 
   private static boolean is5xxServerError(Throwable e) {

--- a/util/src/main/java/care/smith/fts/util/HttpClientConfig.java
+++ b/util/src/main/java/care/smith/fts/util/HttpClientConfig.java
@@ -9,26 +9,61 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 public record HttpClientConfig(
-    @NotBlank String baseUrl, @Nullable HttpClientAuth.Config auth, @Nullable Ssl ssl) {
+    @NotBlank String baseUrl,
+    @Nullable HttpClientAuth.Config auth,
+    @Nullable Ssl ssl,
+    @Nullable Redirects redirects) {
 
   @ConstructorBinding
-  public HttpClientConfig(@NotBlank String baseUrl, HttpClientAuth.Config auth, Ssl ssl) {
+  public HttpClientConfig(
+      @NotBlank String baseUrl, HttpClientAuth.Config auth, Ssl ssl, Redirects redirects) {
     this.baseUrl = requireNonNull(emptyToNull(baseUrl), "Base URL must not be null");
     this.auth = auth;
     this.ssl = ssl;
+    this.redirects = redirects;
+  }
+
+  public HttpClientConfig(@NotBlank String baseUrl, HttpClientAuth.Config auth, Ssl ssl) {
+    this(baseUrl, auth, ssl, null);
   }
 
   public HttpClientConfig(@NotBlank String baseUrl, HttpClientAuth.Config auth) {
-    this(requireNonNull(emptyToNull(baseUrl)), requireNonNull(auth, "auth must not be null"), null);
+    this(
+        requireNonNull(emptyToNull(baseUrl)),
+        requireNonNull(auth, "auth must not be null"),
+        null,
+        null);
   }
 
   public HttpClientConfig(@NotBlank String baseUrl, Ssl ssl) {
-    this(requireNonNull(emptyToNull(baseUrl)), null, requireNonNull(ssl, "ssl must not be null"));
+    this(
+        requireNonNull(emptyToNull(baseUrl)),
+        null,
+        requireNonNull(ssl, "ssl must not be null"),
+        null);
   }
 
   public HttpClientConfig(@NotBlank String baseUrl) {
-    this(requireNonNull(emptyToNull(baseUrl)), null, null);
+    this(requireNonNull(emptyToNull(baseUrl)), null, null, null);
   }
 
   public record Ssl(String bundle) {}
+
+  /**
+   * Per-upstream redirect-following policy. Names describe intent and deliberately hide the
+   * underlying client's API so config is decoupled from the HTTP library. {@link WebClientFactory}
+   * translates these to the Reactor Netty redirect configuration.
+   */
+  public enum Redirects {
+    /** Follow 3xx redirects, but refuse HTTPS&rarr;HTTP downgrades. The default. */
+    FOLLOW_SAFE,
+    /**
+     * Follow all 3xx redirects, including HTTPS&rarr;HTTP downgrades. A downgrade exposes
+     * credentials and data over plaintext, so only use this for a trusted upstream that genuinely
+     * redirects across schemes.
+     */
+    ALWAYS_FOLLOW,
+    /** Do not follow redirects; an unfollowed 3xx surfaces as an error. */
+    DONT_FOLLOW
+  }
 }

--- a/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
+++ b/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
@@ -10,7 +10,9 @@ import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeType;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Component
 public class WebClientDefaults implements WebClientCustomizer {
@@ -36,8 +38,24 @@ public class WebClientDefaults implements WebClientCustomizer {
   @Override
   public void customize(WebClient.Builder builder) {
     builder
-        .filter((r, n) -> n.exchange(r).timeout(ofSeconds(10)))
+        .filter(
+            (request, next) ->
+                next.exchange(request)
+                    .timeout(ofSeconds(10))
+                    .flatMap(WebClientDefaults::errorOnRedirect))
         .codecs(this::configureObjectMapper);
+  }
+
+  /**
+   * A 3xx reaching here means the transport layer did not follow it (a downgrade refused under
+   * {@code FOLLOW_SAFE}, or any redirect under {@code DONT_FOLLOW}). Surface it as an error so the
+   * transfer fails loudly instead of letting the empty redirect body pass through {@code
+   * retrieve()} as a silent success (#1706).
+   */
+  private static Mono<ClientResponse> errorOnRedirect(ClientResponse response) {
+    return response.statusCode().is3xxRedirection()
+        ? response.createException().flatMap(Mono::error)
+        : Mono.just(response);
   }
 
   private void configureObjectMapper(ClientCodecConfigurer cs) {

--- a/util/src/main/java/care/smith/fts/util/WebClientFactory.java
+++ b/util/src/main/java/care/smith/fts/util/WebClientFactory.java
@@ -1,39 +1,59 @@
 package care.smith.fts.util;
 
-import static java.util.Optional.ofNullable;
+import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNullElse;
 
+import care.smith.fts.util.HttpClientConfig.Redirects;
 import care.smith.fts.util.HttpClientConfig.Ssl;
 import care.smith.fts.util.auth.HttpClientAuth;
 import care.smith.fts.util.auth.HttpClientBasicAuth;
 import care.smith.fts.util.auth.HttpClientCookieTokenAuth;
 import care.smith.fts.util.auth.HttpClientOAuth2Auth;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webclient.autoconfigure.WebClientSsl;
+import org.springframework.boot.http.client.HttpClientSettings;
+import org.springframework.boot.http.client.reactive.ClientHttpConnectorBuilder;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.client.ReactorResourceFactory;
+import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClient.Builder;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientRequest;
+import reactor.netty.http.client.HttpClientResponse;
 
 @Slf4j
 @Component
 @Import({HttpClientBasicAuth.class, HttpClientOAuth2Auth.class, HttpClientCookieTokenAuth.class})
 public class WebClientFactory {
 
+  private static final Set<Integer> REDIRECT_CODES = Set.of(301, 302, 303, 307, 308);
+
   private final Builder clientBuilder;
-  private final WebClientSsl ssl;
+  private final ReactorResourceFactory resourceFactory;
+  private final SslBundles sslBundles;
   private final HttpClientBasicAuth basic;
   private final HttpClientOAuth2Auth oauth2;
   private final HttpClientCookieTokenAuth token;
 
   public WebClientFactory(
       WebClient.Builder clientBuilder,
-      WebClientSsl ssl,
+      ReactorResourceFactory resourceFactory,
+      SslBundles sslBundles,
       @Autowired(required = false) HttpClientBasicAuth basic,
       @Autowired(required = false) HttpClientOAuth2Auth oauth2,
       @Autowired(required = false) HttpClientCookieTokenAuth token) {
     this.clientBuilder = clientBuilder;
-    this.ssl = ssl;
+    this.resourceFactory = resourceFactory;
+    this.sslBundles = sslBundles;
     this.basic = basic;
     this.oauth2 = oauth2;
     this.token = token;
@@ -43,34 +63,90 @@ public class WebClientFactory {
     log.debug("Webclient Config {}", config);
     return clientBuilder
         .clone()
+        .clientConnector(connector(config))
         .baseUrl(config.baseUrl())
         .apply(b -> configureAuth(b, config.auth()))
-        .apply(b -> configureSsl(b, config.ssl()))
         .build();
   }
 
-  private void configureAuth(Builder builder, HttpClientAuth.Config auth) {
-    if (auth != null) {
-      if (auth.basic() != null) {
-        configureAuth(builder, "basic", basic, auth.basic());
-      } else if (auth.oauth2() != null) {
-        configureAuth(builder, "oauth2", oauth2, auth.oauth2());
-      } else if (auth.cookieToken() != null) {
-        configureAuth(builder, "cookieToken", token, auth.cookieToken());
-      }
-    }
+  /**
+   * Builds the per-upstream connector. Redirect policy, SSL bundle and connect timeout are composed
+   * onto a single Reactor Netty client here so each {@link HttpClientConfig} controls its own
+   * redirect behaviour, while {@code withReactorResourceFactory} keeps every upstream on the shared
+   * connection pool from {@code AgentConfiguration#ftsClientResources} (#1729). The redirect policy
+   * is applied via an http-client customizer (which runs last and so overrides Spring's
+   * settings-based default), keeping the underlying client API out of the public config. A {@code
+   * null} {@code redirects} defaults to {@link Redirects#FOLLOW_SAFE}.
+   */
+  private ClientHttpConnector connector(HttpClientConfig config) {
+    var settings =
+        HttpClientSettings.defaults()
+            .withConnectTimeout(ofSeconds(10))
+            .withSslBundle(sslBundle(config.ssl()));
+    return ClientHttpConnectorBuilder.reactor()
+        .withReactorResourceFactory(resourceFactory)
+        .withHttpClientCustomizer(client -> applyRedirects(client, config.redirects()))
+        .build(settings);
   }
 
-  private <C> void configureAuth(Builder b, String name, HttpClientAuth<C> impl, C config) {
-    if (impl != null) {
-      impl.configure(config, b);
-    } else {
-      throw new IllegalArgumentException(
-          "Cannot configure %s authentication, missing implementing class.".formatted(name));
-    }
+  /**
+   * Translates the public {@link Redirects} policy to the Reactor Netty redirect configuration.
+   * {@code null} defaults to {@link Redirects#FOLLOW_SAFE}, which follows via {@link
+   * #isSafeRedirect} because Reactor Netty's boolean {@code followRedirect} cannot refuse
+   * HTTPS&rarr;HTTP downgrades on its own.
+   */
+  static HttpClient applyRedirects(HttpClient client, @Nullable Redirects redirects) {
+    return switch (requireNonNullElse(redirects, Redirects.FOLLOW_SAFE)) {
+      case FOLLOW_SAFE -> client.followRedirect(WebClientFactory::isSafeRedirect);
+      case ALWAYS_FOLLOW -> client.followRedirect(true);
+      case DONT_FOLLOW -> client.followRedirect(false);
+    };
   }
 
-  private void configureSsl(Builder b, Ssl ssl) {
-    ofNullable(ssl).ifPresent(s -> b.apply(this.ssl.fromBundle(s.bundle())));
+  /**
+   * Follow a 3xx unless it is an HTTPS&rarr;HTTP downgrade, mirroring the JDK's {@code
+   * Redirect.NORMAL}. A 3xx without a {@code Location} header is not followed, and a request whose
+   * URL is unknown cannot be checked for a downgrade, so its redirect is followed. A refused
+   * downgrade leaves the 3xx to reach WebClient, where {@link WebClientDefaults} turns it into an
+   * error (#1706).
+   */
+  static boolean isSafeRedirect(HttpClientRequest request, HttpClientResponse response) {
+    return REDIRECT_CODES.contains(response.status().code())
+        && Optional.ofNullable(response.responseHeaders().get(HttpHeaderNames.LOCATION))
+            .filter(location -> !isHttpsToHttpDowngrade(request.resourceUrl(), location))
+            .isPresent();
+  }
+
+  private static boolean isHttpsToHttpDowngrade(@Nullable String requestUrl, String location) {
+    return location.startsWith("http://")
+        && Optional.ofNullable(requestUrl).filter(url -> url.startsWith("https://")).isPresent();
+  }
+
+  private @Nullable SslBundle sslBundle(@Nullable Ssl ssl) {
+    return Optional.ofNullable(ssl).map(s -> sslBundles.getBundle(s.bundle())).orElse(null);
+  }
+
+  private void configureAuth(Builder builder, @Nullable HttpClientAuth.Config auth) {
+    Optional.ofNullable(auth)
+        .flatMap(
+            a ->
+                configurer("basic", basic, a.basic())
+                    .or(() -> configurer("oauth2", oauth2, a.oauth2()))
+                    .or(() -> configurer("cookieToken", token, a.cookieToken())))
+        .ifPresent(configurer -> configurer.accept(builder));
+  }
+
+  private static <C> Optional<Consumer<Builder>> configurer(
+      String name, @Nullable HttpClientAuth<C> impl, @Nullable C config) {
+    return Optional.ofNullable(config).map(c -> b -> requireImpl(name, impl).configure(c, b));
+  }
+
+  private static <C> HttpClientAuth<C> requireImpl(String name, @Nullable HttpClientAuth<C> impl) {
+    return Optional.ofNullable(impl)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Cannot configure %s authentication, missing implementing class."
+                        .formatted(name)));
   }
 }

--- a/util/src/test/java/care/smith/fts/util/DefaultRetryStrategyTest.java
+++ b/util/src/test/java/care/smith/fts/util/DefaultRetryStrategyTest.java
@@ -122,6 +122,19 @@ class DefaultRetryStrategyTest {
   }
 
   @Test
+  void doesNotRetryOn3xx() {
+    // A 3xx surfaces when follow-redirects=NEVER lets a redirect reach WebClient (#1706). It is
+    // deterministic, so it must be terminal: no retry, propagated as an error, no latency penalty.
+    var calls = new AtomicInteger();
+    StepVerifier.withVirtualTime(() -> withRetry(calls, 1, responseException(307), "threeXX"))
+        .thenAwait(Duration.ofSeconds(60))
+        .expectError(WebClientResponseException.class)
+        .verify();
+    assertThat(calls.get()).isEqualTo(1);
+    assertThat(retryCount("threeXX")).isZero();
+  }
+
+  @Test
   void exhaustsAfterThreeRetries() {
     var calls = new AtomicInteger();
     StepVerifier.withVirtualTime(

--- a/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
@@ -1,5 +1,7 @@
 package care.smith.fts.util;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -13,7 +15,10 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.netty.http.client.HttpClient;
 
 @WireMockTest
 class WebClientDefaultsTest {
@@ -56,6 +61,52 @@ class WebClientDefaultsTest {
               assertThat(b.consentedPolicies().policyNames()).isNotEmpty();
             })
         .verifyComplete();
+  }
+
+  @Test
+  void followsTemporaryRedirect(WireMockRuntimeInfo wireMockRuntime) {
+    var address = wireMockRuntime.getHttpBaseUrl();
+    var wireMock = wireMockRuntime.getWireMock();
+    wireMock.register(
+        get(urlEqualTo("/source"))
+            .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
+    wireMock.register(
+        get(urlEqualTo("/target")).willReturn(aResponse().withStatus(200).withBody("ok")));
+
+    // A redirect-following connector (as built by WebClientFactory) must pass the followed
+    // response through the redirect-error filter untouched.
+    var connector = new ReactorClientHttpConnector(HttpClient.create().followRedirect(true));
+    WebClient.Builder webClientBuilder = WebClient.builder().clientConnector(connector);
+    new WebClientDefaults(objectMapper).customize(webClientBuilder);
+    WebClient webClient = webClientBuilder.baseUrl(address).build();
+
+    create(webClient.get().uri("/source").retrieve().bodyToMono(String.class))
+        .assertNext(s -> assertThat(s).isEqualTo("ok"))
+        .verifyComplete();
+  }
+
+  @Test
+  void unfollowedRedirectBecomesError(WireMockRuntimeInfo wireMockRuntime) {
+    var address = wireMockRuntime.getHttpBaseUrl();
+    var wireMock = wireMockRuntime.getWireMock();
+    // The default connector does not follow redirects, so the 3xx reaches WebClient and must
+    // surface as an error instead of an empty body silently passing through (#1706).
+    wireMock.register(
+        get(urlEqualTo("/source"))
+            .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
+
+    WebClient.Builder webClientBuilder = WebClient.builder();
+    new WebClientDefaults(objectMapper).customize(webClientBuilder);
+    WebClient webClient = webClientBuilder.baseUrl(address).build();
+
+    create(webClient.get().uri("/source").retrieve().bodyToMono(String.class))
+        .expectErrorSatisfies(
+            e ->
+                assertThat(e)
+                    .isInstanceOf(WebClientResponseException.class)
+                    .extracting(t -> ((WebClientResponseException) t).getStatusCode().value())
+                    .isEqualTo(307))
+        .verify();
   }
 
   @AfterEach

--- a/util/src/test/java/care/smith/fts/util/WebClientFactoryTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientFactoryTest.java
@@ -1,5 +1,8 @@
 package care.smith.fts.util;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,13 +10,21 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.web.reactive.function.client.WebClient.builder;
+import static reactor.test.StepVerifier.create;
 
+import care.smith.fts.util.HttpClientConfig.Redirects;
 import care.smith.fts.util.HttpClientConfig.Ssl;
 import care.smith.fts.util.auth.HttpClientAuth.Config;
 import care.smith.fts.util.auth.HttpClientBasicAuth;
 import care.smith.fts.util.auth.HttpClientCookieTokenAuth;
 import care.smith.fts.util.auth.HttpClientOAuth2Auth;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,29 +32,37 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ssl.NoSuchSslBundleException;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webclient.autoconfigure.WebClientSsl;
+import org.springframework.http.client.ReactorResourceFactory;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClient.Builder;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.netty.http.client.HttpClientRequest;
+import reactor.netty.http.client.HttpClientResponse;
 
 @Slf4j
 @SpringBootTest
+@WireMockTest
 @ExtendWith(MockitoExtension.class)
 class WebClientFactoryTest {
 
   WebClientFactory factory;
+  ReactorResourceFactory resourceFactory;
 
   @BeforeEach
   void setUp(
-      @Autowired WebClientSsl ssl,
+      @Autowired ReactorResourceFactory resourceFactory,
+      @Autowired SslBundles sslBundles,
       @Autowired(required = false) HttpClientBasicAuth basic,
       @Autowired(required = false) HttpClientCookieTokenAuth token) {
     log.info("WebClientFactoryTest setup");
     ReactiveOAuth2AuthorizedClientManager clientManager =
         mock(ReactiveOAuth2AuthorizedClientManager.class);
     var oauth2 = new HttpClientOAuth2Auth(clientManager);
-    factory = new WebClientFactory(builder(), ssl, basic, oauth2, token);
+    this.resourceFactory = resourceFactory;
+    factory = new WebClientFactory(builder(), resourceFactory, sslBundles, basic, oauth2, token);
   }
 
   @Test
@@ -71,7 +90,7 @@ class WebClientFactoryTest {
     var oauth2 = mock(HttpClientOAuth2Auth.class);
     var token = mock(HttpClientCookieTokenAuth.class);
     Builder builder = builder();
-    var factory = new WebClientFactory(builder, null, basic, oauth2, token);
+    var factory = new WebClientFactory(builder, resourceFactory, null, basic, oauth2, token);
 
     var basicConf = new HttpClientBasicAuth.Config("user-1505512", "pwd-15054518");
     var oauth2Conf = new HttpClientOAuth2Auth.Config("usr-142135");
@@ -86,8 +105,8 @@ class WebClientFactoryTest {
   }
 
   @Test
-  void createWithBasicAuthMissingImplementation(@Autowired WebClientSsl ssl) {
-    var factory = new WebClientFactory(builder(), ssl, null, null, null);
+  void createWithBasicAuthMissingImplementation(@Autowired SslBundles sslBundles) {
+    var factory = new WebClientFactory(builder(), resourceFactory, sslBundles, null, null, null);
 
     var auth = new HttpClientBasicAuth.Config("user-144512", "pwd-144538");
     var config = new HttpClientConfig("http://localhost", new Config(auth));
@@ -103,8 +122,8 @@ class WebClientFactoryTest {
   }
 
   @Test
-  void createWithOAuth2AuthMissingImplementation(@Autowired WebClientSsl ssl) {
-    var factory = new WebClientFactory(builder(), ssl, null, null, null);
+  void createWithOAuth2AuthMissingImplementation(@Autowired SslBundles sslBundles) {
+    var factory = new WebClientFactory(builder(), resourceFactory, sslBundles, null, null, null);
 
     var auth = new HttpClientOAuth2Auth.Config("usr-142135");
     var config = new HttpClientConfig("http://localhost", new Config(auth));
@@ -120,8 +139,8 @@ class WebClientFactoryTest {
   }
 
   @Test
-  void createWithTokenAuthMissingImplementation(@Autowired WebClientSsl ssl) {
-    var factory = new WebClientFactory(builder(), ssl, null, null, null);
+  void createWithTokenAuthMissingImplementation(@Autowired SslBundles sslBundles) {
+    var factory = new WebClientFactory(builder(), resourceFactory, sslBundles, null, null, null);
 
     var auth = new HttpClientCookieTokenAuth.Config("token-146520");
     var config = new HttpClientConfig("http://localhost", new Config(auth));
@@ -141,5 +160,121 @@ class WebClientFactoryTest {
     var config = new HttpClientConfig("http://localhost", new Ssl("missing-195151"));
     assertThatExceptionOfType(NoSuchSslBundleException.class)
         .isThrownBy(() -> factory.create(config));
+  }
+
+  @Test
+  void defaultRedirectsFollow(
+      @Autowired WebClient.Builder clientBuilder,
+      @Autowired SslBundles sslBundles,
+      WireMockRuntimeInfo wireMock) {
+    var mock = wireMock.getWireMock();
+    mock.register(
+        get(urlEqualTo("/source"))
+            .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
+    mock.register(
+        get(urlEqualTo("/target")).willReturn(aResponse().withStatus(200).withBody("ok")));
+
+    // No redirects configured -> defaults to FOLLOW_SAFE, so the 307 is followed transparently.
+    var factory =
+        new WebClientFactory(clientBuilder, resourceFactory, sslBundles, null, null, null);
+    var client = factory.create(new HttpClientConfig(wireMock.getHttpBaseUrl()));
+
+    create(client.get().uri("/source").retrieve().bodyToMono(String.class))
+        .assertNext(s -> assertThat(s).isEqualTo("ok"))
+        .verifyComplete();
+  }
+
+  @Test
+  void dontFollowRedirectsSurfacesError(
+      @Autowired WebClient.Builder clientBuilder,
+      @Autowired SslBundles sslBundles,
+      WireMockRuntimeInfo wireMock) {
+    var mock = wireMock.getWireMock();
+    mock.register(
+        get(urlEqualTo("/source"))
+            .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
+
+    // DONT_FOLLOW leaves the 307 unfollowed; WebClientDefaults turns it into an error rather than
+    // letting the empty body pass through as a silent success (#1706).
+    var factory =
+        new WebClientFactory(clientBuilder, resourceFactory, sslBundles, null, null, null);
+    var config = new HttpClientConfig(wireMock.getHttpBaseUrl(), null, null, Redirects.DONT_FOLLOW);
+    var client = factory.create(config);
+
+    create(client.get().uri("/source").retrieve().bodyToMono(String.class))
+        .expectError(WebClientResponseException.class)
+        .verify();
+  }
+
+  @Test
+  void alwaysFollowFollowsRedirect(
+      @Autowired WebClient.Builder clientBuilder,
+      @Autowired SslBundles sslBundles,
+      WireMockRuntimeInfo wireMock) {
+    var mock = wireMock.getWireMock();
+    mock.register(
+        get(urlEqualTo("/source"))
+            .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
+    mock.register(
+        get(urlEqualTo("/target")).willReturn(aResponse().withStatus(200).withBody("ok")));
+
+    var factory =
+        new WebClientFactory(clientBuilder, resourceFactory, sslBundles, null, null, null);
+    var config =
+        new HttpClientConfig(wireMock.getHttpBaseUrl(), null, null, Redirects.ALWAYS_FOLLOW);
+    var client = factory.create(config);
+
+    create(client.get().uri("/source").retrieve().bodyToMono(String.class))
+        .assertNext(s -> assertThat(s).isEqualTo("ok"))
+        .verifyComplete();
+  }
+
+  // FOLLOW_SAFE's HTTPS->HTTP downgrade refusal (the only thing distinguishing it from
+  // ALWAYS_FOLLOW) needs a real TLS upstream to exercise end-to-end, so the redirect predicate is
+  // verified directly.
+  @Test
+  void safeRedirectRefusesHttpsToHttpDowngrade() {
+    assertThat(safeRedirect("https://upstream/source", "http://other/target")).isFalse();
+  }
+
+  @Test
+  void safeRedirectFollowsSameSchemeUpgradeAndRelative() {
+    assertThat(safeRedirect("http://upstream/source", "http://other/target")).isTrue();
+    assertThat(safeRedirect("https://upstream/source", "https://other/target")).isTrue();
+    assertThat(safeRedirect("http://upstream/source", "https://other/target")).isTrue();
+    assertThat(safeRedirect("https://upstream/source", "/target")).isTrue();
+  }
+
+  @Test
+  void safeRedirectIgnoresNonRedirectStatus() {
+    var response = mock(HttpClientResponse.class);
+    when(response.status()).thenReturn(HttpResponseStatus.OK);
+
+    assertThat(WebClientFactory.isSafeRedirect(mock(HttpClientRequest.class), response)).isFalse();
+  }
+
+  @Test
+  void safeRedirectRefusesMissingLocationHeader() {
+    var response = mock(HttpClientResponse.class);
+    when(response.status()).thenReturn(HttpResponseStatus.TEMPORARY_REDIRECT);
+    when(response.responseHeaders()).thenReturn(new DefaultHttpHeaders());
+
+    assertThat(WebClientFactory.isSafeRedirect(mock(HttpClientRequest.class), response)).isFalse();
+  }
+
+  @Test
+  void safeRedirectWithUnknownRequestUrlFollows() {
+    // Without a request URL the downgrade check cannot apply, so the redirect is followed.
+    assertThat(safeRedirect(null, "http://other/target")).isTrue();
+  }
+
+  private static boolean safeRedirect(String requestUrl, String location) {
+    var request = mock(HttpClientRequest.class);
+    var response = mock(HttpClientResponse.class);
+    when(request.resourceUrl()).thenReturn(requestUrl);
+    when(response.status()).thenReturn(HttpResponseStatus.TEMPORARY_REDIRECT);
+    when(response.responseHeaders())
+        .thenReturn(new DefaultHttpHeaders().set(HttpHeaderNames.LOCATION, location));
+    return WebClientFactory.isSafeRedirect(request, response);
   }
 }


### PR DESCRIPTION
Closes #1706

## Problem

A CDA transfer silently produced **no data** when the HDS sat behind a reverse proxy answering HTTP **307**: the JDK `HttpClient` default `Redirect.NEVER` left the 3xx unfollowed, and `WebClient.retrieve()` (which only errors on 4xx/5xx) passed the empty-bodied 3xx through as a successful `Mono.empty()`. The transfer reported `phase=COMPLETED, totalBundles=0` with no error.

## Why per-upstream

Redirect following is a property of a specific connection — only some upstreams sit behind a redirecting proxy — so it belongs on `HttpClientConfig` (alongside `auth`/`ssl`), not on the shared per-agent client. On Spring Boot 4 the SSL path rebuilds the connector via `ClientHttpConnectorBuilder`, so a per-agent setting on the shared client would not even reach SSL upstreams. Building the connector per config fixes that and unifies redirect + SSL + connect-timeout on one client.

## Changes (util)

- **`HttpClientConfig`** — new `redirects` field using Spring's `HttpRedirects` (`FOLLOW_WHEN_POSSIBLE` | `FOLLOW` | `DONT_FOLLOW`), default `FOLLOW_WHEN_POSSIBLE` (JDK `NORMAL`). All existing constructors preserved.
- **`WebClientFactory`** — builds the connector per config via `ClientHttpConnectorBuilder.jdk().build(HttpClientSettings.withRedirects(...).withConnectTimeout(...).withSslBundle(...))`, replacing the `WebClientSsl.fromBundle` path. This is the same `connectorBuilder.build(settings.withSslBundle(bundle))` call Spring's `WebClientSsl` already made — just with `redirects` composed in.
- **`WebClientDefaults`** — defense in depth: any 3xx that still reaches WebClient (an unfollowed redirect under `DONT_FOLLOW`, or an HTTPS→HTTP downgrade) becomes an **error** instead of a silent empty success.
- **`DefaultRetryStrategy`** — a 3xx is classified **terminal, not retryable** (a redirect is deterministic; re-issuing the identical request yields the same redirect).

## Notes on the redirect ↔ retry interaction

Followed redirects are resolved in the JDK transport layer, below Reactor, so they never reach `RetryStrategy`. Only a redirect the policy declines surfaces — now as a loud error, deliberately not retried. `DONT_FOLLOW` therefore fails fast and forces a misconfigured upstream `baseUrl` to be corrected. (`FOLLOW` and `FOLLOW_WHEN_POSSIBLE` both map to JDK `NORMAL` for the JDK client; JDK `ALWAYS` is intentionally not exposed — Spring's connector builder cannot produce it.)

## Verification

- TDD throughout. New/updated tests: `WebClientFactoryTest` (default follows 307→200; `DONT_FOLLOW` → error via the filter), `WebClientDefaultsTest` (3xx → error), `DefaultRetryStrategyTest` (3xx terminal).
- Full `util` suite: 186/186, 0 checkstyle violations.
- SSL refactor verified end-to-end: TCA `AuthIT$CertAuthIT` (mutual TLS) and `BasicAuthIT` pass through the new `WebClientFactory`.
- Whole reactor test-compiles.

## Docs

`docs/types/HttpClientConfig.md` documents the `redirects` field + behaviour table; `docs/configuration/http-client.md` cross-references it.

## Follow-up

JDK HttpClient keep-alive hardening (set the property before the first `HttpClient` is built, out of the `httpClient` bean) is split out to #1728.
