### PR TITLE
Document maxConcurrentPatients in runner config

### DIFF
--- a/docs/configuration/runner.md
+++ b/docs/configuration/runner.md
@@ -8,7 +8,8 @@ lifecycle of processes managed by FTSnext
 
 ```yaml
 runner:
-  maxSendConcurrency: 32
+  maxConcurrentPatients: 8
+  maxSendConcurrency: 2
   maxConcurrentProcesses: 4
   cohortSelectionConcurrency: 4
   processTtl: P1D
@@ -16,17 +17,35 @@ runner:
 
 ## Fields
 
-### `maxSendConcurrency` <Badge type="warning" text="Since 5.0" />
+### `maxConcurrentPatients` <Badge type="warning" text="Since 5.7" />
 
-* **Description**: The maximum number of concurrent bundles that can be sent in parallel.
+* **Description**: The number of patients whose data is fetched and deidentified ahead of the send
+  stage. This bounds how far the pipeline may run ahead of the RDA, and is the upper bound on
+  [`maxSendConcurrency`](#maxsendconcurrency): the agent fails to start if `maxSendConcurrency`
+  exceeds it.
 * **Type**: Integer
-* **Default**: `32`
-* **Minimum**: `1` — set it to `1` to send bundles strictly one at a time, for example when the
-  target RDA is rate-limited or fragile.
+* **Default**: `8`
+* **Minimum**: `1`
 * **Example**:
   ```yaml
   runner:
-    maxSendConcurrency: 50
+    maxConcurrentPatients: 16
+  ```
+
+### `maxSendConcurrency` <Badge type="warning" text="Since 5.0" />
+
+* **Description**: The maximum number of concurrent bundles that can be sent in parallel. This is
+  usually the bottleneck of a transfer and should match the target Blaze's transaction capacity.
+  Must not exceed [`maxConcurrentPatients`](#maxconcurrentpatients); raise that value first when
+  increasing this one.
+* **Type**: Integer
+* **Default**: `2`
+* **Minimum**: `1`
+* **Example**:
+  ```yaml
+  runner:
+    maxConcurrentPatients: 16  # must be raised alongside maxSendConcurrency
+    maxSendConcurrency: 16
   ```
 
 ### `maxConcurrentProcesses` <Badge type="warning" text="Since 5.0" />
@@ -69,6 +88,11 @@ runner:
 
 ## Notes
 
+* **Concurrency Constraint**: `maxSendConcurrency` must not exceed `maxConcurrentPatients`. The
+  agent validates this at startup and fails with
+  `runner.maxSendConcurrency must not exceed runner.maxConcurrentPatients` if violated. Since
+  `maxConcurrentPatients` defaults to `8`, setting `maxSendConcurrency` above `8` without also
+  raising `maxConcurrentPatients` prevents the agent from starting.
 * **ISO-8601 Duration Format**: For more details on the duration format, refer
   to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 * Ensure that the `processTtl` value is reasonable to avoid resource exhaustion due to long-lived


### PR DESCRIPTION
Closes #1829

## Summary

Documents the `runner.maxConcurrentPatients` option for the Clinical Domain Agent, and corrects a
pre-existing error in the documented default for `maxSendConcurrency`.

- Add a `maxConcurrentPatients` section: it bounds how far the fetch/deidentify stages may run
  ahead of the send stage, and acts as the upper bound on `maxSendConcurrency`.
- Document the startup validation `runner.maxSendConcurrency must not exceed
  runner.maxConcurrentPatients`, including the failure mode where raising `maxSendConcurrency`
  past the default `8` prevents the agent from starting.
- Correct the `maxSendConcurrency` default from `32` to `2`, and update the examples so they no
  longer show a configuration that fails validation.

## Note on the corrected default

`main` documented `maxSendConcurrency` as defaulting to `32`. That is wrong. The shipped default in
`clinical-domain-agent/src/main/resources/application.yaml` is `2`; the `32` traces back to a
commented-out example in the packaged template `clinical-domain-agent/application.yaml`, which does
not reflect the effective configuration.

## Verification

All documented claims were checked against the source rather than against existing docs:

| Claim | Source |
| --- | --- |
| `maxConcurrentPatients` default `8` | `clinical-domain-agent/src/main/resources/application.yaml` |
| `maxSendConcurrency` default `2` | `clinical-domain-agent/src/main/resources/application.yaml` |
| Constraint + error string (quoted verbatim) | `TransferProcessRunnerConfig.java` |
| Minimum `1` on both fields | `TransferProcessRunnerConfig.java` (`checkArgument(... > 0)`) |
| `Since 5.7` badge | added in c9eda3ef, tagged v5.7.0 |

## Note on the `Minimum` bullet

#1833 added a `Minimum: 1` bullet to `maxSendConcurrency` with the rationale "set it to `1` to send
bundles strictly one at a time, for example when the target RDA is rate-limited or fragile". This PR
keeps the bullet but drops that trailing rationale, and adds the same bare bullet to
`maxConcurrentPatients`, which carries an equivalent check. Flagging it since it trims prose
introduced by another PR.

Note the minimums are enforced imperatively via Guava `checkArgument`, not Bean Validation `@Min`.

## Follow-up (not in this PR)

The packaged template `clinical-domain-agent/application.yaml` still advertises
`maxSendConcurrency: 32` and omits `maxConcurrentPatients`. It is inert commented-out text, but it
is the origin of the `32` figure this PR corrects and is worth cleaning up separately.