### PR TITLE
Replace Crane With Docker Buildx Imagetools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,16 +530,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Install SLSA Verifier
-      uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
-
-    - name: Install crane
-      uses: iarekylew00t/crane-installer@8efb0e525fa83ad39276d294d67dda1cc85733d9 # v4.0.15
-      with:
-        # Pinned because `latest` breaks when a release omits `multiple.intoto.jsonl`
-        # renovate: datasource=github-releases depName=google/go-containerregistry
-        crane-release: v0.21.7
-
     - name: Login to GHCR
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
@@ -561,10 +551,13 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Retag and Push Container Image
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
       run: |
         while read -r tag; do
-          echo "${tag}" | cut -d: -f2 | xargs crane tag "${REGISTRY}/${{ matrix.agent }}@${DIGEST}"
-        done <<<"${{ steps.meta.outputs.tags }}"
+          [ -n "${tag}" ] || continue
+          docker buildx imagetools create --tag "${tag}" "${REGISTRY}/${{ matrix.agent }}@${DIGEST}"
+        done <<<"${TAGS}"
 
   sign-image:
     needs: [ build-image, combine-sboms ]


### PR DESCRIPTION
Closes #1878

## Problem

The `tag-image` job used `crane` to retag published images. It installed crane
with `iarekylew00t/crane-installer`, which needs the SLSA Verifier to check the
downloaded binary. That verification is unreliable, because crane releases
sometimes omit `multiple.intoto.jsonl`. See #1014 and #1871.

## Change

`tag-image` now uses `docker buildx imagetools create`. Docker and buildx are
already on the `ubuntu-24.04` runner, and the job already authenticates with
`docker/login-action`. This removes two third-party actions and adds none.

The SLSA Verifier step goes away with crane. It existed only so that
`crane-installer` could verify the crane binary; no other step in the job uses
it. The other SLSA jobs (`provenance`, and the generic generator) are untouched.

The retag loop also moves `steps.meta.outputs.tags` into an `env:` variable
instead of interpolating it into the shell script.

## Verification

I ran the new loop end to end against a local registry, with a real
two-platform image index:

- All tags resolve to the same digest as the source image.
- The OCI image index is preserved, with `linux/amd64`, `linux/arm64`, and both
  `unknown/unknown` attestation manifests intact.
- The blob count in the registry does not change, so no blob is re-uploaded.
- `imagetools create` works with the plain `docker` driver, so the job needs no
  `setup-buildx-action` step.

`actionlint` reports no problems for `.github/workflows/build.yml`.
