### PR TITLE
Add AI Contribution Statement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ commit message conventions — lives in the documentation:
 
 <https://medizininformatik-initiative.github.io/fts-next/contributing/contributing.html>
 
+<!-- #region ai-contributions -->
 ## AI-Assisted Contributions
 
 AI tools are allowed. We don't ask you to disclose their use — but you own
@@ -20,3 +21,4 @@ tool add its own `Signed-off-by`; only a human can certify the DCO.
 
 You must understand your own changes. If you can't explain what your patch
 does and why, it will be closed.
+<!-- #endregion ai-contributions -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thank you for considering contributing to FTSnext! Our full contributing guide —
+how to obtain the software, report bugs, open pull requests, coding standards, and
+commit message conventions — lives in the documentation:
+
+<https://medizininformatik-initiative.github.io/fts-next/contributing/contributing.html>
+
+## AI-Assisted Contributions
+
+AI tools are allowed. We don't ask you to disclose their use — but you own
+the result either way.
+
+**DCO — you sign, you own it.** Every commit must carry a `Signed-off-by`
+line (`git commit -s`). By signing off you certify the
+[Developer Certificate of Origin](https://developercertificate.org/): you
+understand the code, you have the right to submit it, and **you are
+responsible for it** — regardless of how it was written. Never let an AI
+tool add its own `Signed-off-by`; only a human can certify the DCO.
+
+You must understand your own changes. If you can't explain what your patch
+does and why, it will be closed.

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -136,6 +136,21 @@ references in individual commits redundant.
 ³ [Linux Kernel Submitting Patches Guidelines][^3]  
 ⁴ [GitHub's Git Commit Message Guidelines][^4]
 
+## AI-Assisted Contributions
+
+AI tools are allowed. We don't ask you to disclose their use — but you own
+the result either way.
+
+**DCO — you sign, you own it.** Every commit must carry a `Signed-off-by`
+line (`git commit -s`). By signing off you certify the
+[Developer Certificate of Origin](https://developercertificate.org/): you
+understand the code, you have the right to submit it, and **you are
+responsible for it** — regardless of how it was written. Never let an AI
+tool add its own `Signed-off-by`; only a human can certify the DCO.
+
+You must understand your own changes. If you can't explain what your patch
+does and why, it will be closed.
+
 ## License
 
 By contributing to this project, you agree that your contributions will be licensed under

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -136,20 +136,7 @@ references in individual commits redundant.
 ³ [Linux Kernel Submitting Patches Guidelines][^3]  
 ⁴ [GitHub's Git Commit Message Guidelines][^4]
 
-## AI-Assisted Contributions
-
-AI tools are allowed. We don't ask you to disclose their use — but you own
-the result either way.
-
-**DCO — you sign, you own it.** Every commit must carry a `Signed-off-by`
-line (`git commit -s`). By signing off you certify the
-[Developer Certificate of Origin](https://developercertificate.org/): you
-understand the code, you have the right to submit it, and **you are
-responsible for it** — regardless of how it was written. Never let an AI
-tool add its own `Signed-off-by`; only a human can certify the DCO.
-
-You must understand your own changes. If you can't explain what your patch
-does and why, it will be closed.
+<!--@include: ../../CONTRIBUTING.md#ai-contributions-->
 
 ## License
 


### PR DESCRIPTION
## Summary

The project had no stated position on AI tool use in contributions. This adds
an explicit **AI-Assisted Contributions** statement:

- AI tools are allowed; disclosure is not required, but the contributor owns the result.
- Every commit must carry a DCO `Signed-off-by` line (`git commit -s`); only a human may sign off.
- Contributors must be able to explain their own changes.

## Changes

- **New `CONTRIBUTING.md`** (repo root): the **single source of truth** — a short
  pointer to the full docs contributing guide plus the AI/DCO statement, so it
  surfaces in GitHub's native PR/issue flow (the repo previously had no root
  `CONTRIBUTING.md`).
- **`docs/contributing/contributing.md`**: pulls the same statement into the
  documentation via a VitePress region include
  (`<!--@include: ../../CONTRIBUTING.md#ai-contributions-->`), so the text is
  never duplicated.

The docs build (`vitepress build`) runs on this PR via the Pages workflow, which
validates the include resolves.

Closes #1842
