### PR TITLE
Migrate First-Party Jackson 2 Usages To Jackson 3

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -47,7 +52,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>

--- a/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
+++ b/api/src/main/java/care/smith/fts/api/ConsentedPatient.java
@@ -2,24 +2,23 @@ package care.smith.fts.api;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.util.*;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 public record ConsentedPatient(
     String identifier, String patientIdentifierSystem, ConsentedPolicies consentedPolicies) {
@@ -95,20 +94,18 @@ public record ConsentedPatient(
     }
   }
 
-  static class MultimapSerializer extends JsonSerializer<Multimap<String, Period>> {
+  static class MultimapSerializer extends ValueSerializer<Multimap<String, Period>> {
     @Override
     public void serialize(
-        Multimap<String, Period> value, JsonGenerator gen, SerializerProvider serializers)
-        throws IOException {
+        Multimap<String, Period> value, JsonGenerator gen, SerializationContext ctxt) {
       Map<String, Collection<Period>> map = value.asMap();
-      gen.writeObject(map);
+      gen.writePOJO(map);
     }
   }
 
-  static class MultimapDeserializer extends JsonDeserializer<Multimap<String, Period>> {
+  static class MultimapDeserializer extends ValueDeserializer<Multimap<String, Period>> {
     @Override
-    public Multimap<String, Period> deserialize(JsonParser p, DeserializationContext ctxt)
-        throws IOException {
+    public Multimap<String, Period> deserialize(JsonParser p, DeserializationContext ctxt) {
       Map<String, Collection<Period>> map =
           p.readValueAs(new TypeReference<Map<String, Collection<Period>>>() {});
       SetMultimap<String, Period> multimap = HashMultimap.create();

--- a/api/src/test/java/care/smith/fts/api/ConsentedPatientTest.java
+++ b/api/src/test/java/care/smith/fts/api/ConsentedPatientTest.java
@@ -3,13 +3,12 @@ package care.smith.fts.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 class ConsentedPatientTest {
@@ -121,9 +120,9 @@ class ConsentedPatientTest {
   }
 
   @Test
-  void deAndSerializationUsingObjectMapper() throws JsonProcessingException {
+  void deAndSerializationUsingObjectMapper() throws JacksonException {
     ConsentedPatient.ConsentedPolicies consentedPolicies = new ConsentedPatient.ConsentedPolicies();
-    ObjectMapper om = new ObjectMapper().registerModule(new JavaTimeModule());
+    ObjectMapper om = new ObjectMapper();
 
     Period period = Period.parse("1234-03-01T00:00:00+00:00", "1234-03-03T00:00:00+00:00");
     consentedPolicies.put("a", period);

--- a/api/src/test/java/care/smith/fts/api/cda/BundleSenderTest.java
+++ b/api/src/test/java/care/smith/fts/api/cda/BundleSenderTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.cda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class BundleSenderTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/api/src/test/java/care/smith/fts/api/cda/CohortSelectorTest.java
+++ b/api/src/test/java/care/smith/fts/api/cda/CohortSelectorTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.cda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class CohortSelectorTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/api/src/test/java/care/smith/fts/api/cda/DataSelectorTest.java
+++ b/api/src/test/java/care/smith/fts/api/cda/DataSelectorTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.cda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class DataSelectorTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/api/src/test/java/care/smith/fts/api/cda/DeidentificatorTest.java
+++ b/api/src/test/java/care/smith/fts/api/cda/DeidentificatorTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.cda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class DeidentificatorTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/api/src/test/java/care/smith/fts/api/rda/BundleSenderTest.java
+++ b/api/src/test/java/care/smith/fts/api/rda/BundleSenderTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.rda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class BundleSenderTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/api/src/test/java/care/smith/fts/api/rda/DeidentificatorTest.java
+++ b/api/src/test/java/care/smith/fts/api/rda/DeidentificatorTest.java
@@ -2,16 +2,16 @@ package care.smith.fts.api.rda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 class DeidentificatorTest {
 
   @Test
-  void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     om.readValue(
         """

--- a/clinical-domain-agent/pom.xml
+++ b/clinical-domain-agent/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
 

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/ClinicalDomainAgent.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/ClinicalDomainAgent.java
@@ -1,15 +1,14 @@
 package care.smith.fts.cda;
 
 import care.smith.fts.util.AgentConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @SpringBootApplication
@@ -23,6 +22,6 @@ public class ClinicalDomainAgent {
 
   @Bean
   public ObjectMapper transferProcessObjectMapper() {
-    return new ObjectMapper(new YAMLFactory()).registerModule(new JavaTimeModule());
+    return TransferProcessObjectMapper.create();
   }
 }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/DefaultTransferProcessRunner.java
@@ -8,7 +8,6 @@ import care.smith.fts.api.ConsentedPatient;
 import care.smith.fts.api.ConsentedPatientBundle;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.cda.BundleSender.Result;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -22,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/ProjectReader.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/ProjectReader.java
@@ -5,7 +5,6 @@ import static java.util.Optional.empty;
 import static org.slf4j.event.Level.ERROR;
 import static org.slf4j.event.Level.WARN;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -20,6 +19,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -101,7 +102,7 @@ public class ProjectReader {
   private Optional<TransferProcessConfig> parseConfig(InputStream inStream, String name) {
     try {
       return Optional.of(objectMapper.readValue(inStream, TransferProcessConfig.class));
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       throwOrLog(ERROR, "Unable to parse '%s' project's configuration".formatted(name), e);
       return empty();
     }

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessFactory.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessFactory.java
@@ -8,7 +8,6 @@ import care.smith.fts.api.cda.BundleSender;
 import care.smith.fts.api.cda.CohortSelector;
 import care.smith.fts.api.cda.DataSelector;
 import care.smith.fts.api.cda.Deidentificator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Streams;
 import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Field;
@@ -23,6 +22,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -148,7 +149,7 @@ public class TransferProcessFactory {
   private <C> C createConfig(Class<C> configClass, Object config) {
     try {
       return objectMapper.convertValue(config, configClass);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | JacksonException e) {
       throw new IllegalArgumentException(
           "Invalid %s config: '%s'".formatted(configClass.getName(), config), e);
     }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -18,7 +18,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
 
 class DefaultTransferProcessRunnerTest {
 

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/ProjectReaderTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/ProjectReaderTest.java
@@ -7,8 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectReaderTest {
@@ -31,7 +31,7 @@ class ProjectReaderTest {
   private @TempDir Path tempDirectory;
 
   public ProjectReaderTest() {
-    objectMapper = new ObjectMapper(new YAMLFactory());
+    objectMapper = TransferProcessObjectMapper.create();
   }
 
   @Test

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessFactoryIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessFactoryIT.java
@@ -3,7 +3,6 @@ package care.smith.fts.cda;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 class TransferProcessFactoryIT {

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessFactoryTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessFactoryTest.java
@@ -13,9 +13,7 @@ import care.smith.fts.cda.test.MockBundleSender;
 import care.smith.fts.cda.test.MockCohortSelector;
 import care.smith.fts.cda.test.MockDataSelector;
 import care.smith.fts.cda.test.MockDeidentificator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,7 +39,7 @@ class TransferProcessFactoryTest {
 
   @BeforeEach
   void setUp() {
-    var mapper = new ObjectMapper(new YAMLFactory()).registerModule(new JavaTimeModule());
+    var mapper = TransferProcessObjectMapper.create();
 
     lenient()
         .doReturn(cohortSelectorFactory)

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/impl/TcaCohortSelectorIT.java
@@ -20,7 +20,6 @@ import care.smith.fts.util.DefaultRetryStrategy;
 import care.smith.fts.util.HttpClientConfig;
 import care.smith.fts.util.WebClientFactory;
 import care.smith.fts.util.error.TransferProcessException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -37,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @SpringBootTest

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/rest/TransferProcessStatusSerializationIT.java
@@ -9,7 +9,6 @@ import care.smith.fts.cda.TransferProcessRunner;
 import care.smith.fts.cda.TransferProcessRunner.Phase;
 import care.smith.fts.cda.TransferProcessStatus;
 import care.smith.fts.test.TestWebClientFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +22,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = ClinicalDomainAgent.class, webEnvironment = RANDOM_PORT)
 @Import(TestWebClientFactory.class)

--- a/research-domain-agent/pom.xml
+++ b/research-domain-agent/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
 

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/DefaultTransferProcessRunner.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/DefaultTransferProcessRunner.java
@@ -5,7 +5,6 @@ import static care.smith.fts.util.JsonLogFormatter.asJson;
 import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.Deidentificator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import java.time.Instant;
@@ -17,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/ProjectReader.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/ProjectReader.java
@@ -5,7 +5,6 @@ import static java.util.Optional.empty;
 import static org.slf4j.event.Level.ERROR;
 import static org.slf4j.event.Level.WARN;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -20,6 +19,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -100,7 +101,7 @@ public class ProjectReader {
   private Optional<TransferProcessConfig> parseConfig(InputStream inStream, String name) {
     try {
       return Optional.of(objectMapper.readValue(inStream, TransferProcessConfig.class));
-    } catch (IOException e) {
+    } catch (JacksonException e) {
       throwOrLog(ERROR, "Unable to parse '%s' project's configuration".formatted(name), e);
       return empty();
     }

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/ResearchDomainAgent.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/ResearchDomainAgent.java
@@ -1,9 +1,7 @@
 package care.smith.fts.rda;
 
 import care.smith.fts.util.AgentConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import io.github.resilience4j.micrometer.tagged.TaggedBulkheadMetrics;
@@ -15,6 +13,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @SpringBootApplication
@@ -28,7 +27,7 @@ public class ResearchDomainAgent {
 
   @Bean
   public ObjectMapper transferProcessObjectMapper() {
-    return new ObjectMapper(new YAMLFactory()).registerModule(new JavaTimeModule());
+    return TransferProcessObjectMapper.create();
   }
 
   @Bean

--- a/research-domain-agent/src/main/java/care/smith/fts/rda/TransferProcessFactory.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/TransferProcessFactory.java
@@ -5,7 +5,6 @@ import static java.util.Arrays.stream;
 import care.smith.fts.api.*;
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.Deidentificator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Streams;
 import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Field;
@@ -20,6 +19,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -132,7 +133,7 @@ public class TransferProcessFactory {
   private <C> C createConfig(Class<C> configClass, Object config) {
     try {
       return objectMapper.convertValue(config, configClass);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | JacksonException e) {
       throw new IllegalArgumentException(
           "Invalid %s config: '%s'".formatted(configClass.getName(), config), e);
     }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/DefaultTransferProcessRunnerTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/DefaultTransferProcessRunnerTest.java
@@ -9,7 +9,6 @@ import care.smith.fts.api.TransportBundle;
 import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.TransferProcessRunner.Phase;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.resilience4j.bulkhead.BulkheadConfig;
 import io.github.resilience4j.bulkhead.BulkheadRegistry;
 import java.time.Duration;
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.ObjectMapper;
 
 class DefaultTransferProcessRunnerTest {
 

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/ProjectReaderTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/ProjectReaderTest.java
@@ -8,8 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -20,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectReaderTest {
@@ -32,7 +32,7 @@ class ProjectReaderTest {
   private @TempDir Path tempDirectory;
 
   public ProjectReaderTest() {
-    objectMapper = new ObjectMapper(new YAMLFactory());
+    objectMapper = TransferProcessObjectMapper.create();
   }
 
   @Test

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/TransferProcessFactoryIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/TransferProcessFactoryIT.java
@@ -3,7 +3,6 @@ package care.smith.fts.rda;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 class TransferProcessFactoryIT {

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/TransferProcessFactoryTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/TransferProcessFactoryTest.java
@@ -8,9 +8,7 @@ import care.smith.fts.api.rda.BundleSender;
 import care.smith.fts.api.rda.Deidentificator;
 import care.smith.fts.rda.test.MockBundleSender;
 import care.smith.fts.rda.test.MockDeidentificator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import care.smith.fts.util.TransferProcessObjectMapper;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -33,7 +31,7 @@ class TransferProcessFactoryTest {
 
   @BeforeEach
   void setUp() {
-    var mapper = new ObjectMapper(new YAMLFactory()).registerModule(new JavaTimeModule());
+    var mapper = TransferProcessObjectMapper.create();
 
     lenient()
         .doReturn(deidentificatorFactory)

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>

--- a/test-util/src/main/java/care/smith/fts/test/GpasTestHelper.java
+++ b/test-util/src/main/java/care/smith/fts/test/GpasTestHelper.java
@@ -4,17 +4,17 @@ import static java.util.List.of;
 import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.Map.Entry;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public interface GpasTestHelper {
 
   ObjectMapper objectMapper = new ObjectMapper();
 
   static String pseudonymizeAllowCreate(String domain, Map<String, String> pseudonyms)
-      throws JsonProcessingException {
+      throws JacksonException {
     var parameters = pseudonyms.entrySet().stream().map(e -> forPseudonym(domain, e)).toList();
     var response = ofEntries(entry("resourceType", "Parameters"), entry("parameter", parameters));
 

--- a/test-util/src/main/java/care/smith/fts/test/MockServerUtil.java
+++ b/test-util/src/main/java/care/smith/fts/test/MockServerUtil.java
@@ -13,8 +13,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpStatus.OK;
 
 import care.smith.fts.util.HttpClientConfig;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
@@ -29,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public interface MockServerUtil {
 
@@ -198,7 +198,7 @@ public interface MockServerUtil {
   private static ResponseDefinitionBuilder jsonResponse(Object body, int statusCode) {
     try {
       return WireMock.jsonResponse(objectMapper.writeValueAsString(body), statusCode);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new IllegalArgumentException("Body cannot be converted to json.", e);
     }
   }

--- a/test-util/src/test/java/care/smith/fts/test/TestWebClientConfigTest.java
+++ b/test-util/src/test/java/care/smith/fts/test/TestWebClientConfigTest.java
@@ -4,16 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import care.smith.fts.util.auth.HttpClientBasicAuth.Config;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class TestWebClientConfigTest {
 
   @Test
-  public void deserializationWithoutAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithoutAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """
@@ -28,8 +28,8 @@ public class TestWebClientConfigTest {
   }
 
   @Test
-  public void deserializationWithBasicAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithBasicAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -60,9 +60,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
+++ b/util/src/main/java/care/smith/fts/util/AgentConfiguration.java
@@ -4,12 +4,8 @@ import ca.uhn.fhir.context.FhirContext;
 import care.smith.fts.util.auth.HttpServerAuthConfig;
 import care.smith.fts.util.auth.OAuth2ConfigurationExistsCondition;
 import care.smith.fts.util.fhir.FhirCodecConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import java.util.TimeZone;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -100,16 +96,6 @@ public class AgentConfiguration {
     resourceFactory.setUseGlobalResources(false);
     resourceFactory.setConnectionProvider(connectionProvider);
     return resourceFactory;
-  }
-
-  @Bean
-  @Primary
-  public ObjectMapper defaultObjectMapper(
-      @Value("${spring.jackson.time-zone:UTC}") String timeZone) {
-    return new ObjectMapper()
-        .registerModule(new JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        .setTimeZone(TimeZone.getTimeZone(timeZone));
   }
 
   @Bean

--- a/util/src/main/java/care/smith/fts/util/JsonLogFormatter.java
+++ b/util/src/main/java/care/smith/fts/util/JsonLogFormatter.java
@@ -1,13 +1,13 @@
 package care.smith.fts.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public interface JsonLogFormatter {
   static <T> String asJson(ObjectMapper om, T t) {
     try {
       return om.writer().writeValueAsString(t);
-    } catch (JsonProcessingException ignored) {
+    } catch (JacksonException ignored) {
       return t.toString();
     }
   }

--- a/util/src/main/java/care/smith/fts/util/TransferProcessObjectMapper.java
+++ b/util/src/main/java/care/smith/fts/util/TransferProcessObjectMapper.java
@@ -1,0 +1,16 @@
+package care.smith.fts.util;
+
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+public interface TransferProcessObjectMapper {
+  static ObjectMapper create() {
+    // Config-binding semantics: tolerate omitted primitive fields (e.g. boolean flags) and reject
+    // unknown properties so config typos fail fast.
+    return YAMLMapper.builder()
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .build();
+  }
+}

--- a/util/src/test/java/care/smith/fts/util/HttpClientConfigTest.java
+++ b/util/src/test/java/care/smith/fts/util/HttpClientConfigTest.java
@@ -2,10 +2,10 @@ package care.smith.fts.util;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class HttpClientConfigTest {
 
@@ -32,8 +32,8 @@ public class HttpClientConfigTest {
   }
 
   @Test
-  public void deserializationWithoutAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithoutAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """
@@ -44,8 +44,8 @@ public class HttpClientConfigTest {
   }
 
   @Test
-  public void deserializationWithEmptyAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithEmptyAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """
@@ -57,8 +57,8 @@ public class HttpClientConfigTest {
   }
 
   @Test
-  public void deserializationWithNoneAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithNoneAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """
@@ -71,8 +71,8 @@ public class HttpClientConfigTest {
   }
 
   @Test
-  public void deserializationWithAuth() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserializationWithAuth() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """

--- a/util/src/test/java/care/smith/fts/util/JsonLogFormatterTest.java
+++ b/util/src/test/java/care/smith/fts/util/JsonLogFormatterTest.java
@@ -3,9 +3,9 @@ package care.smith.fts.util;
 import static care.smith.fts.util.JsonLogFormatter.asJson;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class JsonLogFormatterTest {
   private ObjectMapper objectMapper;
@@ -38,7 +38,12 @@ class JsonLogFormatterTest {
   private record SerializableObject(String name, int value) {}
 
   private static final class UnserializableObject {
-    private final Object circular = this; // Creates circular reference that can't be serialized
+    // Jackson invokes this getter during serialization; the thrown exception is wrapped as a
+    // JacksonException, exercising asJson's toString fallback. A property that actively throws is
+    // needed to force a serialization failure.
+    public String getValue() {
+      throw new IllegalStateException("cannot serialize");
+    }
 
     @Override
     public String toString() {

--- a/util/src/test/java/care/smith/fts/util/auth/HttpClientBasicAuthTest.java
+++ b/util/src/test/java/care/smith/fts/util/auth/HttpClientBasicAuthTest.java
@@ -4,17 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import care.smith.fts.util.auth.HttpClientAuth.Config;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class HttpClientBasicAuthTest {
 
   @Test
-  public void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """

--- a/util/src/test/java/care/smith/fts/util/auth/HttpClientCookieTokenAuthTest.java
+++ b/util/src/test/java/care/smith/fts/util/auth/HttpClientCookieTokenAuthTest.java
@@ -5,16 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.springframework.web.reactive.function.client.WebClient.builder;
 
 import care.smith.fts.util.auth.HttpClientAuth.Config;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 public class HttpClientCookieTokenAuthTest {
 
   @Test
-  public void deserialization() throws JsonProcessingException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+  public void deserialization() throws JacksonException {
+    ObjectMapper om = YAMLMapper.builder().build();
 
     var config =
         """

--- a/util/src/test/java/care/smith/fts/util/tca/ConsentFetchAllRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/ConsentFetchAllRequestTest.java
@@ -2,19 +2,17 @@ package care.smith.fts.util.tca;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class ConsentFetchAllRequestTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void serialize() throws JsonProcessingException {
+  void serialize() throws JacksonException {
     var request =
         new ConsentFetchAllRequest("domain", Set.of("policy1", "policy2"), "policySystem");
 
@@ -28,7 +26,7 @@ class ConsentFetchAllRequestTest {
   }
 
   @Test
-  void deserialize() throws JsonProcessingException {
+  void deserialize() throws JacksonException {
     String json =
         """
         {

--- a/util/src/test/java/care/smith/fts/util/tca/ConsentFetchRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/ConsentFetchRequestTest.java
@@ -2,20 +2,18 @@ package care.smith.fts.util.tca;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class ConsentFetchRequestTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void serialize() throws JsonProcessingException {
+  void serialize() throws JacksonException {
     var request =
         new ConsentFetchRequest(
             "domain",
@@ -36,7 +34,7 @@ class ConsentFetchRequestTest {
   }
 
   @Test
-  void deserialize() throws JsonProcessingException {
+  void deserialize() throws JacksonException {
     String json =
         """
         {

--- a/util/src/test/java/care/smith/fts/util/tca/DateShiftingRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/DateShiftingRequestTest.java
@@ -3,28 +3,26 @@ package care.smith.fts.util.tca;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class DateShiftingRequestTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void serialize() throws JsonProcessingException {
+  void serialize() throws JacksonException {
     var request = new DateShiftingRequest("id1", Duration.ofDays(7));
 
     String jsonString = objectMapper.writeValueAsString(request);
 
-    assertThat(jsonString).contains("id1").contains("604800"); // 7 days in seconds
+    assertThat(jsonString).contains("id1").contains("PT168H"); // 7 days as ISO-8601 duration
   }
 
   @Test
-  void deserialize() throws JsonProcessingException {
+  void deserialize() throws JacksonException {
     String json =
         """
         {

--- a/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/TransportMappingRequestTest.java
@@ -3,20 +3,18 @@ package care.smith.fts.util.tca;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.api.DateShiftPreserve;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class TransportMappingRequestTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void serialize() throws JsonProcessingException {
+  void serialize() throws JacksonException {
     var request =
         new TransportMappingRequest(
             "patient123",
@@ -43,11 +41,11 @@ class TransportMappingRequestTest {
         .contains("pDomain")
         .contains("sDomain")
         .contains("dDomain")
-        .contains("2592000"); // 30 Days in seconds
+        .contains("PT720H"); // 30 days as ISO-8601 duration
   }
 
   @Test
-  void deserialize() throws JsonProcessingException {
+  void deserialize() throws JacksonException {
     String json =
         """
         {

--- a/util/src/test/java/care/smith/fts/util/tca/TransportMappingResponseTest.java
+++ b/util/src/test/java/care/smith/fts/util/tca/TransportMappingResponseTest.java
@@ -2,25 +2,23 @@ package care.smith.fts.util.tca;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 class TransportMappingResponseTest {
 
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
-  void serialize() throws JsonProcessingException {
+  void serialize() throws JacksonException {
     var response = new TransportMappingResponse("transferId");
 
     assertThat(objectMapper.writeValueAsString(response)).contains("transferId");
   }
 
   @Test
-  void deserialize() throws JsonProcessingException {
+  void deserialize() throws JacksonException {
     var response =
         objectMapper.readValue(
             """


### PR DESCRIPTION
## Summary

Migrate all first-party Jackson usages from Jackson 2
(`com.fasterxml.jackson.{core,databind,dataformat,datatype}`) to the
Jackson 3 `tools.jackson.*` packages. Jackson annotations remain on
`com.fasterxml.jackson.annotation.*`, which Jackson 3 reuses.

## Key changes

- Repoint 13 main-source + ~27 test files and 5 poms to `tools.jackson.*`.
- Extract the duplicated `transferProcessObjectMapper` YAML-mapper builder
  into a shared `util.TransferProcessObjectMapper` factory (interface +
  static method, matching `JsonLogFormatter`). The cda/rda `ProjectReader`
  tests now share this strict factory instead of a bare mapper.
- Drop the `@Primary` Jackson 2 `ObjectMapper` bean; Spring Boot 4.1's
  auto-configured `JsonMapper` preserves prior behavior (java.time bundled,
  `WRITE_DATES_AS_TIMESTAMPS` false, `Europe/Berlin` time zone).
- Adapt catch clauses to Jackson 3's unchecked `JacksonException` and
  `ConsentedPatient`'s custom codec to the `ValueSerializer` /
  `ValueDeserializer` API.

## Notes

- Config-binding semantics preserved by disabling
  `FAIL_ON_NULL_FOR_PRIMITIVES` and enabling `FAIL_ON_UNKNOWN_PROPERTIES`
  (both flipped by Jackson 3 defaults).
- `Duration` now serializes as ISO-8601 (e.g. `PT168H`); this wire shift
  already went live for production WebClient traffic in #1813.

Closes #1815
