### PR TITLE
Fix Typo In Configuration Docs Intro

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -5,8 +5,8 @@
 # Configuration
 
 This documentation is generated for the main branch of FTSnext, it may document features that are
-not yet released. Therefor configuration options are annotated with a badge to indicate in which
-version the feature is or will be available, e.g. <Badge type="warning" text="Since 5.1" />
+not yet released. Therefore, configuration options are annotated with a badge indicating the
+version in which the feature is or will be available, e.g. <Badge type="warning" text="Since 5.1" />
 
 The latest stable version
 is: [{{ release }}](https://github.com/medizininformatik-initiative/fts-next/releases/latest)


### PR DESCRIPTION
Rewords the intro paragraph of `docs/usage/configuration.md` as requested in the issue: corrects "Therefor" to "Therefore" and smooths the badge explanation.

The "latest stable version" line is left untouched — it already says the same thing and its hyperlink to the releases page is intentional.

Closes #1822