### PR TITLE
Allow Concurrency Of 1 In CDA Runner Config

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/TransferProcessRunnerConfig.java
@@ -36,8 +36,8 @@ public record TransferProcessRunnerConfig(
   public TransferProcessRunnerConfig {
     cohortSelectionConcurrency =
         requireNonNullElse(cohortSelectionConcurrency, DEFAULT_COHORT_SELECTION_CONCURRENCY);
-    checkArgument(maxConcurrentPatients > 1, "runner.maxConcurrentPatients must be greater than 0");
-    checkArgument(maxSendConcurrency > 1, "runner.maxSendConcurrency must be greater than 0");
+    checkArgument(maxConcurrentPatients > 0, "runner.maxConcurrentPatients must be greater than 0");
+    checkArgument(maxSendConcurrency > 0, "runner.maxSendConcurrency must be greater than 0");
     checkArgument(
         maxSendConcurrency <= maxConcurrentPatients,
         "runner.maxSendConcurrency must not exceed runner.maxConcurrentPatients");

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/DefaultTransferProcessRunnerTest.java
@@ -607,6 +607,48 @@ class DefaultTransferProcessRunnerTest {
     assertThat(peakInFlight.get()).isLessThanOrEqualTo(maxSend);
   }
 
+  @Test
+  void serializedConcurrencyTransfersEveryPatient() {
+    int patientCount = 5;
+
+    var cfg = new TransferProcessRunnerConfig(1, 1, 1, 4, Duration.ofSeconds(10));
+    var serializedRunner = new DefaultTransferProcessRunner(new ObjectMapper(), cfg);
+
+    var inFlight = new AtomicInteger(0);
+    var peakInFlight = new AtomicInteger(0);
+    var sent = new AtomicInteger(0);
+
+    var patients =
+        IntStream.range(0, patientCount)
+            .mapToObj(i -> new ConsentedPatient("patient-" + i, "system"))
+            .toList();
+
+    var process =
+        new TransferProcessDefinition(
+            "test",
+            rawConfig,
+            pids -> fromIterable(patients),
+            p -> fromIterable(List.of(new ConsentedPatientBundle(new Bundle(), p))),
+            b -> just(new TransportBundle(new Bundle(), "transferId")),
+            b -> {
+              int current = inFlight.incrementAndGet();
+              peakInFlight.updateAndGet(peak -> Math.max(peak, current));
+              return Mono.just(new Result())
+                  .delayElement(Duration.ofMillis(20))
+                  .doOnNext(
+                      r -> {
+                        sent.incrementAndGet();
+                        inFlight.decrementAndGet();
+                      });
+            });
+
+    var processId = serializedRunner.start(process, List.of());
+    waitForCompletion(serializedRunner, processId);
+
+    assertThat(sent.get()).isEqualTo(patientCount);
+    assertThat(peakInFlight.get()).isEqualTo(1);
+  }
+
   private void waitForCompletion(String processId) {
     waitForCompletion(runner, processId);
   }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/TransferProcessRunnerConfigTest.java
@@ -25,21 +25,34 @@ class TransferProcessRunnerConfigTest {
   }
 
   @Test
-  void failsWhenMaxConcurrentPatientsIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(1, 2, 4, 4, Duration.ofDays(1)))
+  void bindsWhenSendConcurrencyIsOne() {
+    var config = new TransferProcessRunnerConfig(8, 1, 4, 4, Duration.ofDays(1));
+    assertThat(config.maxSendConcurrency()).isEqualTo(1);
+  }
+
+  @Test
+  void bindsWhenPrefetchWindowIsOne() {
+    var config = new TransferProcessRunnerConfig(1, 1, 4, 4, Duration.ofDays(1));
+    assertThat(config.maxConcurrentPatients()).isEqualTo(1);
+    assertThat(config.maxSendConcurrency()).isEqualTo(1);
+  }
+
+  @Test
+  void failsWhenMaxConcurrentPatientsIsZeroOrNegative() {
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(0, 2, 4, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(-1, 2, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxConcurrentPatients must be greater than 0");
   }
 
   @Test
-  void failsWhenMaxSendConcurrencyIsZeroOrOne() {
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 1, 4, 4, Duration.ofDays(1)))
+  void failsWhenMaxSendConcurrencyIsZeroOrNegative() {
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
-    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, 0, 4, 4, Duration.ofDays(1)))
+    assertThatThrownBy(() -> new TransferProcessRunnerConfig(8, -1, 4, 4, Duration.ofDays(1)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("maxSendConcurrency must be greater than 0");
   }

--- a/docs/configuration/runner.md
+++ b/docs/configuration/runner.md
@@ -21,6 +21,8 @@ runner:
 * **Description**: The maximum number of concurrent bundles that can be sent in parallel.
 * **Type**: Integer
 * **Default**: `32`
+* **Minimum**: `1` — set it to `1` to send bundles strictly one at a time, for example when the
+  target RDA is rate-limited or fragile.
 * **Example**:
   ```yaml
   runner:


### PR DESCRIPTION
## Summary

`TransferProcessRunnerConfig` (CDA) rejected `1` for `maxConcurrentPatients` and
`maxSendConcurrency` while both messages claimed the bound was `0`:

```
runner.maxSendConcurrency must be greater than 0
```

`1` *is* greater than `0`, so the error gave operators no route to a fix. With the shipped
default at `2`, anyone tuning down hit this immediately.

This relaxes both predicates to `> 0`, making the existing messages true.

## Why the predicate was the defect

Both values are passed straight to Reactor's `flatMap(mapper, concurrency)`, which accepts
`concurrency == 1` and treats it as "one in flight at a time" — there is no technical reason to
reject it at either call site. The RDA's equivalent config already agrees, permitting `1` via
`maxConcurrentTransactions >= 1`. The commit that introduced these checks (c9eda3ef) records no
rationale for the `> 1` bound.

`maxSendConcurrency: 1` is a reasonable ask: serialize sends to a fragile or rate-limited RDA.
`maxConcurrentPatients: 1` is relaxed alongside it, since `maxSendConcurrency` must not exceed it
— capping it at `> 1` would leave the fully-serialized configuration unreachable.

## Changes

- Relax both predicates to `> 0`; messages unchanged, and now accurate.
- Split `failsWhen…IsZeroOrOne` into rejected-`0`/`-1` cases plus accepted-`1` cases, resolving the
  contradiction those tests encoded.
- Add `serializedConcurrencyTransfersEveryPatient`, asserting that at `(1, 1)` every patient still
  transfers and peak in-flight is exactly `1` — the pipeline serializes rather than stalls.
- Document the `maxSendConcurrency` minimum in `docs/configuration/runner.md`.

## Note on #1829

The `maxConcurrentPatients` docs section and the `Default: 32` → `2` correction are left to #1829,
which already rewrites those lines, to keep the diffs disjoint. Its minimum should be documented
there when it lands.

Closes #1832