### PR TITLE
Bump libexpat Pin To 2.8.3-r0

### DIFF
--- a/clinical-domain-agent/Dockerfile
+++ b/clinical-domain-agent/Dockerfile
@@ -4,7 +4,7 @@ FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeae
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
-ARG LIBEXPAT_VERSION="2.8.2-r0"
+ARG LIBEXPAT_VERSION="2.8.3-r0"
 # renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 

--- a/research-domain-agent/Dockerfile
+++ b/research-domain-agent/Dockerfile
@@ -4,7 +4,7 @@ FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeae
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
-ARG LIBEXPAT_VERSION="2.8.2-r0"
+ARG LIBEXPAT_VERSION="2.8.3-r0"
 # renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 

--- a/trust-center-agent/Dockerfile
+++ b/trust-center-agent/Dockerfile
@@ -4,7 +4,7 @@ FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeae
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
-ARG LIBEXPAT_VERSION="2.8.2-r0"
+ARG LIBEXPAT_VERSION="2.8.3-r0"
 # renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 


### PR DESCRIPTION
Fixes #1901

Alpine published `libexpat-2.8.3-r0` and dropped `2.8.2-r0` from the branch index. The exact pin then had no match, so `apk add` failed and every `build-image` job failed.

Bumps the pin in all three agent Dockerfiles. `P11_KIT_VERSION` stays at `0.26.2-r0`, which the index still serves.

Verified: `apk add` resolves the three packages in the pinned base image `eclipse-temurin@sha256:28db6fdf`.