### PR TITLE
Select Newest Published Release For Docs Links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,11 @@ on:
     branches: [ "**" ]
   merge_group:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag (v*.*.*) to link docs downloads against; empty = newest published release"
+        required: false
+        type: string
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -44,19 +49,51 @@ jobs:
     - name: Build Images
       run: make all
 
-    - name: Get Latest Release Tag using GitHub Script
+    - name: Determine Release Tag
       id: gh_latest_tag
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # Passed via env instead of template interpolation to keep the input out of script code
+        RELEASE_TAG: ${{ inputs.release_tag }}
       with:
         script: |
-          const latestRelease = await github.rest.repos.getLatestRelease({
+          const semver = /^v\d+\.\d+\.\d+$/;
+
+          const explicit = (process.env.RELEASE_TAG ?? "").trim();
+          if (explicit) {
+            if (!semver.test(explicit)) {
+              core.setFailed(`release_tag input "${explicit}" is not a v*.*.* tag.`);
+              return;
+            }
+            console.log(`Building docs against dispatched release: ${explicit}`);
+            core.setOutput("latest_tag", explicit);
+            return;
+          }
+
+          const releases = await github.rest.repos.listReleases({
             owner: context.repo.owner,
             repo: context.repo.repo,
+            per_page: 100,
           });
 
-          const latestTag = latestRelease.data.tag_name || "v0.0.0"; // Default if no release
-          console.log(`Latest tag: ${latestTag}`);
-          core.setOutput("latest_tag", latestTag);
+          const published = releases.data.filter((release) =>
+            !release.draft
+            && !release.prerelease
+            && semver.test(release.tag_name ?? ""));
+          if (published.length === 0) {
+            core.setFailed("No published v*.*.* release found to link docs downloads against.");
+            return;
+          }
+
+          // listReleases orders by creation date, which ranks a hotfix for an
+          // older line above the actual newest version — compare semver instead
+          const version = (release) => release.tag_name.slice(1).split(".").map(Number);
+          const latest = published.reduce((a, b) => {
+            const [va, vb] = [version(a), version(b)];
+            return (va[0] - vb[0] || va[1] - vb[1] || va[2] - vb[2]) >= 0 ? a : b;
+          });
+          console.log(`Building docs against release: ${latest.tag_name}`);
+          core.setOutput("latest_tag", latest.tag_name);
 
     - name: Clear Application Yamls
       working-directory: .github/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,6 @@ jobs:
     - name: Trigger Pages Build
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh workflow run Pages --ref main --repo ${{ github.repository }}
+        REPO: ${{ github.repository }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: gh workflow run Pages --ref main --repo "$REPO" -f release_tag="$RELEASE_TAG"


### PR DESCRIPTION
Closes #1823.

## Problem

The installation docs linked downloads at `untagged-588557b3ec1cd093b88b` instead of a real tag, so every `wget` link 404'd.

Root cause: `pages.yml` resolved `VITE_LATEST_RELEASE` via `getLatestRelease`. That placeholder release was **published** before being retagged `v5.7.0` — both tags still point at `2d6ca48e` — so the API legitimately returned the slug and the build baked it in.

## Fix

Keep deploying docs on every main push (unchanged behaviour), but make the lookup select the right release rather than trusting whichever is "latest" at that instant: list releases newest-first and take the first that is non-draft, non-prerelease, and matches `^v\d+\.\d+\.\d+$`.

A draft in flight is skipped **by construction** rather than rejected, so a release window can never fail an unrelated PR build.

Also drops the `|| "v0.0.0"` fallback, which would silently bake a broken link if no release existed; that now fails loudly.

## Verification

Selection logic exercised against the live releases API:

| scenario | selected |
| --- | --- |
| steady state | `v5.7.0` |
| draft at head of list (the bug) | `v5.7.0` |
| draft + prerelease at head | `v5.7.0` |
| published `untagged-*` at head | `v5.7.0` |
| no releases at all | fails loudly |

## Note on the issue's acceptance criteria

Criterion 1 ("release-triggered deploy uses the published tag verbatim, no `getLatestRelease` guess") is **deliberately not met**. Passing the tag in from `release.yml` would have gated publishing on a release event, meaning docs no longer deploy on main pushes. Selecting correctly is simpler and preserves continuous docs deploys. Criteria 2 and 3 are met.

## Remediation

The live docs still show the bad slug until this merges and a docs deploy runs.