### PR TITLE
Use Reactor Netty as Outbound HTTP Connector

### DIFF
--- a/clinical-domain-agent/application.yaml
+++ b/clinical-domain-agent/application.yaml
@@ -66,11 +66,11 @@
 ### FTS Outbound HTTP Client
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
 # fts.http.client:
-#   # Pool keep-alive for outbound http connections. Must stay below the
-#   # idle timeout of every upstream (for cd-agent: cd-hds Blaze 30s, tc-agent, rd-agent)
-#   # to avoid "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # Max time an idle pooled outbound connection is kept before eviction. Keep it below the
+#   # idle timeout of every upstream (for cd-agent: cd-hds Blaze 30s, tc-agent, rd-agent) so a
+#   # request never lands on a socket the upstream has already closed.
 #   # ISO-8601 duration; default PT25S.
-#   keepalive-timeout: PT25S
+#   max-idle-time: PT25S
 
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -1,5 +1,6 @@
 package care.smith.fts.cda;
 
+import static care.smith.fts.util.AgentConfiguration.MAX_OUTBOUND_FANOUT;
 import static care.smith.fts.util.JsonLogFormatter.asJson;
 import static care.smith.fts.util.NanoIdUtils.nanoId;
 import static java.util.stream.Stream.concat;
@@ -179,7 +180,9 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
       return cohortSelection
           .doOnNext(
               p -> log.trace("[Process {}] selectData for patient {}", processId(), p.identifier()))
-          .flatMap(this::selectDataForPatient)
+          // Bound the per-patient fan-out to the shared outbound connection budget so this stage
+          // never dispatches more concurrent upstream requests than the pool can hold.
+          .flatMap(this::selectDataForPatient, MAX_OUTBOUND_FANOUT)
           .doOnNext(
               b -> {
                 status.updateAndGet(TransferProcessStatus::incTotalBundles);
@@ -229,7 +232,9 @@ public class DefaultTransferProcessRunner implements TransferProcessRunner {
       var beforeMsg = "[Process {}] deidentify for patient {}";
       return dataSelection
           .doOnNext(b -> log.trace(beforeMsg, processId(), b.consentedPatient().identifier()))
-          .flatMap(this::deidentifyForPatient)
+          // Bound the per-patient fan-out to the shared outbound connection budget so this stage
+          // never dispatches more concurrent upstream requests than the pool can hold.
+          .flatMap(this::deidentifyForPatient, MAX_OUTBOUND_FANOUT)
           .doOnNext(
               b -> {
                 status.updateAndGet(TransferProcessStatus::incDeidentifiedBundles);

--- a/docs/configuration/http-client.md
+++ b/docs/configuration/http-client.md
@@ -1,44 +1,58 @@
 # HTTP Client <Badge type="tip" text="All Agents" /> <Badge type="tip" text="Optional" /> <Badge type="warning" text="Since 5.7" />
 
-All FTSnext agents share a pooled outbound HTTP client. This page documents the connection
-keep-alive timeout exposed for that pool.
+All FTSnext agents share a pooled outbound HTTP client backed by Reactor Netty. This page documents
+the connection-pool idle timeout exposed for that pool.
 
 ## Configuration Example
 
 ```yaml
 fts.http.client:
-  keepalive-timeout: PT25S
+  max-idle-time: PT25S
 ```
 
 ## Fields
 
-### `fts.http.client.keepalive-timeout` <Badge type="warning" text="Since 5.7" />
+### `fts.http.client.max-idle-time` <Badge type="warning" text="Since 5.7" />
 
-* **Description**: Maximum time an idle connection is kept in the pool before being closed.
-  Applies to every outbound HTTP call an agent makes. Requires an agent restart to take effect.
+* **Description**: Maximum time an idle connection is kept in the pool before it is evicted.
+  Applies to every outbound HTTP call an agent makes, on both plain and SSL/mTLS connections.
+  Requires an agent restart to take effect.
 * **Type**: ISO-8601 `Duration` (e.g. `PT25S`, `PT1M`)
 * **Default**: `PT25S`
 
 ## Notes
 
-### Pick a value below the lowest upstream idle timeout
+### How idle connections are handled
 
-If the keep-alive is **greater than or equal to** the idle timeout of any server the agent talks
-to, that server will silently close pooled sockets first. The next request reuses a half-dead
-socket, the write succeeds, the read returns EOF, and the call fails with:
+The Reactor Netty connection pool is configured programmatically per agent (no JVM-global system
+property). Two mechanisms keep pooled sockets healthy:
+
+* **Event-driven eviction**: a pooled connection sits on a Netty event loop, so when an upstream
+  closes an idle socket the resulting FIN triggers `channelInactive` and the connection is evicted
+  from the pool *before* it can be reused.
+* **`max-idle-time`**: connections idle longer than this are evicted on acquisition, and a
+  background sweep removes them even without traffic.
+
+Together these largely remove the "reuse a half-dead socket" failure that the JDK client was prone
+to, where the next request after an idle gap would write successfully but read EOF and fail with:
 
 ```
 WebClientRequestException: HTTP/1.1 header parser received no bytes
   caused by EOFException: EOF reached while reading
 ```
 
-This typically manifests as a burst of failures on the *first* request to an upstream after an
-idle gap, then stabilises once the pool is repopulated with fresh sockets.
+The connection's total lifetime is additionally capped (max life time) so long-lived pools pick up
+upstream changes (e.g. DNS or load-balancer rotation).
+
+### Pick a value below the lowest upstream idle timeout
+
+Eviction is event-driven, but the time-to-first-event window is not zero. Keeping `max-idle-time`
+below the idle timeout of every server the agent talks to ensures the pool drops a connection on
+its own schedule rather than racing the upstream's close.
 
 ### Per-agent upstreams
 
-Each agent talks to a different set of servers; size the keep-alive against the tightest of
-them.
+Each agent talks to a different set of servers; size `max-idle-time` against the tightest of them.
 
 | Agent | Outbound upstreams |
 | --- | --- |

--- a/research-domain-agent/application.yaml
+++ b/research-domain-agent/application.yaml
@@ -55,11 +55,11 @@
 ### FTS Outbound HTTP Client
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
 # fts.http.client:
-#   # Pool keep-alive for outbound http connections. Must stay below the
-#   # idle timeout of every upstream (for rd-agent: rd-hds Blaze 30s, tc-agent) to avoid
-#   # "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # Max time an idle pooled outbound connection is kept before eviction. Keep it below the
+#   # idle timeout of every upstream (for rd-agent: rd-hds Blaze 30s, tc-agent) so a request
+#   # never lands on a socket the upstream has already closed.
 #   # ISO-8601 duration; default PT25S.
-#   keepalive-timeout: PT25S
+#   max-idle-time: PT25S
 
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security

--- a/trust-center-agent/application.yaml
+++ b/trust-center-agent/application.yaml
@@ -71,11 +71,11 @@
 ### FTS Outbound HTTP Client
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/http-client
 # fts.http.client:
-#   # Pool keep-alive for outbound http connections. Must stay below the
-#   # idle timeout of every upstream (for tc-agent: gICS, gPAS) to avoid
-#   # "header parser received no bytes" / EOF on the first request after an idle gap.
+#   # Max time an idle pooled outbound connection is kept before eviction. Keep it below the
+#   # idle timeout of every upstream (for tc-agent: gICS, gPAS) so a request never lands on a
+#   # socket the upstream has already closed.
 #   # ISO-8601 duration; default PT25S.
-#   keepalive-timeout: PT25S
+#   max-idle-time: PT25S
 
 ### FTS Server Security Configuration
 ##! https://medizininformatik-initiative.github.io/fts-next/configuration/security

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -75,6 +75,14 @@
       <artifactId>spring-boot-starter-webclient</artifactId>
     </dependency>
 
+    <!-- Reactor Netty connection pool tuning (ConnectionProvider) for the shared outbound
+         WebClient. The Reactor Netty connector itself is the Spring Boot default; this brings the
+         pool-configuration API onto the main classpath. -->
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-http</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -1,7 +1,5 @@
 package care.smith.fts.util;
 
-import static java.time.Duration.ofSeconds;
-
 import ca.uhn.fhir.context.FhirContext;
 import care.smith.fts.util.auth.HttpServerAuthConfig;
 import care.smith.fts.util.auth.OAuth2ConfigurationExistsCondition;
@@ -10,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.TimeZone;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +16,13 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.ReactorResourceFactory;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import reactor.netty.resources.ConnectionProvider;
 
 @Configuration
 @Import({
@@ -47,26 +46,41 @@ public class AgentConfiguration {
   }
 
   /**
-   * Pooled JDK HTTP client used by every agent's outbound WebClient.
+   * Reactor Netty connection-pool resources shared by every agent's outbound WebClient. Spring Boot
+   * feeds this {@link ReactorResourceFactory} into the auto-detected Reactor Netty connector, so
+   * the same pool backs both plain and SSL/mTLS clients.
    *
-   * <p>JDK HttpClient exposes no builder API for connection-pool keep-alive; the only knob is the
-   * {@code jdk.httpclient.keepalive.timeout} system property. We set it here so the pool evicts
-   * cached connections before any upstream server closes them on its own idle timeout. The value
-   * must stay below the lowest idle timeout among the agent's upstreams; if client keep-alive ≥
-   * server idle, the pool reuses a half-dead socket and the first request after an idle gap fails
-   * with "HTTP/1.1 header parser received no bytes" / {@code EOFException}.
+   * <p>Unlike the JDK client's single JVM-global {@code jdk.httpclient.keepalive.timeout} knob, the
+   * pool is configured programmatically: {@code maxIdleTime} evicts connections idle longer than
+   * the configured duration, and a pooled channel sits on an event loop so a server FIN evicts it
+   * before reuse. Together these largely remove the "reuse a half-dead socket → EOF after an idle
+   * gap" failure mode without under-tuning a global timeout. {@code maxLifeTime} caps total
+   * connection age and {@code evictInBackground} sweeps expired connections without waiting for
+   * traffic.
    *
-   * <p>Default 25s targets the tightest upstream we know about: Samply Blaze (Jetty, 30s idle),
-   * reached by cd-agent and rd-agent via cd-hds / rd-hds. tc-agent talks to gICS and gPAS
-   * (WildFly/Undertow) and serves inbound calls from cd-/rd-agent itself, so the same pool covers
-   * those flows too. See {@code docs/configuration/http-client.md}.
+   * <p>{@code maxIdleTime} should still stay below the tightest upstream idle timeout (e.g. Samply
+   * Blaze defaults to 30s). See {@code docs/configuration/http-client.md}.
+   *
+   * <p>Marked {@code @Primary} because Spring Boot still auto-configures its own {@code
+   * reactorResourceFactory}; without a primary, the Netty server's single-typed injection of {@code
+   * ReactorResourceFactory} is ambiguous. With {@code @Primary}, both the outbound client connector
+   * and the Netty server resolve to this instance. The connection pool is only exercised by
+   * outbound clients; the server merely shares its event-loop resources.
    */
   @Bean
-  public HttpClient httpClient(
-      @Value("${fts.http.client.keepalive-timeout:PT25S}") Duration keepaliveTimeout) {
-    System.setProperty(
-        "jdk.httpclient.keepalive.timeout", String.valueOf(keepaliveTimeout.toSeconds()));
-    return HttpClient.newBuilder().connectTimeout(ofSeconds(10)).build();
+  @Primary
+  public ReactorResourceFactory ftsClientResources(
+      @Value("${fts.http.client.max-idle-time:PT25S}") Duration maxIdleTime) {
+    var connectionProvider =
+        ConnectionProvider.builder("fts-http-client")
+            .maxIdleTime(maxIdleTime)
+            .maxLifeTime(Duration.ofMinutes(5))
+            .evictInBackground(Duration.ofSeconds(30))
+            .build();
+    var resourceFactory = new ReactorResourceFactory();
+    resourceFactory.setUseGlobalResources(false);
+    resourceFactory.setConnectionProvider(connectionProvider);
+    return resourceFactory;
   }
 
   @Bean

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -35,6 +35,16 @@ import reactor.netty.resources.ConnectionProvider;
 })
 public class AgentConfiguration {
 
+  /**
+   * Per-host outbound concurrency budget. The transfer pipeline's highest-fan-out stages (patient
+   * select, de-identify) dispatch up to this many concurrent requests onto a single upstream host;
+   * the shared connection pool is capped at the same value (see {@link #ftsClientResources}) so the
+   * transport never throttles the pipeline below its dispatch rate. Kept as one constant,
+   * referenced by both the pool cap and the pipeline {@code flatMap} concurrency, so the two cannot
+   * drift.
+   */
+  public static final int MAX_OUTBOUND_FANOUT = 256;
+
   @Bean
   public FhirContext fhirContext() {
     return FhirContext.forR4();
@@ -61,6 +71,13 @@ public class AgentConfiguration {
    * <p>{@code maxIdleTime} should still stay below the tightest upstream idle timeout (e.g. Samply
    * Blaze defaults to 30s). See {@code docs/configuration/http-client.md}.
    *
+   * <p>{@code maxConnections} caps in-flight connections <em>per upstream host</em> at {@link
+   * #MAX_OUTBOUND_FANOUT}, the same value the pipeline fans out at, so the pool never throttles a
+   * transfer below its dispatch rate. Left unset, the pool would fall back to reactor-netty's
+   * library default ({@code max(cores,8)*2}, &ge;16) and reject or stall bursts. {@code
+   * pendingAcquireTimeout} is aligned with the request-timeout filter so a saturated pool fails
+   * fast with a meaningful pool error rather than the generic 45s default.
+   *
    * <p>Marked {@code @Primary} because Spring Boot still auto-configures its own {@code
    * reactorResourceFactory}; without a primary, the Netty server's single-typed injection of {@code
    * ReactorResourceFactory} is ambiguous. With {@code @Primary}, both the outbound client connector
@@ -73,6 +90,8 @@ public class AgentConfiguration {
       @Value("${fts.http.client.max-idle-time:PT25S}") Duration maxIdleTime) {
     var connectionProvider =
         ConnectionProvider.builder("fts-http-client")
+            .maxConnections(MAX_OUTBOUND_FANOUT)
+            .pendingAcquireTimeout(Duration.ofSeconds(10))
             .maxIdleTime(maxIdleTime)
             .maxLifeTime(Duration.ofMinutes(5))
             .evictInBackground(Duration.ofSeconds(30))

--- a/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
+++ b/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
@@ -3,10 +3,8 @@ package care.smith.fts.util;
 import static java.time.Duration.ofSeconds;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.http.HttpClient;
 import org.springframework.boot.webclient.WebClientCustomizer;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.reactive.JdkClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
@@ -24,18 +22,20 @@ public class WebClientDefaults implements WebClientCustomizer {
         MediaType.APPLICATION_PROBLEM_JSON
       };
 
-  private final HttpClient httpClient;
   private final ObjectMapper objectMapper;
 
-  public WebClientDefaults(HttpClient httpClient, ObjectMapper objectMapper) {
-    this.httpClient = httpClient;
+  public WebClientDefaults(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
   }
 
+  /**
+   * Applies shared request defaults. The outbound connector is left to Spring Boot's auto-detected
+   * Reactor Netty {@code ClientHttpConnector} (tuned via {@code ftsClientResources}); overriding it
+   * here would also discard the connection-pool configuration on the SSL/mTLS path.
+   */
   @Override
   public void customize(WebClient.Builder builder) {
     builder
-        .clientConnector(new JdkClientHttpConnector(httpClient))
         .filter((r, n) -> n.exchange(r).timeout(ofSeconds(10)))
         .codecs(this::configureObjectMapper);
   }

--- a/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
+++ b/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
@@ -3,43 +3,18 @@ package care.smith.fts.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.client.ReactorResourceFactory;
 
 class AgentConfigurationTest {
 
-  private static final String KEEPALIVE_PROP = "jdk.httpclient.keepalive.timeout";
-
-  private String savedKeepalive;
-
-  @BeforeEach
-  void snapshot() {
-    savedKeepalive = System.getProperty(KEEPALIVE_PROP);
-    System.clearProperty(KEEPALIVE_PROP);
-  }
-
-  @AfterEach
-  void restore() {
-    if (savedKeepalive == null) {
-      System.clearProperty(KEEPALIVE_PROP);
-    } else {
-      System.setProperty(KEEPALIVE_PROP, savedKeepalive);
-    }
-  }
-
   @Test
-  void httpClientSetsKeepaliveSystemProperty() {
-    var client = new AgentConfiguration().httpClient(Duration.ofSeconds(17));
+  void clientResourcesUseADedicatedConnectionProvider() {
+    ReactorResourceFactory resources =
+        new AgentConfiguration().ftsClientResources(Duration.ofSeconds(17));
 
-    assertThat(client).isNotNull();
-    assertThat(System.getProperty(KEEPALIVE_PROP)).isEqualTo("17");
-  }
-
-  @Test
-  void httpClientRoundsToSecondsForSubSecondDurations() {
-    new AgentConfiguration().httpClient(Duration.ofMillis(1500));
-
-    assertThat(System.getProperty(KEEPALIVE_PROP)).isEqualTo("1");
+    assertThat(resources).isNotNull();
+    assertThat(resources.getConnectionProvider()).isNotNull();
+    assertThat(resources.getConnectionProvider().name()).isEqualTo("fts-http-client");
   }
 }

--- a/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
+++ b/util/src/test/java/care/smith/fts/util/AgentConfigurationTest.java
@@ -17,4 +17,17 @@ class AgentConfigurationTest {
     assertThat(resources.getConnectionProvider()).isNotNull();
     assertThat(resources.getConnectionProvider().name()).isEqualTo("fts-http-client");
   }
+
+  @Test
+  void clientResourcesCapConnectionsToTheOutboundFanout() {
+    ReactorResourceFactory resources =
+        new AgentConfiguration().ftsClientResources(Duration.ofSeconds(25));
+
+    // The per-host cap must equal the pipeline's fan-out (one constant, shared with the
+    // select/deidentify flatMaps) so the pool never throttles a transfer below its dispatch rate.
+    // Without the explicit cap the pool would fall back to reactor-netty's library default
+    // (max(cores,8)*2, >=16) and reject or stall high-fan-out bursts.
+    assertThat(resources.getConnectionProvider().maxConnections())
+        .isEqualTo(AgentConfiguration.MAX_OUTBOUND_FANOUT);
+  }
 }

--- a/util/src/test/java/care/smith/fts/util/IdleConnectionReuseTest.java
+++ b/util/src/test/java/care/smith/fts/util/IdleConnectionReuseTest.java
@@ -1,0 +1,52 @@
+package care.smith.fts.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.test.StepVerifier.create;
+
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Pins down the connection-pool behaviour that motivated the connector swap (issue #1729). The
+ * shared outbound {@link WebClient} must honour a per-pool {@code max-idle-time}: a connection that
+ * has been idle longer than that is evicted rather than reused, so a request never lands on a
+ * socket an upstream may have closed underneath us. The JDK connector has no per-pool idle eviction
+ * (only a JVM-global keep-alive, here the {@code PT25S} default) and reuses the still-pooled
+ * socket; the Reactor Netty connector evicts it and opens a fresh connection.
+ */
+@SpringBootTest(properties = "fts.http.client.max-idle-time=PT0.1S")
+class IdleConnectionReuseTest {
+
+  @Autowired WebClient.Builder webClientBuilder;
+  @Autowired ApplicationContext applicationContext;
+
+  @Test
+  void opensFreshConnectionAfterMaxIdleTimeElapses() throws Exception {
+    try (var server = new KeepAliveTestServer()) {
+      WebClient client = webClientBuilder.baseUrl(server.baseUrl()).build();
+
+      create(client.get().retrieve().bodyToMono(String.class)).expectNext("{}").verifyComplete();
+
+      // Idle for longer than max-idle-time (100ms) while the server keeps the socket open. The
+      // pool evicts on acquisition when idle time exceeds max-idle-time, so the 5x margin (not the
+      // background eviction sweep) is what makes the next request deterministically open a fresh
+      // connection.
+      Thread.sleep(500);
+
+      create(client.get().retrieve().bodyToMono(String.class)).expectNext("{}").verifyComplete();
+
+      // The idle connection was evicted, so the second request opened a fresh one instead of
+      // reusing the pooled socket.
+      assertThat(server.connectionsAccepted()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void doesNotRegisterJdkHttpClientBean() {
+    assertThat(applicationContext.getBeanNamesForType(HttpClient.class)).isEmpty();
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/KeepAliveTestServer.java
+++ b/util/src/test/java/care/smith/fts/util/KeepAliveTestServer.java
@@ -1,0 +1,108 @@
+package care.smith.fts.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Minimal HTTP/1.1 test server that holds every connection open as a persistent keep-alive socket,
+ * serving any number of requests on the same connection. It never closes a connection itself, so a
+ * client is free to reuse a pooled socket indefinitely.
+ *
+ * <p>This lets a test distinguish connection <em>reuse</em> from a <em>fresh</em> connection purely
+ * by counting accepts: if the outbound pool reuses an idle socket the count stays at one; if the
+ * pool evicts the idle socket (e.g. because its {@code maxIdleTime} elapsed) the next request opens
+ * a new connection and the count rises. See {@link #connectionsAccepted()}.
+ */
+final class KeepAliveTestServer implements AutoCloseable {
+
+  private final ServerSocket serverSocket;
+  private final ExecutorService workers =
+      Executors.newCachedThreadPool(
+          r -> {
+            var t = new Thread(r, "keep-alive-test-server");
+            t.setDaemon(true);
+            return t;
+          });
+  private final AtomicInteger connectionsAccepted = new AtomicInteger();
+
+  KeepAliveTestServer() throws IOException {
+    serverSocket = new ServerSocket();
+    serverSocket.bind(new InetSocketAddress("localhost", 0));
+    workers.submit(this::acceptLoop);
+  }
+
+  String baseUrl() {
+    return "http://localhost:" + serverSocket.getLocalPort();
+  }
+
+  int connectionsAccepted() {
+    return connectionsAccepted.get();
+  }
+
+  private void acceptLoop() {
+    while (!serverSocket.isClosed()) {
+      try {
+        Socket socket = serverSocket.accept();
+        connectionsAccepted.incrementAndGet();
+        workers.submit(() -> servePersistently(socket));
+      } catch (IOException e) {
+        return; // server socket closed → stop accepting
+      }
+    }
+  }
+
+  private void servePersistently(Socket socket) {
+    try (socket) {
+      InputStream in = socket.getInputStream();
+      OutputStream out = socket.getOutputStream();
+      while (readRequestHeaders(in)) {
+        byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+        String head =
+            "HTTP/1.1 200 OK\r\n"
+                + "Content-Type: application/json\r\n"
+                + "Content-Length: "
+                + body.length
+                + "\r\n"
+                + "Connection: keep-alive\r\n"
+                + "\r\n";
+        out.write(head.getBytes(StandardCharsets.US_ASCII));
+        out.write(body);
+        out.flush();
+      }
+    } catch (IOException ignored) {
+      // client closed the connection or the server is shutting down
+    }
+  }
+
+  /**
+   * Reads and discards one request's headers up to the blank line that terminates them. Returns
+   * {@code false} when the stream reaches EOF before a full request arrives (client hung up).
+   */
+  private static boolean readRequestHeaders(InputStream in) throws IOException {
+    int matched = 0; // chars of the \r\n\r\n terminator matched so far
+    int b;
+    while (matched < 4 && (b = in.read()) != -1) {
+      boolean expectCarriageReturn = matched == 0 || matched == 2;
+      if ((expectCarriageReturn && b == '\r') || (!expectCarriageReturn && b == '\n')) {
+        matched++;
+      } else {
+        matched = (b == '\r') ? 1 : 0;
+      }
+    }
+    return matched == 4;
+  }
+
+  @Override
+  public void close() throws IOException {
+    serverSocket.close();
+    workers.shutdownNow();
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
@@ -3,7 +3,6 @@ package care.smith.fts.util;
 import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.test.StepVerifier.create;
 
@@ -12,7 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import java.net.http.HttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -22,8 +20,6 @@ class WebClientDefaultsTest {
 
   private static final ObjectMapper objectMapper =
       new ObjectMapper().registerModule(new JavaTimeModule());
-  private static final HttpClient httpClient =
-      HttpClient.newBuilder().connectTimeout(ofSeconds(10)).build();
 
   @Test
   void customizeWebClientAndDecodeToMono(WireMockRuntimeInfo wireMockRuntime) {
@@ -49,7 +45,7 @@ class WebClientDefaultsTest {
                     200)));
 
     WebClient.Builder webClientBuilder = WebClient.builder();
-    new WebClientDefaults(httpClient, objectMapper).customize(webClientBuilder);
+    new WebClientDefaults(objectMapper).customize(webClientBuilder);
     WebClient webClient = webClientBuilder.baseUrl(address).build();
 
     create(webClient.post().retrieve().bodyToMono(ConsentedPatient.class))


### PR DESCRIPTION
## Summary

Swaps the shared outbound `WebClient` connector from the JDK `JdkClientHttpConnector` to Reactor Netty (the Spring Boot framework default; reactor-netty is already on every agent's runtime classpath via `spring-boot-starter-webflux`). This is a connector swap, not a dependency change.

- Replaces the `HttpClient` bean + the JVM-global `System.setProperty("jdk.httpclient.keepalive.timeout", …)` hack with a tuned Reactor Netty `ConnectionProvider`, exposed via an `@Primary` `ReactorResourceFactory`.
- `WebClientDefaults` no longer overrides the connector. Spring Boot's auto-detected Reactor connector (built from `ReactorResourceFactory`) now backs **both** plain clients and `WebClientSsl.fromBundle` (mTLS) clients — they share one pool. This also fixes a pre-existing inconsistency where SSL clients already used Reactor Netty while plain clients used the JDK connector.
- The request-timeout filter (`PT10S`) and retry strategy are unchanged.

## Why

The JDK client's only keep-alive control was a single JVM-global system property, with no per-pool idle eviction, max-life, background eviction, or pre-reuse liveness validation. Reactor Netty's `ConnectionProvider` evicts connections idle past `max-idle-time` and, because a pooled channel lives on an event loop, evicts on a server FIN (`channelInactive`) before reuse — largely removing the "reuse a half-dead socket → EOF after an idle gap" failure without under-tuning a global timeout.

## Config change

Renames `fts.http.client.keepalive-timeout` → `fts.http.client.max-idle-time` (drives `ConnectionProvider.maxIdleTime`, default `PT25S`). `maxLifeTime` (5m) and `evictInBackground` (30s) use sensible non-configurable defaults. Docs and the three agent `application.yaml` examples are updated.

## Notes for reviewers

- The `ReactorResourceFactory` is `@Primary` because Spring Boot still auto-configures its own `reactorResourceFactory` (its `@ConditionalOnMissingBean` does not back off for the differently-named bean); without `@Primary` the Netty server's single-typed injection is ambiguous. The connection pool is only exercised by outbound clients; the server merely shares event-loop resources.
- `IdleConnectionReuseTest` (added first, TDD) drives the production-wired `WebClient` against a raw keep-alive server: with the JDK connector it reuses the idle socket (1 connection); with Reactor Netty + a short `max-idle-time` it evicts and opens a fresh one (2 connections).

## Validation

`util` full verify (incl. the new idle-eviction + structural tests), `clinical-domain-agent` full verify (142 ITs incl. connection-scenario/retry resilience), and `AuthIT` (Basic + mTLS `CertAuthIT` + OAuth2) on all three agents — all green.

Closes #1729