### PR TITLE
Expose cohort selection concurrency as runner config

### DIFF
--- a/clinical-domain-agent/application.yaml
+++ b/clinical-domain-agent/application.yaml
@@ -5,6 +5,8 @@
 #   maxSendConcurrency: 32
 #   # Maximum number of processes that can run concurrently
 #   maxConcurrentProcesses: 4
+#   # Number of rails used to group patients and consents during cohort selection
+#   cohortSelectionConcurrency: 4
 #   # Time-to-live for a process, specified as an ISO-8601 duration (e.g., P1D means 1 day)
 #   # see https://de.wikipedia.org/wiki/ISO_8601
 #   processTtl: P1D

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
@@ -1,6 +1,7 @@
 package care.smith.fts.cda;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNullElse;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -17,13 +18,27 @@ public record TransferProcessRunnerConfig(
      */
     Integer maxSendConcurrency,
     Integer maxConcurrentProcesses,
+
+    /*
+     * Number of rails used to group patients and their consents during cohort selection. Bounds the
+     * CPU-bound grouping work to a dedicated Reactor scheduler instead of the JVM-wide common
+     * ForkJoinPool. Defaults to DEFAULT_COHORT_SELECTION_CONCURRENCY when unset.
+     */
+    Integer cohortSelectionConcurrency,
     Duration processTtl) {
 
+  /** Default number of cohort selection rails when {@code cohortSelectionConcurrency} is unset. */
+  public static final int DEFAULT_COHORT_SELECTION_CONCURRENCY = 4;
+
   public TransferProcessRunnerConfig {
+    cohortSelectionConcurrency =
+        requireNonNullElse(cohortSelectionConcurrency, DEFAULT_COHORT_SELECTION_CONCURRENCY);
     checkArgument(maxConcurrentPatients > 1, "runner.maxConcurrentPatients must be greater than 0");
     checkArgument(maxSendConcurrency > 1, "runner.maxSendConcurrency must be greater than 0");
     checkArgument(
         maxSendConcurrency <= maxConcurrentPatients,
         "runner.maxSendConcurrency must not exceed runner.maxConcurrentPatients");
+    checkArgument(
+        cohortSelectionConcurrency > 0, "runner.cohortSelectionConcurrency must be greater than 0");
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
@@ -14,7 +14,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -26,18 +25,24 @@ import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 class FhirCohortSelector implements CohortSelector {
   private final FhirCohortSelectorConfig config;
   private final WebClient fhirClient;
   private final RetryStrategy retryStrategy;
+  private final int cohortSelectionConcurrency;
 
   public FhirCohortSelector(
-      FhirCohortSelectorConfig config, WebClient fhirClient, RetryStrategy retryStrategy) {
+      FhirCohortSelectorConfig config,
+      WebClient fhirClient,
+      RetryStrategy retryStrategy,
+      int cohortSelectionConcurrency) {
     this.config = config;
     this.fhirClient = fhirClient;
     this.retryStrategy = retryStrategy;
+    this.cohortSelectionConcurrency = cohortSelectionConcurrency;
   }
 
   @Override
@@ -95,30 +100,41 @@ class FhirCohortSelector implements CohortSelector {
 
   private Flux<ConsentedPatient> extractConsentedPatients(Bundle bundle) {
     var patientIdentifierSystem = config.patientIdentifierSystem();
-    var bundles = groupPatientsAndConsents(bundle);
-    return Flux.fromStream(
-            processConsentedPatients(
-                patientIdentifierSystem,
-                config.policySystem(),
-                bundles,
-                config.policies(),
-                b -> getPatientIdentifier(patientIdentifierSystem, b)))
+    return groupPatientsAndConsents(bundle)
+        .mapNotNull(
+            b ->
+                processConsentedPatient(
+                        patientIdentifierSystem,
+                        config.policySystem(),
+                        b,
+                        config.policies(),
+                        p -> getPatientIdentifier(patientIdentifierSystem, p))
+                    .orElse(null))
         .doOnNext(p -> log.trace("extractConsentedPatients: emitted {}", p.identifier()))
         .doOnComplete(() -> log.trace("extractConsentedPatients completed for bundle"));
   }
 
-  private static Stream<Bundle> groupPatientsAndConsents(Bundle bundle) {
-    var patients = typedResourceStream(bundle, Patient.class);
-    return patients
-        .parallel()
-        .map(
-            p -> {
-              var inner = new Bundle().addEntry(new BundleEntryComponent().setResource(p));
-              typedResourceStream(bundle, Consent.class)
-                  .filter(c -> isConsentOfPatient(p, c))
-                  .forEach(c -> inner.addEntry(new BundleEntryComponent().setResource(c)));
-              return inner;
-            });
+  /**
+   * Groups each patient in the bundle with its matching consents. The CPU-bound grouping runs on a
+   * bounded {@link reactor.core.publisher.ParallelFlux} with {@code cohortSelectionConcurrency}
+   * rails on a dedicated Reactor scheduler, instead of the JVM-wide common ForkJoinPool that a
+   * parallel {@link java.util.stream.Stream} would use.
+   */
+  private Flux<Bundle> groupPatientsAndConsents(Bundle bundle) {
+    var patients = typedResourceStream(bundle, Patient.class).toList();
+    return Flux.fromIterable(patients)
+        .parallel(cohortSelectionConcurrency)
+        .runOn(Schedulers.parallel())
+        .map(p -> groupPatientWithConsents(bundle, p))
+        .sequential();
+  }
+
+  private static Bundle groupPatientWithConsents(Bundle bundle, Patient p) {
+    var inner = new Bundle().addEntry(new BundleEntryComponent().setResource(p));
+    typedResourceStream(bundle, Consent.class)
+        .filter(c -> isConsentOfPatient(p, c))
+        .forEach(c -> inner.addEntry(new BundleEntryComponent().setResource(c)));
+    return inner;
   }
 
   private static boolean isConsentOfPatient(Patient patient, Consent c) {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
@@ -1,6 +1,7 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.cda.TransferProcessRunnerConfig;
 import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import org.springframework.stereotype.Component;
@@ -10,10 +11,15 @@ public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCoh
 
   private final WebClientFactory clientFactory;
   private final RetryStrategy retryStrategy;
+  private final int cohortSelectionConcurrency;
 
-  public FhirCohortSelectorFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
+  public FhirCohortSelectorFactory(
+      WebClientFactory clientFactory,
+      RetryStrategy retryStrategy,
+      TransferProcessRunnerConfig runnerConfig) {
     this.clientFactory = clientFactory;
     this.retryStrategy = retryStrategy;
+    this.cohortSelectionConcurrency = runnerConfig.cohortSelectionConcurrency();
   }
 
   @Override
@@ -24,6 +30,6 @@ public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCoh
   @Override
   public CohortSelector create(CohortSelector.Config ignored, FhirCohortSelectorConfig config) {
     var client = clientFactory.create(config.server());
-    return new FhirCohortSelector(config, client, retryStrategy);
+    return new FhirCohortSelector(config, client, retryStrategy, cohortSelectionConcurrency);
   }
 }

--- a/clinical-domain-agent/src/main/resources/application.yaml
+++ b/clinical-domain-agent/src/main/resources/application.yaml
@@ -24,6 +24,7 @@ runner:
   maxConcurrentPatients: 8
   maxSendConcurrency: 2
   maxConcurrentProcesses: 4
+  cohortSelectionConcurrency: 4
   processTtl: P1D
 
 springdoc:

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -50,7 +50,7 @@ class DefaultTransferProcessRunnerTest {
   private final TransferProcessConfig rawConfig = new TransferProcessConfig(null, null, null, null);
 
   DefaultTransferProcessRunnerTest() {
-    config = new TransferProcessRunnerConfig(64, 64, 2, Duration.ofSeconds(3));
+    config = new TransferProcessRunnerConfig(64, 64, 2, 4, Duration.ofSeconds(3));
   }
 
   @BeforeEach
@@ -217,7 +217,7 @@ class DefaultTransferProcessRunnerTest {
 
   @Test
   void ttl() throws InterruptedException {
-    var config = new TransferProcessRunnerConfig(64, 64, 2, Duration.ofMillis(100));
+    var config = new TransferProcessRunnerConfig(64, 64, 2, 4, Duration.ofMillis(100));
     var process =
         new TransferProcessDefinition(
             "test",
@@ -572,7 +572,7 @@ class DefaultTransferProcessRunnerTest {
     int patientCount = 10;
     int maxSend = 2;
 
-    var cfg = new TransferProcessRunnerConfig(8, maxSend, 1, Duration.ofSeconds(10));
+    var cfg = new TransferProcessRunnerConfig(8, maxSend, 1, 4, Duration.ofSeconds(10));
     var boundedRunner = new DefaultTransferProcessRunner(new ObjectMapper(), cfg);
 
     var inFlight = new AtomicInteger(0);

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
@@ -1,5 +1,6 @@
 package care.smith.fts.cda;
 
+import static care.smith.fts.cda.TransferProcessRunnerConfig.DEFAULT_COHORT_SELECTION_CONCURRENCY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -10,35 +11,52 @@ class TransferProcessRunnerConfigTest {
 
   @Test
   void bindsWhenSendConcurrencyWithinPrefetchWindow() {
-    var config = new TransferProcessRunnerConfig(8, 2, 4, Duration.ofDays(1));
+    var config = new TransferProcessRunnerConfig(8, 2, 4, 4, Duration.ofDays(1));
     assertThat(config.maxConcurrentPatients()).isEqualTo(8);
     assertThat(config.maxSendConcurrency()).isEqualTo(2);
+    assertThat(config.cohortSelectionConcurrency()).isEqualTo(4);
   }
 
   @Test
   void failsWhenSendConcurrencyExceedsPrefetchWindow() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(2, 8, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(2, 8, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must not exceed runner.maxConcurrentPatients");
   }
 
   @Test
   void failsWhenMaxConcurrentPatientsIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(1, 2, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(1, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
   }
 
   @Test
   void failsWhenMaxSendConcurrencyIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 1, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 1, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
+  }
+
+  @Test
+  void cohortSelectionConcurrencyDefaultsWhenNull() {
+    var config = new TransferProcessRunnerConfig(8, 2, 4, null, Duration.ofDays(1));
+    assertThat(config.cohortSelectionConcurrency()).isEqualTo(DEFAULT_COHORT_SELECTION_CONCURRENCY);
+  }
+
+  @Test
+  void failsWhenCohortSelectionConcurrencyIsZeroOrNegative() {
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 2, 4, 0, Duration.ofDays(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cohortSelectionConcurrency must be greater than 0");
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 2, 4, -1, Duration.ofDays(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cohortSelectionConcurrency must be greater than 0");
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.cda.TransferProcessRunnerConfig;
 import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
@@ -16,12 +17,15 @@ class FhirCohortSelectorFactoryIT {
 
   @Autowired MeterRegistry meterRegistry;
   @Autowired WebClientFactory clientFactory;
+  @Autowired TransferProcessRunnerConfig runnerConfig;
 
   private FhirCohortSelectorFactory factory;
 
   @BeforeEach
   void setUp() {
-    factory = new FhirCohortSelectorFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
+    factory =
+        new FhirCohortSelectorFactory(
+            clientFactory, new DefaultRetryStrategy(meterRegistry), runnerConfig);
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
@@ -62,7 +62,7 @@ class FhirCohortSelectorIT {
     this.config = MockServerUtil.clientConfig(wireMockRuntime);
     var fhirClient = clientFactory.create(this.config);
     cohortSelector =
-        new FhirCohortSelector(config, fhirClient, new DefaultRetryStrategy(meterRegistry));
+        new FhirCohortSelector(config, fhirClient, new DefaultRetryStrategy(meterRegistry), 4);
     wireMock = wireMockRuntime.getWireMock();
     cohortGenerator = new FhirCohortGenerator(PID_SYSTEM, POLICY_SYSTEM, POLICIES);
   }

--- a/docs/configuration/runner.md
+++ b/docs/configuration/runner.md
@@ -10,6 +10,7 @@ lifecycle of processes managed by FTSnext
 runner:
   maxSendConcurrency: 32
   maxConcurrentProcesses: 4
+  cohortSelectionConcurrency: 4
   processTtl: P1D
 ```
 
@@ -35,6 +36,19 @@ runner:
   ```yaml
   runner:
     maxConcurrentProcesses: 10
+  ```
+
+### `cohortSelectionConcurrency` <Badge type="warning" text="Since 5.7" />
+
+* **Description**: The number of parallel workers used to group patients with their consents during
+  cohort selection. This grouping is CPU-bound; raise it on hosts with more cores if cohort
+  selection is a bottleneck.
+* **Type**: Integer
+* **Default**: `4`
+* **Example**:
+  ```yaml
+  runner:
+    cohortSelectionConcurrency: 8
   ```
 
 ### `processTtl` <Badge type="warning" text="Since 5.0" />


### PR DESCRIPTION
## Summary

Resolves #1697.

`FhirCohortSelector.groupPatientsAndConsents` used a parallel Java `Stream` (`.parallel()`), backed by the **JVM-wide common ForkJoinPool**. That pool is shared across the whole JVM, sized to `availableProcessors() - 1`, and only tunable via the `-Djava.util.concurrent.ForkJoinPool.common.parallelism=N` JVM flag — undocumented and ambiguous when interpreting performance sweeps against `maxSendConcurrency`.

This implements **Option 2** from the issue (the cleaner one): replace the parallel `Stream` with a bounded Reactor `ParallelFlux` on a dedicated scheduler, and expose the number of rails as a Spring property.

## Changes

- **`FhirCohortSelector`**: `groupPatientsAndConsents` now builds a `Flux.fromIterable(...).parallel(cohortSelectionConcurrency).runOn(Schedulers.parallel())...sequential()` instead of a common-pool parallel `Stream`. The per-patient grouping was extracted into `groupPatientWithConsents`, and `extractConsentedPatients` maps each grouped bundle through `processConsentedPatient` reactively.
- **`TransferProcessRunnerConfig`**: new `runner.cohortSelectionConcurrency` property (default `4`, validated `> 0`, defaults when unset). Mirrors `maxSendConcurrency` naming and gives per-agent control with no global pool coupling.
- **`FhirCohortSelectorFactory`**: injects the runner config and passes the configured concurrency into the selector.
- **Docs / config**: documented the new property in `docs/configuration/runner.md` and added it to the example `application.yaml` files.

## Tests

- `TransferProcessRunnerConfigTest`: added coverage for the new property — default-when-null and the `> 0` validation (zero/negative). Updated existing constructions for the new record component.
- `FhirCohortSelectorFactoryIT`: autowires `TransferProcessRunnerConfig` and passes it through the factory.
- `FhirCohortSelectorIT`: existing cohort-selection integration tests exercise the new `ParallelFlux` grouping path; updated to the new constructor.

> [!NOTE]
> The full Maven build/tests (and JaCoCo coverage) could not be run in this sandboxed environment because the transitive `de.ume:deidentifhir` dependency is hosted on GitHub Packages, which is blocked by the egress policy here. The reactive changes were verified against the cached Reactor API and all changed files pass `google-java-format`. CI will validate the build, tests, and patch coverage.