### PR TITLE
Decouple Cohort Selection From Common ForkJoinPool

### DIFF
--- a/clinical-domain-agent/application.yaml
+++ b/clinical-domain-agent/application.yaml
@@ -5,6 +5,8 @@
 #   maxSendConcurrency: 32
 #   # Maximum number of processes that can run concurrently
 #   maxConcurrentProcesses: 4
+#   # Number of concurrent workers grouping patients and consents during cohort selection
+#   cohortSelectionConcurrency: 4
 #   # Time-to-live for a process, specified as an ISO-8601 duration (e.g., P1D means 1 day)
 #   # see https://de.wikipedia.org/wiki/ISO_8601
 #   processTtl: P1D

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/CohortSelectionSchedulerConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/CohortSelectionSchedulerConfig.java
@@ -1,0 +1,22 @@
+package care.smith.fts.cda;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Provides a dedicated, Spring-managed Reactor {@link Scheduler} for the CPU-bound grouping of
+ * patients with their consents during cohort selection. Sizing it to {@code
+ * cohortSelectionConcurrency} caps the total threads this work may use and isolates it from the
+ * JVM-wide {@link Schedulers#parallel()} pool that is shared with all other Reactor work. The bean
+ * is a singleton, so concurrent transfer processes share this one bounded pool.
+ */
+@Configuration
+class CohortSelectionSchedulerConfig {
+
+  @Bean(destroyMethod = "dispose")
+  Scheduler cohortSelectionScheduler(TransferProcessRunnerConfig config) {
+    return Schedulers.newParallel("cohort-selection", config.cohortSelectionConcurrency(), true);
+  }
+}

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
@@ -1,6 +1,7 @@
 package care.smith.fts.cda;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNullElse;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -17,13 +18,30 @@ public record TransferProcessRunnerConfig(
      */
     Integer maxSendConcurrency,
     Integer maxConcurrentProcesses,
+
+    /*
+     * Number of concurrent workers grouping patients with their consents during cohort selection.
+     * Also sizes the dedicated cohort-selection scheduler, bounding this CPU-bound work to its own
+     * pool instead of the JVM-wide common ForkJoinPool. Defaults to
+     * DEFAULT_COHORT_SELECTION_CONCURRENCY when unset.
+     */
+    Integer cohortSelectionConcurrency,
     Duration processTtl) {
 
+  /**
+   * Default number of cohort selection workers when {@code cohortSelectionConcurrency} is unset.
+   */
+  public static final int DEFAULT_COHORT_SELECTION_CONCURRENCY = 4;
+
   public TransferProcessRunnerConfig {
+    cohortSelectionConcurrency =
+        requireNonNullElse(cohortSelectionConcurrency, DEFAULT_COHORT_SELECTION_CONCURRENCY);
     checkArgument(maxConcurrentPatients > 1, "runner.maxConcurrentPatients must be greater than 0");
     checkArgument(maxSendConcurrency > 1, "runner.maxSendConcurrency must be greater than 0");
     checkArgument(
         maxSendConcurrency <= maxConcurrentPatients,
         "runner.maxSendConcurrency must not exceed runner.maxConcurrentPatients");
+    checkArgument(
+        cohortSelectionConcurrency > 0, "runner.cohortSelectionConcurrency must be greater than 0");
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelector.java
@@ -14,7 +14,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -26,18 +25,27 @@ import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 
 @Slf4j
 class FhirCohortSelector implements CohortSelector {
   private final FhirCohortSelectorConfig config;
   private final WebClient fhirClient;
   private final RetryStrategy retryStrategy;
+  private final Scheduler scheduler;
+  private final int cohortSelectionConcurrency;
 
   public FhirCohortSelector(
-      FhirCohortSelectorConfig config, WebClient fhirClient, RetryStrategy retryStrategy) {
+      FhirCohortSelectorConfig config,
+      WebClient fhirClient,
+      RetryStrategy retryStrategy,
+      Scheduler scheduler,
+      int cohortSelectionConcurrency) {
     this.config = config;
     this.fhirClient = fhirClient;
     this.retryStrategy = retryStrategy;
+    this.scheduler = scheduler;
+    this.cohortSelectionConcurrency = cohortSelectionConcurrency;
   }
 
   @Override
@@ -95,30 +103,41 @@ class FhirCohortSelector implements CohortSelector {
 
   private Flux<ConsentedPatient> extractConsentedPatients(Bundle bundle) {
     var patientIdentifierSystem = config.patientIdentifierSystem();
-    var bundles = groupPatientsAndConsents(bundle);
-    return Flux.fromStream(
-            processConsentedPatients(
-                patientIdentifierSystem,
-                config.policySystem(),
-                bundles,
-                config.policies(),
-                b -> getPatientIdentifier(patientIdentifierSystem, b)))
+    return groupPatientsAndConsents(bundle)
+        .mapNotNull(
+            b ->
+                processConsentedPatient(
+                        patientIdentifierSystem,
+                        config.policySystem(),
+                        b,
+                        config.policies(),
+                        p -> getPatientIdentifier(patientIdentifierSystem, p))
+                    .orElse(null))
         .doOnNext(p -> log.trace("extractConsentedPatients: emitted {}", p.identifier()))
         .doOnComplete(() -> log.trace("extractConsentedPatients completed for bundle"));
   }
 
-  private static Stream<Bundle> groupPatientsAndConsents(Bundle bundle) {
-    var patients = typedResourceStream(bundle, Patient.class);
-    return patients
-        .parallel()
-        .map(
-            p -> {
-              var inner = new Bundle().addEntry(new BundleEntryComponent().setResource(p));
-              typedResourceStream(bundle, Consent.class)
-                  .filter(c -> isConsentOfPatient(p, c))
-                  .forEach(c -> inner.addEntry(new BundleEntryComponent().setResource(c)));
-              return inner;
-            });
+  /**
+   * Groups each patient in the bundle with its matching consents. The CPU-bound grouping is spread
+   * across {@code cohortSelectionConcurrency} concurrent workers on the injected, dedicated {@link
+   * Scheduler}, instead of the JVM-wide common ForkJoinPool that a parallel {@link
+   * java.util.stream.Stream} would use.
+   */
+  private Flux<Bundle> groupPatientsAndConsents(Bundle bundle) {
+    var patients = typedResourceStream(bundle, Patient.class).toList();
+    return Flux.fromIterable(patients)
+        .parallel(cohortSelectionConcurrency)
+        .runOn(scheduler)
+        .map(p -> groupPatientWithConsents(bundle, p))
+        .sequential();
+  }
+
+  private static Bundle groupPatientWithConsents(Bundle bundle, Patient p) {
+    var inner = new Bundle().addEntry(new BundleEntryComponent().setResource(p));
+    typedResourceStream(bundle, Consent.class)
+        .filter(c -> isConsentOfPatient(p, c))
+        .forEach(c -> inner.addEntry(new BundleEntryComponent().setResource(c)));
+    return inner;
   }
 
   private static boolean isConsentOfPatient(Patient patient, Consent c) {

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/impl/FhirCohortSelectorFactory.java
@@ -1,19 +1,29 @@
 package care.smith.fts.cda.impl;
 
 import care.smith.fts.api.cda.CohortSelector;
+import care.smith.fts.cda.TransferProcessRunnerConfig;
 import care.smith.fts.util.RetryStrategy;
 import care.smith.fts.util.WebClientFactory;
 import org.springframework.stereotype.Component;
+import reactor.core.scheduler.Scheduler;
 
 @Component("fhirCohortSelector")
 public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCohortSelectorConfig> {
 
   private final WebClientFactory clientFactory;
   private final RetryStrategy retryStrategy;
+  private final Scheduler cohortSelectionScheduler;
+  private final int cohortSelectionConcurrency;
 
-  public FhirCohortSelectorFactory(WebClientFactory clientFactory, RetryStrategy retryStrategy) {
+  public FhirCohortSelectorFactory(
+      WebClientFactory clientFactory,
+      RetryStrategy retryStrategy,
+      Scheduler cohortSelectionScheduler,
+      TransferProcessRunnerConfig runnerConfig) {
     this.clientFactory = clientFactory;
     this.retryStrategy = retryStrategy;
+    this.cohortSelectionScheduler = cohortSelectionScheduler;
+    this.cohortSelectionConcurrency = runnerConfig.cohortSelectionConcurrency();
   }
 
   @Override
@@ -24,6 +34,7 @@ public class FhirCohortSelectorFactory implements CohortSelector.Factory<FhirCoh
   @Override
   public CohortSelector create(CohortSelector.Config ignored, FhirCohortSelectorConfig config) {
     var client = clientFactory.create(config.server());
-    return new FhirCohortSelector(config, client, retryStrategy);
+    return new FhirCohortSelector(
+        config, client, retryStrategy, cohortSelectionScheduler, cohortSelectionConcurrency);
   }
 }

--- a/clinical-domain-agent/src/main/resources/application.yaml
+++ b/clinical-domain-agent/src/main/resources/application.yaml
@@ -24,6 +24,7 @@ runner:
   maxConcurrentPatients: 8
   maxSendConcurrency: 2
   maxConcurrentProcesses: 4
+  cohortSelectionConcurrency: 4
   processTtl: P1D
 
 springdoc:

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/CohortSelectionSchedulerConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/CohortSelectionSchedulerConfigTest.java
@@ -1,0 +1,37 @@
+package care.smith.fts.cda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+class CohortSelectionSchedulerConfigTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(CohortSelectionSchedulerConfig.class)
+          .withBean(
+              TransferProcessRunnerConfig.class,
+              () -> new TransferProcessRunnerConfig(8, 2, 4, 4, Duration.ofDays(1)));
+
+  @Test
+  void providesDedicatedSchedulerDistinctFromGlobalParallel() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasSingleBean(Scheduler.class);
+          assertThat(context.getBean("cohortSelectionScheduler", Scheduler.class))
+              .isNotSameAs(Schedulers.parallel());
+        });
+  }
+
+  @Test
+  void disposesSchedulerWhenContextCloses() {
+    var schedulerRef = new AtomicReference<Scheduler>();
+    contextRunner.run(context -> schedulerRef.set(context.getBean(Scheduler.class)));
+    assertThat(schedulerRef.get().isDisposed()).isTrue();
+  }
+}

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -50,7 +50,7 @@ class DefaultTransferProcessRunnerTest {
   private final TransferProcessConfig rawConfig = new TransferProcessConfig(null, null, null, null);
 
   DefaultTransferProcessRunnerTest() {
-    config = new TransferProcessRunnerConfig(64, 64, 2, Duration.ofSeconds(3));
+    config = new TransferProcessRunnerConfig(64, 64, 2, 4, Duration.ofSeconds(3));
   }
 
   @BeforeEach
@@ -217,7 +217,7 @@ class DefaultTransferProcessRunnerTest {
 
   @Test
   void ttl() throws InterruptedException {
-    var config = new TransferProcessRunnerConfig(64, 64, 2, Duration.ofMillis(100));
+    var config = new TransferProcessRunnerConfig(64, 64, 2, 4, Duration.ofMillis(100));
     var process =
         new TransferProcessDefinition(
             "test",
@@ -572,7 +572,7 @@ class DefaultTransferProcessRunnerTest {
     int patientCount = 10;
     int maxSend = 2;
 
-    var cfg = new TransferProcessRunnerConfig(8, maxSend, 1, Duration.ofSeconds(10));
+    var cfg = new TransferProcessRunnerConfig(8, maxSend, 1, 4, Duration.ofSeconds(10));
     var boundedRunner = new DefaultTransferProcessRunner(new ObjectMapper(), cfg);
 
     var inFlight = new AtomicInteger(0);

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
@@ -1,5 +1,6 @@
 package care.smith.fts.cda;
 
+import static care.smith.fts.cda.TransferProcessRunnerConfig.DEFAULT_COHORT_SELECTION_CONCURRENCY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -10,35 +11,52 @@ class TransferProcessRunnerConfigTest {
 
   @Test
   void bindsWhenSendConcurrencyWithinPrefetchWindow() {
-    var config = new TransferProcessRunnerConfig(8, 2, 4, Duration.ofDays(1));
+    var config = new TransferProcessRunnerConfig(8, 2, 4, 4, Duration.ofDays(1));
     assertThat(config.maxConcurrentPatients()).isEqualTo(8);
     assertThat(config.maxSendConcurrency()).isEqualTo(2);
+    assertThat(config.cohortSelectionConcurrency()).isEqualTo(4);
   }
 
   @Test
   void failsWhenSendConcurrencyExceedsPrefetchWindow() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(2, 8, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(2, 8, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must not exceed runner.maxConcurrentPatients");
   }
 
   @Test
   void failsWhenMaxConcurrentPatientsIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(1, 2, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(1, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
   }
 
   @Test
   void failsWhenMaxSendConcurrencyIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 1, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 1, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
+  }
+
+  @Test
+  void cohortSelectionConcurrencyDefaultsWhenNull() {
+    var config = new TransferProcessRunnerConfig(8, 2, 4, null, Duration.ofDays(1));
+    assertThat(config.cohortSelectionConcurrency()).isEqualTo(DEFAULT_COHORT_SELECTION_CONCURRENCY);
+  }
+
+  @Test
+  void failsWhenCohortSelectionConcurrencyIsZeroOrNegative() {
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 2, 4, 0, Duration.ofDays(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cohortSelectionConcurrency must be greater than 0");
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 2, 4, -1, Duration.ofDays(1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cohortSelectionConcurrency must be greater than 0");
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorFactoryIT.java
@@ -2,6 +2,7 @@ package care.smith.fts.cda.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import care.smith.fts.cda.TransferProcessRunnerConfig;
 import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
@@ -10,18 +11,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import reactor.core.scheduler.Schedulers;
 
 @SpringBootTest
 class FhirCohortSelectorFactoryIT {
 
   @Autowired MeterRegistry meterRegistry;
   @Autowired WebClientFactory clientFactory;
+  @Autowired TransferProcessRunnerConfig runnerConfig;
 
   private FhirCohortSelectorFactory factory;
 
   @BeforeEach
   void setUp() {
-    factory = new FhirCohortSelectorFactory(clientFactory, new DefaultRetryStrategy(meterRegistry));
+    factory =
+        new FhirCohortSelectorFactory(
+            clientFactory,
+            new DefaultRetryStrategy(meterRegistry),
+            Schedulers.parallel(),
+            runnerConfig);
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/FhirCohortSelectorIT.java
@@ -5,6 +5,7 @@ import static care.smith.fts.test.MockServerUtil.fhirResponse;
 import static care.smith.fts.util.fhir.FhirUtils.toBundle;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static reactor.test.StepVerifier.create;
 
@@ -23,6 +24,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +35,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 @Slf4j
 @SpringBootTest
@@ -54,15 +60,22 @@ class FhirCohortSelectorIT {
 
   private FhirCohortGenerator cohortGenerator;
   private HttpClientConfig config;
+  private FhirCohortSelectorConfig selectorConfig;
+  private WebClient fhirClient;
 
   @BeforeEach
   void setUp(WireMockRuntimeInfo wireMockRuntime, @Autowired WebClientFactory clientFactory) {
     var ignored = new HttpClientConfig("ignored");
-    var config = new FhirCohortSelectorConfig(ignored, PID_SYSTEM, POLICY_SYSTEM, POLICIES);
+    selectorConfig = new FhirCohortSelectorConfig(ignored, PID_SYSTEM, POLICY_SYSTEM, POLICIES);
     this.config = MockServerUtil.clientConfig(wireMockRuntime);
-    var fhirClient = clientFactory.create(this.config);
+    fhirClient = clientFactory.create(this.config);
     cohortSelector =
-        new FhirCohortSelector(config, fhirClient, new DefaultRetryStrategy(meterRegistry));
+        new FhirCohortSelector(
+            selectorConfig,
+            fhirClient,
+            new DefaultRetryStrategy(meterRegistry),
+            Schedulers.parallel(),
+            4);
     wireMock = wireMockRuntime.getWireMock();
     cohortGenerator = new FhirCohortGenerator(PID_SYSTEM, POLICY_SYSTEM, POLICIES);
   }
@@ -128,6 +141,34 @@ class FhirCohortSelectorIT {
     var bundle = cohortGenerator.generate();
     wireMock.register(fetchAllRequest().willReturn(fhirResponse(bundle)));
     create(cohortSelector.selectCohort(List.of())).expectNextCount(1).verifyComplete();
+  }
+
+  @Test
+  void groupingRunsOnInjectedScheduler() {
+    var used = new AtomicBoolean(false);
+    var delegate = Schedulers.parallel();
+    Scheduler spy =
+        new Scheduler() {
+          @Override
+          public Disposable schedule(Runnable task) {
+            return delegate.schedule(task);
+          }
+
+          @Override
+          public Worker createWorker() {
+            used.set(true);
+            return delegate.createWorker();
+          }
+        };
+    var selector =
+        new FhirCohortSelector(
+            selectorConfig, fhirClient, new DefaultRetryStrategy(meterRegistry), spy, 4);
+
+    var bundle = cohortGenerator.generate();
+    wireMock.register(fetchAllRequest().willReturn(fhirResponse(bundle)));
+
+    create(selector.selectCohort(List.of())).expectNextCount(1).verifyComplete();
+    assertThat(used).isTrue();
   }
 
   @Test

--- a/docs/configuration/runner.md
+++ b/docs/configuration/runner.md
@@ -10,6 +10,7 @@ lifecycle of processes managed by FTSnext
 runner:
   maxSendConcurrency: 32
   maxConcurrentProcesses: 4
+  cohortSelectionConcurrency: 4
   processTtl: P1D
 ```
 
@@ -35,6 +36,21 @@ runner:
   ```yaml
   runner:
     maxConcurrentProcesses: 10
+  ```
+
+### `cohortSelectionConcurrency` <Badge type="warning" text="Since 5.7" />
+
+* **Description**: The number of concurrent workers used to group patients with their consents
+  during cohort selection. This grouping is CPU-bound and runs on a dedicated scheduler that this
+  value also sizes; the scheduler is shared across all concurrent processes, so this caps the total
+  threads cohort selection may use rather than being per-process. Raise it on hosts with more cores
+  if cohort selection is a bottleneck.
+* **Type**: Integer
+* **Default**: `4`
+* **Example**:
+  ```yaml
+  runner:
+    cohortSelectionConcurrency: 8
   ```
 
 ### `processTtl` <Badge type="warning" text="Since 5.0" />


### PR DESCRIPTION
## Summary

`FhirCohortSelector.groupPatientsAndConsents` grouped each patient with its consents via a parallel Java `Stream`, which runs on the **JVM-wide common ForkJoinPool**. That pool is shared across the whole JVM, sized to `availableProcessors()-1`, competes with other parallel streams and JDK internals, and is only tunable via the `-Djava.util.concurrent.ForkJoinPool.common.parallelism` JVM flag — documented nowhere. Performance sweeps treat `maxSendConcurrency` as the parallelism knob, so cohort selection running on a separate, undisclosed pool made benchmark interpretation ambiguous.

## Changes

- Replace the parallel `Stream` with a bounded Reactor `ParallelFlux` running on a dedicated `Schedulers.parallel()` scheduler. Grouping now returns a `Flux<Bundle>` and consents are matched per patient, dropping the intermediate `Stream` plumbing in `extractConsentedPatients`.
- Expose the rail count as a new Spring property `runner.cohortSelectionConcurrency` (default `4`, must be `> 0`), wired through `TransferProcessRunnerConfig` and `FhirCohortSelectorFactory` into the selector. Per-agent control without coupling to the global ForkJoinPool, mirroring the existing `maxSendConcurrency` naming.
- Document the property in `docs/configuration/runner.md` and add it to the clinical-domain-agent example `application.yaml` files.

Closes #1697