### PR TITLE
Maintain temporary transitive CVE-mitigation dependency pins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,37 @@
         <version>8.10.0</version>
       </dependency>
 
-      <!-- TODO: Temporary transitive updates for CVE mitigation - Remove when updated! -->
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.20.0</version>
-      </dependency>
+      <!-- TODO: Temporary transitive update for CVE mitigation - Remove when the Spring Boot BOM manages nimbus-jose-jwt >= 10.9.1! -->
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>10.9.1</version>
+      </dependency>
+
+      <!-- TODO: Temporary transitive update for CVE-2026-10532 - Remove when the Spring Boot BOM manages logback-core >= 1.5.35! -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>1.5.35</version>
+      </dependency>
+
+      <!-- TODO: Temporary transitive update for CVE-2026-54515 - Remove when the Spring Boot BOM manages jackson-databind >= 2.21.5! -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.21.5</version>
+      </dependency>
+
+      <!-- TODO: Temporary transitive update for CVE-2026-55471 and CVE-2026-45367 - Remove when hapi-fhir bundles org.hl7.fhir core >= 6.9.10! -->
+      <dependency>
+        <groupId>ca.uhn.hapi.fhir</groupId>
+        <artifactId>org.hl7.fhir.r4</artifactId>
+        <version>6.9.10</version>
+      </dependency>
+      <dependency>
+        <groupId>ca.uhn.hapi.fhir</groupId>
+        <artifactId>org.hl7.fhir.utilities</artifactId>
+        <version>6.9.10</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Generalizes the temporary CVE-mitigation dependency management in the root `pom.xml` from a one-off cleanup into an actively maintained register of transitive pins.

### Removed
- `org.apache.commons:commons-lang3` 3.20.0 — redundant; the Spring Boot 4.1.0 BOM already manages 3.20.0.

### Added (clear open code-scanning CVE alerts)
| Dependency | Version | CVE |
|---|---|---|
| `ch.qos.logback:logback-core` | 1.5.35 | CVE-2026-10532 (deserialization) |
| `com.fasterxml.jackson.core:jackson-databind` | 2.21.5 | CVE-2026-54515 (ignored props modified) |
| `ca.uhn.hapi.fhir:org.hl7.fhir.r4` | 6.9.10 | CVE-2026-45367 (FHIRPath ReDoS) |
| `ca.uhn.hapi.fhir:org.hl7.fhir.utilities` | 6.9.10 | CVE-2026-55471 (Saxon XXE) |

### Unchanged
- `com.nimbusds:nimbus-jose-jwt` 10.9.1 pin stays until the BOM ships ≥ 10.9.1.

## Notes / risk

- logback-core and jackson-databind are clean patch-level overrides of the Spring Boot BOM (low risk).
- The **org.hl7.fhir core bundle** is the risky one: the latest `hapi-fhir-structures-r4` (8.10.0) still bundles core **6.9.4.1** with no upstream fix, so both core artifacts are force-overridden to **6.9.10** (utilities patched=6.9.10; r4 needs ≥6.9.7 — aligned to 6.9.10 to avoid intra-bundle version skew). This override is untested by HAPI upstream and must be dropped once a HAPI release bundles fixed core.
- `tools.jackson.core:jackson-databind` (Jackson 3.x, CVE-2026-54515) already resolves to patched 3.1.4 via the BOM — no pin needed.
- Out of scope: 2 `java/deprecated-call` code-scanning alerts in `util/.../WebClientDefaults.java` are source-code findings, not dependency issues.

Each pin and its removal condition is tracked in #1811.

Refs #1811
