### PR TITLE
Replace Deprecated Jackson2 WebClient Codecs

### DIFF
--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessControllerIT.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -84,7 +83,7 @@ public class TransferProcessControllerIT {
                         c.bodyToMono(ProblemDetail.class)
                             .flatMap(p -> Mono.error(new IllegalStateException(p.getDetail()))))
                 .toBodilessEntity())
-        .expectError(DecodingException.class)
+        .expectError(IllegalStateException.class)
         .verifyThenAssertThat()
         .hasOperatorErrors();
   }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/rest/TransferProcessControllerIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/rest/TransferProcessControllerIT.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -76,7 +75,7 @@ public class TransferProcessControllerIT {
                         c.bodyToMono(ProblemDetail.class)
                             .flatMap(p -> Mono.error(new IllegalStateException(p.getDetail()))))
                 .toBodilessEntity())
-        .expectError(DecodingException.class)
+        .expectError(IllegalStateException.class)
         .verifyThenAssertThat()
         .hasOperatorErrors();
   }

--- a/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
+++ b/util/src/main/java/care/smith/fts/util/WebClientDefaults.java
@@ -2,17 +2,17 @@ package care.smith.fts.util;
 
 import static java.time.Duration.ofSeconds;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.webclient.WebClientCustomizer;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ClientCodecConfigurer;
-import org.springframework.http.codec.json.Jackson2JsonDecoder;
-import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.http.codec.json.JacksonJsonDecoder;
+import org.springframework.http.codec.json.JacksonJsonEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeType;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
 
 @Component
 public class WebClientDefaults implements WebClientCustomizer {
@@ -24,10 +24,10 @@ public class WebClientDefaults implements WebClientCustomizer {
         MediaType.APPLICATION_PROBLEM_JSON
       };
 
-  private final ObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
 
-  public WebClientDefaults(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public WebClientDefaults(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
   }
 
   /**
@@ -43,7 +43,7 @@ public class WebClientDefaults implements WebClientCustomizer {
                 next.exchange(request)
                     .timeout(ofSeconds(10))
                     .flatMap(WebClientDefaults::errorOnRedirect))
-        .codecs(this::configureObjectMapper);
+        .codecs(this::configureJacksonCodecs);
   }
 
   /**
@@ -58,10 +58,10 @@ public class WebClientDefaults implements WebClientCustomizer {
         : Mono.just(response);
   }
 
-  private void configureObjectMapper(ClientCodecConfigurer cs) {
-    var encoder = new Jackson2JsonEncoder(objectMapper, JACKSON_MIME_TYPES);
-    cs.defaultCodecs().jackson2JsonEncoder(encoder);
-    var decoder = new Jackson2JsonDecoder(objectMapper, JACKSON_MIME_TYPES);
-    cs.defaultCodecs().jackson2JsonDecoder(decoder);
+  private void configureJacksonCodecs(ClientCodecConfigurer cs) {
+    var encoder = new JacksonJsonEncoder(jsonMapper, JACKSON_MIME_TYPES);
+    cs.defaultCodecs().jacksonJsonEncoder(encoder);
+    var decoder = new JacksonJsonDecoder(jsonMapper, JACKSON_MIME_TYPES);
+    cs.defaultCodecs().jacksonJsonDecoder(decoder);
   }
 }

--- a/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
+++ b/util/src/test/java/care/smith/fts/util/WebClientDefaultsTest.java
@@ -8,23 +8,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.test.StepVerifier.create;
 
-import care.smith.fts.api.ConsentedPatient;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import care.smith.fts.util.tca.DateShiftingRequest;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.netty.http.client.HttpClient;
+import tools.jackson.databind.json.JsonMapper;
 
 @WireMockTest
 class WebClientDefaultsTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final JsonMapper jsonMapper = JsonMapper.builder().build();
 
   @Test
   void customizeWebClientAndDecodeToMono(WireMockRuntimeInfo wireMockRuntime) {
@@ -36,29 +35,21 @@ class WebClientDefaultsTest {
                 jsonResponse(
                     """
                     {
-                      "identifier": "patient",
-                      "patientIdentifierSystem": "system",
-                      "consentedPolicies": {
-                        "policies":{
-                          "a":[
-                            {"start": -23220777600.000000000, "end": -23220604800.000000000}
-                          ]
-                        }
-                      }
+                      "id": "id1",
+                      "dateShift": 604800.000000000
                     }
                     """,
                     200)));
 
     WebClient.Builder webClientBuilder = WebClient.builder();
-    new WebClientDefaults(objectMapper).customize(webClientBuilder);
+    new WebClientDefaults(jsonMapper).customize(webClientBuilder);
     WebClient webClient = webClientBuilder.baseUrl(address).build();
 
-    create(webClient.post().retrieve().bodyToMono(ConsentedPatient.class))
+    create(webClient.post().retrieve().bodyToMono(DateShiftingRequest.class))
         .assertNext(
             b -> {
-              assertThat(b.identifier()).isEqualTo("patient");
-              assertThat(b.patientIdentifierSystem()).isEqualTo("system");
-              assertThat(b.consentedPolicies().policyNames()).isNotEmpty();
+              assertThat(b.id()).isEqualTo("id1");
+              assertThat(b.dateShift()).isEqualTo(Duration.ofDays(7));
             })
         .verifyComplete();
   }
@@ -77,7 +68,7 @@ class WebClientDefaultsTest {
     // response through the redirect-error filter untouched.
     var connector = new ReactorClientHttpConnector(HttpClient.create().followRedirect(true));
     WebClient.Builder webClientBuilder = WebClient.builder().clientConnector(connector);
-    new WebClientDefaults(objectMapper).customize(webClientBuilder);
+    new WebClientDefaults(jsonMapper).customize(webClientBuilder);
     WebClient webClient = webClientBuilder.baseUrl(address).build();
 
     create(webClient.get().uri("/source").retrieve().bodyToMono(String.class))
@@ -96,7 +87,7 @@ class WebClientDefaultsTest {
             .willReturn(aResponse().withStatus(307).withHeader("Location", "/target")));
 
     WebClient.Builder webClientBuilder = WebClient.builder();
-    new WebClientDefaults(objectMapper).customize(webClientBuilder);
+    new WebClientDefaults(jsonMapper).customize(webClientBuilder);
     WebClient webClient = webClientBuilder.baseUrl(address).build();
 
     create(webClient.get().uri("/source").retrieve().bodyToMono(String.class))


### PR DESCRIPTION
## Summary

Closes #1813. Resolves the two `java/deprecated-call` CodeQL alerts (#1064, #1065) by migrating `WebClientDefaults` off the Spring 7-deprecated Jackson 2 reactive codec path.

- `Jackson2JsonEncoder` / `Jackson2JsonDecoder` → `JacksonJsonEncoder` / `JacksonJsonDecoder`
- `defaultCodecs().jackson2JsonEncoder(...)` / `jackson2JsonDecoder(...)` → `jacksonJsonEncoder(...)` / `jacksonJsonDecoder(...)`
- The codecs take a Jackson 3 `tools.jackson.databind.json.JsonMapper`, so `WebClientDefaults` now injects Spring Boot 4's auto-configured `JsonMapper` instead of the Jackson 2 `defaultObjectMapper`.

## Why inject Boot's `JsonMapper` (not the custom Jackson 2 bean)

Spring Boot 4.1's `JacksonAutoConfiguration` builds the auto-configured `JsonMapper` with `WRITE_DATES_AS_TIMESTAMPS` / `WRITE_DURATIONS_AS_TIMESTAMPS` disabled and `spring.jackson.time-zone` applied — i.e. it reproduces the serialization semantics of the old custom `defaultObjectMapper` (`JavaTimeModule` + dates-as-timestamps disabled + timezone). Java-time is auto-registered by Jackson 3's databind core. It's a single `@ConditionalOnMissingBean JsonMapper`, so the injection is unambiguous.

`defaultObjectMapper` (Jackson 2) is left untouched — it is still used by the CDA/RDA `DefaultTransferProcessRunner` and `JsonLogFormatter`.

## Scope notes for reviewers

- **`ConsentedPatient` intentionally not migrated.** It uses Jackson 2 custom serializers (`@JsonSerialize`/`@JsonDeserialize` + `JsonSerializer`/`JsonDeserializer`), which a Jackson 3 mapper silently ignores. It is **not** (de)serialized over this WebClient in production — `TcaCohortSelector` builds it from a FHIR `Bundle` via the HAPI codec, and its only Jackson usage goes through Jackson 2 mappers. The unit test previously used it as an incidental fixture; the decode test now targets `DateShiftingRequest`, a real WebClient DTO whose `java.time.Duration` field exercises java-time round-tripping through the new Jackson 3 codec.
- **One behavior delta:** Boot's `JsonMapper` also disables `FAIL_ON_UNKNOWN_PROPERTIES` (the old custom Jackson 2 mapper was strict). This makes WebClient response decoding more lenient, consistent with the app's server-side codec.
- A full app-wide Jackson 2 → 3 migration is separate future work.

## Verification

- `mvn checkstyle:check` (util): 0 violations.
- `mvn clean verify -pl util -am`: 219 tests pass, including the Spring-context `WebClientFactoryTest` that boots `AgentConfiguration` and validates the `JsonMapper` injection into `WebClientDefaults`.
- `mvn clean install -DskipTests`: all six modules compile.
- FHIR (`application/fhir+json`) continues to flow through the separate HAPI `FhirEncoder`/`FhirDecoder`; the registered MIME types are unchanged.
