### PR TITLE
Harden Link Check Against Flaky Hosts

### DIFF
--- a/.github/release/check-links.sh
+++ b/.github/release/check-links.sh
@@ -47,19 +47,41 @@ check_url() {
         return 0
     fi
 
-    # Check URL availability
-    if curl --retry 3 --max-time 2 -fsL --head "$url" >/dev/null 2>&1; then
+    # Check URL availability. A fast HEAD probe handles the common case; on any
+    # failure (transient WAF 403/429, slow TLS, or servers that reject HEAD with
+    # 405) fall back to a robust ranged GET that retries with backoff. A
+    # browser user-agent avoids reputation-based bot blocking by external hosts.
+    # -S makes curl emit the underlying error despite -s, so a hard failure can
+    # report *why* (HTTP status / connection error) instead of a bare url.
+    local ua="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    local common=(-A "$ua" -fsSL --connect-timeout 10 --max-time 20)
+    if curl "${common[@]}" -I "$url" >/dev/null 2>&1; then
         echo "✓ URL is available: $url"
         return 0
+    fi
+
+    # Capture the fallback's stderr (retry warnings + final error) so we can
+    # surface curl's diagnostic on failure.
+    local err
+    if err=$(curl "${common[@]}" -r 0-0 \
+                 --retry 5 --retry-all-errors --retry-delay 1 --retry-max-time 30 \
+                 "$url" 2>&1 >/dev/null); then
+        echo "✓ URL is available: $url"
+        return 0
+    fi
+
+    # Collapse the multi-line output to its last meaningful line (the final
+    # "curl: (NN) ..." error) for a compact, informative message.
+    local detail
+    detail=$(printf '%s\n' "$err" | grep -v '^[[:space:]]*$' | tail -n 1) || true
+
+    # Check if this URL is in the required list
+    if url_matches_list "$url" "$required_urls"; then
+      echo "✗ URL is unavailable: $url${detail:+ — $detail}"
+      return 1  # Exit with error for required URLs
     else
-        # Check if this URL is in the required list
-        if url_matches_list "$url" "$required_urls"; then
-          echo "✗ URL is unavailable: $url"
-          return 1  # Exit with error for required URLs
-        else
-          echo "⚠ Optional URL is unavailable: $url" >&2
-          return 0  # Don't fail for optional URLs
-        fi
+      echo "⚠ Optional URL is unavailable: $url${detail:+ — $detail}" >&2
+      return 0  # Don't fail for optional URLs
     fi
 }
 


### PR DESCRIPTION
## Problem

The `Check Link Targets` step in `create-release` intermittently hard-failed when external hosts (notably hl7.org's WAF) transiently blocked GitHub Actions (Azure) runner IPs by reputation. The single curl in `check-links.sh` was fragile:

- `--max-time 2` — too tight for cold DNS/TLS to distant hosts.
- `--head` — some servers reject `HEAD` with `405`.
- Default curl user-agent — invites WAF/bot blocking.

## Change (Layer 1 hardening)

Replace the single request in `check_url` with a **fast HEAD probe + robust ranged-GET fallback**:

- Browser-like `-A` user-agent (defeats UA-based bot blocking).
- `--retry 5 --retry-all-errors --retry-delay 1 --retry-max-time 30` — retries `403`/`429`, not just `5xx`, with bounded backoff.
- `--connect-timeout 10 --max-time 20` — replaces the 2s timeout.
- HEAD first (fast path); on any failure, fall back to a 1-byte ranged `GET` (`-r 0-0`) for servers that reject HEAD.

All URLs stay in `required` — genuinely dead links still fail the check.

## Scope / limitations

This addresses UA-based blocking, `HEAD`-405 rejection, tight timeouts, and transient `429`/`5xx` throttling (via backoff). It does **not** fix a *persistent* IP-reputation block for the duration of a run: retries reuse the same runner IP and user-agent, so a WAF decision keyed purely on the source IP would still hard-fail. Removing WAF-prone third-party hosts from `required` (a separate policy change) would be needed to fully decouple the release from those hosts' availability.

## Acceptance criteria

- [x] Reduces transient `403`/`429`/timeout failures from external hosts (browser UA + retry-all-errors with backoff, HEAD→GET fallback).
- [x] Genuinely dead internal/documentation links still fail the check.

Closes #1741
