### PR TITLE
Pin Crane Release to v0.21.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,6 +535,10 @@ jobs:
 
     - name: Install crane
       uses: iarekylew00t/crane-installer@f1daea28c11fff5fbc9a5f92700570e84d2d418c # v4.0.14
+      with:
+        # Pinned because `latest` breaks when a release omits `multiple.intoto.jsonl`
+        # renovate: datasource=github-releases depName=google/go-containerregistry
+        crane-release: v0.21.7
 
     - name: Login to GHCR
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0


### PR DESCRIPTION
The `tag-image` job uses `iarekylew00t/crane-installer` with the default `crane-release: latest` and `verify: true`. The action downloads the release tarball and `multiple.intoto.jsonl` (SLSA attestation).

Release `v0.21.8` of `google/go-containerregistry` does not publish `multiple.intoto.jsonl`. So the attestation download gives a 404 and all three `tag-image` legs fail:

```
🏗️ Setting up crane v0.21.8
⏬ Downloading crane release
🔏 Downloading attestation
##[error]Unexpected HTTP response: 404
```

This pins crane to `v0.21.7`, which has the attestation. The attestation check stays active. Renovate updates the pin when a subsequent release publishes the file again.

Closes #1871