### PR TITLE
Fix Lost Date Shift Extension

### DIFF
--- a/.github/scripts/check-date-shift.sh
+++ b/.github/scripts/check-date-shift.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verify that the deidentifhir shiftDateHandler shifted the dates of the
+# transferred resources.
+#
+# The clinical domain agent replaces each configured date with a transport ID,
+# the trust center agent maps that ID onto a shifted date, and the research
+# domain agent writes the shifted date into RD-HDS. The shift is deterministic
+# per patient, so all dates of one patient move by the same amount.
+#
+# The check runs in three steps:
+#   1. Find the patients that a transfer moved into RD-HDS. CD-HDS also holds
+#      patients that no transfer selected. A patient counts as transferred if
+#      RD-HDS contains the Patient resource ID derived from it.
+#   2. Pair each original date of those patients with the date of the same
+#      field in the RD-HDS counterpart of the resource.
+#   3. Assert that the pairs cover every date field, at least two patients, and
+#      at least two dates per patient. Without that coverage the checks below
+#      hold for an empty or one-sided set of pairs.
+#   4. Compute the shift of every pair and assert that no date is unshifted,
+#      no shift exceeds maxDateShift, each patient has exactly one shift, and
+#      the shifts differ between patients.
+#
+# Usage: check-date-shift.sh [project]
+#
+# With a project name, the maximum shift comes from that project configuration.
+# Without one, it comes from the largest maxDateShift of all project files.
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=.github/scripts/patient-mapping.sh
+. "$SCRIPT_DIR/patient-mapping.sh"
+
+PROJECT_DIR=${PROJECT_DIR:-cd-agent/projects}
+# Number of resources examined per patient and resource type.
+PER_PATIENT_LIMIT=${PER_PATIENT_LIMIT:-5}
+# The consistency check needs this many dates per patient to have any force.
+MIN_DATES_PER_PATIENT=${MIN_DATES_PER_PATIENT:-2}
+
+# Date fields that the deidentifhir configuration shifts, per resource type.
+declare -A DATE_FIELDS=(
+    [Encounter]="period.start period.end"
+    [Condition]="recordedDate"
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Convert an ISO-8601 duration such as P14D or PT12H30M into seconds.
+iso_duration_to_seconds() {
+    local duration=$1
+    local pattern='^P(([0-9]+)D)?(T(([0-9]+)H)?(([0-9]+)M)?(([0-9]+)S)?)?$'
+    if [[ ! $duration =~ $pattern ]]; then
+        >&2 echo "Cannot read the duration $duration"
+        exit 2
+    fi
+    local days=${BASH_REMATCH[2]:-0} hours=${BASH_REMATCH[5]:-0}
+    local minutes=${BASH_REMATCH[7]:-0} seconds=${BASH_REMATCH[9]:-0}
+    echo $(( days * 86400 + hours * 3600 + minutes * 60 + seconds ))
+}
+
+# Print the largest maxDateShift of the given project files, in seconds.
+max_date_shift_seconds() {
+    local max=0 duration seconds
+    while read -r duration; do
+        seconds=$(iso_duration_to_seconds "$duration")
+        [ "$seconds" -gt "$max" ] && max=$seconds
+    done < <(grep -ho 'maxDateShift:[[:space:]]*[^[:space:]]*' "$@" | awk '{print $2}' | sort -u)
+
+    if [ "$max" -eq 0 ]; then
+        >&2 echo "No maxDateShift found in $*"
+        exit 2
+    fi
+    echo "$max"
+}
+
+if [ -n "${MAX_DATE_SHIFT_SECONDS:-}" ]; then
+    :
+elif [ -n "${1:-}" ]; then
+    MAX_DATE_SHIFT_SECONDS=$(max_date_shift_seconds "${PROJECT_DIR}/${1}.yaml")
+else
+    MAX_DATE_SHIFT_SECONDS=$(max_date_shift_seconds "${PROJECT_DIR}"/*.yaml)
+fi
+
+if ! cd_hds_base_url="http://$(docker compose port cd-hds 8080)/fhir"; then
+    >&2 echo "Unable to find clinical domain health data store URL"
+    exit 2
+fi
+
+if ! rd_hds_base_url="http://$(docker compose port rd-hds 8080)/fhir"; then
+    >&2 echo "Unable to find research domain health data store URL"
+    exit 2
+fi
+
+if ! gpas_base_url="http://$(docker compose port gpas 8080)/ttp-fhir/fhir/gpas"; then
+    >&2 echo "Unable to find gPAS URL"
+    exit 2
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# ---------------------------------------------------------------------------
+# Reading dates from a health data store
+# ---------------------------------------------------------------------------
+
+# Print one line per resource and date field of one resource type:
+#
+#   resource-id <TAB> patient-id <TAB> field <TAB> date
+#
+# A missing date prints as "-", so every resource has a line for every field.
+#
+# Usage: fetch_dates <base-url> <resource-type> <field>...
+fetch_dates() {
+    local base_url=$1 res_type=$2
+    shift 2
+    local fields=("$@")
+
+    # _elements takes top-level element names only, e.g. "period" for "period.start".
+    local elements
+    elements=$(printf '%s\n' "${fields[@]%%.*}" | sort -u | paste -sd, -)
+
+    local entries_file
+    entries_file=$(mktemp -p "$tmp_dir")
+    fetch_all_entries "$base_url" \
+        "${base_url}/${res_type}?_count=${FTS_PAGE_SIZE}&_elements=id,subject,${elements}" \
+        "$entries_file"
+
+    jq -r '
+        .resource
+        | .id as $id
+        | (.subject.reference // "-" | ltrimstr("Patient/")) as $patient
+        | $ARGS.positional[] as $field
+        | [$id, $patient, $field, (getpath($field | split(".")) // "-")]
+        | @tsv' "$entries_file" --args "${fields[@]}"
+}
+
+# Load the output of fetch_dates into two associative arrays:
+#   dates[resource-id/field] = date
+#   patient_of[resource-id]  = patient-id
+#
+# Usage: load_dates <base-url> <resource-type> <dates-array> <patient-array> <field>...
+# shellcheck disable=SC2034  # the arrays are filled through name references
+load_dates() {
+    local base_url=$1 res_type=$2
+    local -n dates=$3 patient_of=$4
+    shift 4
+
+    local resource patient field date
+    while IFS=$'\t' read -r resource patient field date; do
+        dates["$resource/$field"]=$date
+        patient_of["$resource"]=$patient
+    done < <(fetch_dates "$base_url" "$res_type" "$@")
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: transferred patients
+# ---------------------------------------------------------------------------
+
+# Keyed by the CD-HDS Patient resource ID.
+declare -A TRANSFERRED
+
+find_transferred_patients() {
+    local -A rd_patient_ids=()
+    local rd_id
+    while read -r rd_id; do
+        rd_patient_ids["$rd_id"]=1
+    done < <(fetch_dates "$rd_hds_base_url" Patient id | cut -f1)
+
+    local cd_id
+    for cd_id in "${!PATIENT_PID[@]}"; do
+        rd_id=$(rd_resource_id "${PATIENT_SALT[$cd_id]}" "${PATIENT_PID[$cd_id]}" Patient "$cd_id")
+        if [ -n "${rd_patient_ids[$rd_id]:-}" ]; then
+            TRANSFERRED["$cd_id"]=1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Step 2: pairs of original and shifted dates
+# ---------------------------------------------------------------------------
+
+# Print one line per shifted date of one resource type:
+#
+#   pseudonym <TAB> ResourceType.field <TAB> original-date <TAB> shifted-date
+#
+# Usage: collect_date_pairs <resource-type>
+collect_date_pairs() {
+    local res_type=$1
+    local fields
+    read -r -a fields <<< "${DATE_FIELDS[$res_type]}"
+
+    local -A cd_date=() cd_patient=() rd_date=() rd_patient=()
+    load_dates "$cd_hds_base_url" "$res_type" cd_date cd_patient "${fields[@]}"
+    load_dates "$rd_hds_base_url" "$res_type" rd_date rd_patient "${fields[@]}"
+
+    local -A examined=()
+    local cd_id patient pid rd_id field
+    for cd_id in "${!cd_patient[@]}"; do
+        patient=${cd_patient[$cd_id]}
+        [ -n "${TRANSFERRED[$patient]:-}" ] || continue
+
+        examined["$patient"]=$(( ${examined[$patient]:-0} + 1 ))
+        [ "${examined[$patient]}" -le "$PER_PATIENT_LIMIT" ] || continue
+
+        pid=${PATIENT_PID[$patient]}
+        rd_id=$(rd_resource_id "${PATIENT_SALT[$patient]}" "$pid" "$res_type" "$cd_id")
+        # A resource without counterpart did not match any deidentifhir profile.
+        [ -n "${rd_patient[$rd_id]:-}" ] || continue
+
+        for field in "${fields[@]}"; do
+            [ "${cd_date["$cd_id/$field"]}" != "-" ] || continue
+            printf '%s\t%s.%s\t%s\t%s\n' "$pid" "$res_type" "$field" \
+                "${cd_date["$cd_id/$field"]}" "${rd_date["$rd_id/$field"]}"
+        done
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Steps 3 and 4: checks
+# ---------------------------------------------------------------------------
+
+FAILED=0
+
+# Print "line: count" for each distinct input line.
+count_lines() {
+    sort | uniq -c | awk '{ print $2 ": " $1 }'
+}
+
+# Report a check. It passes when the list of violations is empty.
+#
+# Usage: check <label> <violations>
+check() {
+    local label=$1 violations=$2
+    if [ -z "$violations" ]; then
+        echo "  OK ✅  $label"
+    else
+        echo "Fail ❌  $label"
+        local lines
+        mapfile -t lines <<< "$violations"
+        printf '         %s\n' "${lines[@]}"
+        FAILED=1
+    fi
+}
+
+echo "Check Date Shifting"
+
+load_patient_mappings "$cd_hds_base_url" "$gpas_base_url"
+
+find_transferred_patients
+if [ ${#TRANSFERRED[@]} -lt 2 ]; then
+    echo "Fail ❌  found ${#TRANSFERRED[@]} transferred patients, expected at least 2"
+    exit 1
+fi
+
+pairs_file="$tmp_dir/pairs"
+for res_type in "${!DATE_FIELDS[@]}"; do
+    collect_date_pairs "$res_type"
+done > "$pairs_file"
+
+compared=$(wc -l < "$pairs_file")
+
+# Coverage. Every check below reports success on an empty list of violations,
+# so an empty or one-sided set of pairs passes them all. These three checks
+# assert the structure that the later checks need.
+
+# Each entry of DATE_FIELDS must contribute a pair. Otherwise the shift checks
+# say nothing about that field.
+expected_fields=$(
+    for res_type in "${!DATE_FIELDS[@]}"; do
+        read -r -a fields <<< "${DATE_FIELDS[$res_type]}"
+        printf '%s\n' "${fields[@]/#/${res_type}.}"
+    done | sort
+)
+missing_fields=$(comm -23 <(echo "$expected_fields") <(cut -f2 "$pairs_file" | sort -u))
+check "every date field contributes a pair" "$missing_fields"
+
+# The last check compares the shifts of two patients, so two patients must
+# contribute. A patient can be in TRANSFERRED and still contribute no pair.
+patients_with_pairs=$(cut -f1 "$pairs_file" | sort -u | wc -l)
+if [ "$patients_with_pairs" -lt 2 ]; then
+    check "at least two patients contribute pairs" \
+        "$patients_with_pairs of ${#TRANSFERRED[@]} transferred patients contribute a pair"
+else
+    check "at least two patients contribute pairs ($patients_with_pairs patients)" ""
+fi
+
+# "each patient has one date shift" is vacuous for a patient with one pair.
+too_few_dates=$(cut -f1 "$pairs_file" | sort | uniq -c \
+    | awk -v min="$MIN_DATES_PER_PATIENT" \
+        '$1 < min { print $2 " contributes " $1 " of " min " dates" }')
+check "each patient contributes at least $MIN_DATES_PER_PATIENT dates" "$too_few_dates"
+
+if [ "$FAILED" -ne 0 ]; then
+    exit 1
+fi
+
+unrestored=$(awk -F'\t' '$4 == "-" { print $2 }' "$pairs_file" | count_lines)
+if [ -n "$unrestored" ]; then
+    check "RD-HDS holds every shifted date" "$unrestored"
+    exit 1
+fi
+
+# pseudonym <TAB> ResourceType.field <TAB> shift in seconds
+#
+# GNU date reads a whole file at once, which keeps this at one process per
+# column instead of one process per date.
+shifts_file="$tmp_dir/shifts"
+paste <(cut -f1,2 "$pairs_file") \
+      <(cut -f3 "$pairs_file" | date -u -f - +%s) \
+      <(cut -f4 "$pairs_file" | date -u -f - +%s) \
+    | awk -F'\t' -v OFS='\t' '{ print $1, $2, $4 - $3 }' > "$shifts_file"
+
+field_count=$(cut -f2 "$shifts_file" | sort -u | wc -l)
+unshifted=$(awk -F'\t' '$3 == 0 { print $2 }' "$shifts_file" | count_lines)
+check "all dates are shifted ($compared values in $field_count fields)" "$unshifted"
+
+too_far=$(awk -F'\t' -v max="$MAX_DATE_SHIFT_SECONDS" \
+    '$3 > max || $3 < -max { print $1 " is shifted by " $3 " seconds" }' "$shifts_file" | sort -u)
+check "all shifts are within +/-$MAX_DATE_SHIFT_SECONDS seconds" "$too_far"
+
+patient_count=$(cut -f1 "$shifts_file" | sort -u | wc -l)
+# Patients that appear with more than one distinct shift.
+inconsistent=$(cut -f1,3 "$shifts_file" | sort -u | cut -f1 | uniq -d)
+check "each patient has one date shift ($patient_count patients)" "$inconsistent"
+
+distinct_shifts=$(cut -f3 "$shifts_file" | sort -u | wc -l)
+if [ "$distinct_shifts" -lt 2 ]; then
+    check "date shifts differ per patient" "all patients share the same date shift"
+else
+    check "date shifts differ per patient ($distinct_shifts distinct shifts)" ""
+fi
+
+exit "$FAILED"

--- a/.github/scripts/compute-expected-resource-ids.sh
+++ b/.github/scripts/compute-expected-resource-ids.sh
@@ -2,46 +2,20 @@
 set -euo pipefail
 
 # Compute expected pseudonyms and resource IDs by querying CD-HDS and gPAS.
-#
-# Resource IDs in RD-HDS are SHA-256(salt + namespacedKey) where:
-#   - salt = gPAS pseudonym for "Salt_{patientIdentifier}" in domain "MII"
-#   - namespacedKey = "{patientIdentifier}.{ResourceType}:{blazeResourceId}"
-#
-# Patient pseudonyms are gPAS pseudonyms for the patient identifier in domain "MII".
+# See patient-mapping.sh for how the IDs are derived.
 #
 # Outputs JSON: {"pseudonyms": [...], "resourceIds": [...]}
 #
 # Usage: compute-expected-resource-ids.sh <cd-hds-base-url> <gpas-base-url>
 
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=.github/scripts/patient-mapping.sh
+. "$SCRIPT_DIR/patient-mapping.sh"
+
 cd_hds_base_url=$1
 gpas_base_url=$2
 
-PAGE_SIZE=10000
-DOMAIN="MII"
 RESOURCE_TYPES=(Encounter Observation Condition DiagnosticReport MedicationAdministration)
-
-# Fetch all FHIR bundle entries across pages into a temp file (one JSON object per line).
-fetch_all_entries() {
-    local base_url=$1
-    local url=$2
-    local out_file=$3
-    local origin
-    origin=$(echo "$base_url" | sed 's|^\(http://[^/]*\).*|\1|')
-
-    while [ -n "$url" ]; do
-        local page
-        page=$(curl -sSf "$url")
-        echo "$page" | jq -c '.entry[]?' >> "$out_file"
-
-        local next_url
-        next_url=$(echo "$page" | jq -r '(.link[]? | select(.relation == "next") | .url) // empty')
-        if [ -n "$next_url" ]; then
-            url=$(echo "$next_url" | sed "s|^http://[^/]*|${origin}|")
-        else
-            url=""
-        fi
-    done
-}
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -49,95 +23,35 @@ trap 'rm -rf "$tmp_dir"' EXIT
 pseudonyms_file="$tmp_dir/pseudonyms"
 resource_ids_file="$tmp_dir/resource_ids"
 
-# --- 1. Fetch all patients from CD-HDS ---
-patient_entries_file="$tmp_dir/patient_entries"
-fetch_all_entries "$cd_hds_base_url" \
-    "${cd_hds_base_url}/Patient?_count=${PAGE_SIZE}&_elements=id,identifier" \
-    "$patient_entries_file"
+# --- 1. Fetch patients from CD-HDS and their gPAS pseudonyms and salts ---
+load_patient_mappings "$cd_hds_base_url" "$gpas_base_url"
 
-# Extract blaze_id<TAB>pid pairs (first identifier with system http://fts.smith.care)
-patient_pids_file="$tmp_dir/patient_pids"
-jq -r '.resource | .id as $id |
-    (.identifier[]? | select(.system == "http://fts.smith.care") | .value) as $pid |
-    "\($id)\t\($pid)"' "$patient_entries_file" | sort -u -t$'\t' -k1,1 > "$patient_pids_file"
+# --- 2. Compute patient pseudonyms and Patient resource IDs ---
+for cd_id in "${!PATIENT_PID[@]}"; do
+    pid=${PATIENT_PID[$cd_id]}
+    salt=${PATIENT_SALT[$cd_id]}
 
+    echo "${PATIENT_PSEUDONYM[$cd_id]}" >> "$pseudonyms_file"
+    rd_resource_id "$salt" "$pid" Patient "$cd_id" >> "$resource_ids_file"
+done
 
-# --- 2. Batch-fetch all pseudonyms and salts from gPAS ---
-# Build the list of originals: each pid and its Salt_ variant
-gpas_originals=()
-while IFS=$'\t' read -r _ pid; do
-    gpas_originals+=("$pid" "Salt_${pid}")
-done < "$patient_pids_file"
-
-# Build FHIR Parameters request body
-gpas_body=$(printf '%s\n' "${gpas_originals[@]}" | jq -R -s --arg domain "$DOMAIN" '
-    split("\n") | map(select(length > 0)) |
-    {
-        resourceType: "Parameters",
-        parameter: ([{ name: "target", valueString: $domain }] +
-            map({ name: "original", valueString: . }))
-    }')
-
-gpas_response=$(curl -sSf \
-    -H "Content-Type: application/fhir+json" \
-    -H "Accept: application/fhir+json" \
-    -d "$gpas_body" \
-    "${gpas_base_url}/\$pseudonymizeAllowCreate")
-
-# Parse response into TSV: original<TAB>pseudonym
-gpas_mapping_file="$tmp_dir/gpas_mapping"
-echo "$gpas_response" | jq -r '
-    .parameter[]? | .part as $parts |
-    ($parts | map(select(.name == "original")) | first | .valueIdentifier.value) as $orig |
-    ($parts | map(select(.name == "pseudonym")) | first | .valueIdentifier.value) as $pseudo |
-    "\($orig)\t\($pseudo)"' > "$gpas_mapping_file"
-
-# Load into associative array
-declare -A gpas_mapping
-while IFS=$'\t' read -r orig pseudo; do
-    gpas_mapping["$orig"]="$pseudo"
-done < "$gpas_mapping_file"
-
-
-# --- 3. Compute patient pseudonyms and Patient resource IDs ---
-declare -A patient_data_pid patient_data_salt
-
-while IFS=$'\t' read -r blaze_id pid; do
-    patient_pseudo="${gpas_mapping[$pid]:-}"
-    salt="${gpas_mapping[Salt_${pid}]:-}"
-
-    if [ -z "$patient_pseudo" ] || [ -z "$salt" ]; then
-        >&2 echo "WARNING: missing gPAS mapping for patient $pid"
-        continue
-    fi
-
-    echo "$patient_pseudo" >> "$pseudonyms_file"
-    patient_data_pid["$blaze_id"]="$pid"
-    patient_data_salt["$blaze_id"]="$salt"
-
-    namespaced_key="${pid}.Patient:${blaze_id}"
-    printf '%s' "${salt}${namespaced_key}" | sha256sum | cut -d' ' -f1 >> "$resource_ids_file"
-done < "$patient_pids_file"
-
-
-# --- 4. Fetch resource types and compute their resource IDs ---
+# --- 3. Fetch resource types and compute their resource IDs ---
 for res_type in "${RESOURCE_TYPES[@]}"; do
     entries_file="$tmp_dir/entries_${res_type}"
     fetch_all_entries "$cd_hds_base_url" \
-        "${cd_hds_base_url}/${res_type}?_count=${PAGE_SIZE}&_elements=id,subject" \
+        "${cd_hds_base_url}/${res_type}?_count=${FTS_PAGE_SIZE}&_elements=id,subject" \
         "$entries_file"
 
-    # Extract res_id and patient blaze_id from subject reference
-    while IFS=$'\t' read -r res_id patient_blaze_id; do
-        pid="${patient_data_pid[$patient_blaze_id]:-}"
-        salt="${patient_data_salt[$patient_blaze_id]:-}"
+    # Extract res_id and the CD Patient ID from the subject reference
+    while IFS=$'\t' read -r res_id patient_cd_id; do
+        pid="${PATIENT_PID[$patient_cd_id]:-}"
+        salt="${PATIENT_SALT[$patient_cd_id]:-}"
 
         if [ -z "$pid" ] || [ -z "$salt" ] || [ -z "$res_id" ]; then
             continue
         fi
 
-        namespaced_key="${pid}.${res_type}:${res_id}"
-        printf '%s' "${salt}${namespaced_key}" | sha256sum | cut -d' ' -f1
+        rd_resource_id "$salt" "$pid" "$res_type" "$res_id"
     done < <(jq -r '.resource |
         .id as $id |
         (.subject.reference // "" | ltrimstr("Patient/")) as $patient_id |

--- a/.github/scripts/patient-mapping.sh
+++ b/.github/scripts/patient-mapping.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Shared helpers that map CD-HDS patients and resources onto their RD-HDS
+# counterparts. Source this file, do not execute it.
+#
+# RD-HDS resource IDs are SHA-256(salt + namespacedKey) where:
+#   - salt = gPAS pseudonym for "Salt_{patientIdentifier}" in domain "MII"
+#   - namespacedKey = "{patientIdentifier}.{ResourceType}:{cdResourceId}"
+#
+# Patient pseudonyms are gPAS pseudonyms for the patient identifier in domain "MII".
+
+FTS_DOMAIN=${FTS_DOMAIN:-MII}
+FTS_PAGE_SIZE=${FTS_PAGE_SIZE:-10000}
+FTS_IDENTIFIER_SYSTEM=${FTS_IDENTIFIER_SYSTEM:-http://fts.smith.care}
+
+# Keyed by the CD-HDS Patient resource ID. Filled by load_patient_mappings.
+# shellcheck disable=SC2034
+declare -gA PATIENT_PID PATIENT_SALT PATIENT_PSEUDONYM
+
+# Fetch all FHIR bundle entries across pages into a file, one JSON object per line.
+#
+# Usage: fetch_all_entries <base-url> <start-url> <out-file>
+fetch_all_entries() {
+    local base_url=$1
+    local url=$2
+    local out_file=$3
+    local origin
+    origin=$(echo "$base_url" | sed 's|^\(http://[^/]*\).*|\1|')
+
+    while [ -n "$url" ]; do
+        local page
+        page=$(curl -sSf "$url")
+        echo "$page" | jq -c '.entry[]?' >> "$out_file"
+
+        local next_url
+        next_url=$(echo "$page" | jq -r '(.link[]? | select(.relation == "next") | .url) // empty')
+        if [ -n "$next_url" ]; then
+            # The FHIR server's "next" links use the container-internal hostname,
+            # which is unreachable from the host. Rewrite it to the mapped origin.
+            url=$(echo "$next_url" | sed "s|^http://[^/]*|${origin}|")
+        else
+            url=""
+        fi
+    done
+}
+
+# Load the gPAS pseudonym and the date/ID salt of every CD-HDS patient into
+# PATIENT_PID, PATIENT_SALT and PATIENT_PSEUDONYM.
+#
+# Usage: load_patient_mappings <cd-hds-base-url> <gpas-base-url>
+load_patient_mappings() {
+    local cd_hds_base_url=$1
+    local gpas_base_url=$2
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+
+    local patient_entries_file="$tmp_dir/patient_entries"
+    fetch_all_entries "$cd_hds_base_url" \
+        "${cd_hds_base_url}/Patient?_count=${FTS_PAGE_SIZE}&_elements=id,identifier" \
+        "$patient_entries_file"
+
+    # Extract cd_id<TAB>pid pairs (first identifier with the FTS system)
+    local patient_pids_file="$tmp_dir/patient_pids"
+    jq -r --arg system "$FTS_IDENTIFIER_SYSTEM" '.resource | .id as $id |
+        (.identifier[]? | select(.system == $system) | .value) as $pid |
+        "\($id)\t\($pid)"' "$patient_entries_file" | sort -u -t$'\t' -k1,1 > "$patient_pids_file"
+
+    # Build the list of originals: each pid and its Salt_ variant
+    local gpas_originals=()
+    local cd_id pid
+    while IFS=$'\t' read -r _ pid; do
+        gpas_originals+=("$pid" "Salt_${pid}")
+    done < "$patient_pids_file"
+
+    local gpas_body
+    gpas_body=$(printf '%s\n' "${gpas_originals[@]}" | jq -R -s --arg domain "$FTS_DOMAIN" '
+        split("\n") | map(select(length > 0)) |
+        {
+            resourceType: "Parameters",
+            parameter: ([{ name: "target", valueString: $domain }] +
+                map({ name: "original", valueString: . }))
+        }')
+
+    local gpas_response
+    gpas_response=$(curl -sSf \
+        -H "Content-Type: application/fhir+json" \
+        -H "Accept: application/fhir+json" \
+        -d "$gpas_body" \
+        "${gpas_base_url}/\$pseudonymizeAllowCreate")
+
+    local gpas_mapping_file="$tmp_dir/gpas_mapping"
+    echo "$gpas_response" | jq -r '
+        .parameter[]? | .part as $parts |
+        ($parts | map(select(.name == "original")) | first | .valueIdentifier.value) as $orig |
+        ($parts | map(select(.name == "pseudonym")) | first | .valueIdentifier.value) as $pseudo |
+        "\($orig)\t\($pseudo)"' > "$gpas_mapping_file"
+
+    local -A gpas_mapping
+    local orig pseudo
+    while IFS=$'\t' read -r orig pseudo; do
+        gpas_mapping["$orig"]="$pseudo"
+    done < "$gpas_mapping_file"
+
+    while IFS=$'\t' read -r cd_id pid; do
+        local patient_pseudo="${gpas_mapping[$pid]:-}"
+        local salt="${gpas_mapping[Salt_${pid}]:-}"
+
+        if [ -z "$patient_pseudo" ] || [ -z "$salt" ]; then
+            >&2 echo "WARNING: missing gPAS mapping for patient $pid"
+            continue
+        fi
+
+        PATIENT_PID["$cd_id"]="$pid"
+        PATIENT_SALT["$cd_id"]="$salt"
+        PATIENT_PSEUDONYM["$cd_id"]="$patient_pseudo"
+    done < "$patient_pids_file"
+
+    rm -rf "$tmp_dir"
+}
+
+# Print the RD-HDS resource ID of a CD-HDS resource.
+#
+# Usage: rd_resource_id <salt> <pid> <resource-type> <cd-resource-id>
+rd_resource_id() {
+    local salt=$1 pid=$2 resource_type=$3 cd_id=$4
+    printf '%s' "${salt}${pid}.${resource_type}:${cd_id}" | sha256sum | cut -d' ' -f1
+}

--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -1,10 +1,11 @@
 .PHONY: all pull generate-certs check-certs start upload-consents check-consent upload-test-data \
 	transfer-all transfer-list transfer-with-fhir-consent-list wait  \
-	check-status check-resources check-pseudonymization show-status show-hds clean-dbs clean-rd-hds \
+	check-status check-resources check-pseudonymization check-date-shift show-status show-hds \
+	clean-dbs clean-rd-hds \
 	download-test-data download-test-data-checksums check-test-data \
 	openapi-specs list-projects show-project
 
-all: pull generate-certs start upload-test-data transfer-all wait check-status check-resources check-pseudonymization show-hds clean-dbs
+all: pull generate-certs start upload-test-data transfer-all wait check-status check-resources check-pseudonymization check-date-shift show-hds clean-dbs
 
 COMPOSE_FILES?=-f compose.yaml
 SERVICES?=
@@ -69,6 +70,9 @@ check-resources:
 
 check-pseudonymization:
 	$(SCRIPTS)/check-pseudonymization.sh
+
+check-date-shift:
+	$(SCRIPTS)/check-date-shift.sh ${PROJECT}
 
 show-status:
 	curl -sSf "$(shell cat process.url)"

--- a/.github/test/deidentifhir/de.medizininformatikinitiative.kerndatensatz.diagnose-1.0.4/diagnose/CDtoTransport.conf
+++ b/.github/test/deidentifhir/de.medizininformatikinitiative.kerndatensatz.diagnose-1.0.4/diagnose/CDtoTransport.conf
@@ -4,6 +4,7 @@
     "paths" : {
         "Condition.id" : { handler = idReplacementHandler }
         "Condition.subject.reference" : { handler = referenceReplacementHandler }
+        "Condition.recordedDate" : { handler = shiftDateHandler }
     },
     "pattern" : "Condition.meta.profile contains 'https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose'"
 }

--- a/.github/test/deidentifhir/de.medizininformatikinitiative.kerndatensatz.fall-1.0.1/kontakt/CDtoTransport.conf
+++ b/.github/test/deidentifhir/de.medizininformatikinitiative.kerndatensatz.fall-1.0.1/kontakt/CDtoTransport.conf
@@ -5,6 +5,8 @@
         "Encounter.id" : { handler = idReplacementHandler }
         "Encounter.diagnosis.condition.reference" : { handler = referenceReplacementHandler }
         "Encounter.subject.reference" : { handler = referenceReplacementHandler }
+        "Encounter.period.start" : { handler = shiftDateHandler }
+        "Encounter.period.end" : { handler = shiftDateHandler }
     },
     "pattern" : "Encounter.meta.profile contains 'https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung'"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,6 +407,7 @@ jobs:
         make check-status RESULTS_FILE=example.json
         check-resources.sh example.json "${LAST_UPDATED}"
         check-pseudonymization.sh
+        check-date-shift.sh gics-consent-example
 
     - name: Run e2e with failing mTLS
       if: matrix.id == 'mtls'
@@ -426,6 +427,7 @@ jobs:
         make check-status RESULTS_FILE=example-with-fhir-consent.json
         check-resources.sh example-with-fhir-consent.json "${LAST_UPDATED}"
         check-pseudonymization.sh
+        check-date-shift.sh mtls
 
     - name: Collect Agent Logs
       if: failure() || cancelled()

--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
@@ -9,6 +9,8 @@ import de.ume.deidentifhir.util.Handlers;
 import de.ume.deidentifhir.util.JavaCompat;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.ArrayList;
+import java.util.List;
 import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.BaseDateTimeType;
 import org.hl7.fhir.r4.model.Bundle;
@@ -19,6 +21,8 @@ import scala.collection.immutable.Map;
 import scala.collection.immutable.Seq;
 
 public interface DeidentifhirUtils {
+
+  String SHIFT_DATE_HANDLER = "shiftDateHandler";
 
   /**
    * Builds a registry with handlers that use the provided GeneratingReplacementProvider. During
@@ -51,11 +55,9 @@ public interface DeidentifhirUtils {
         JavaCompat.partiallyApply2(
             provider, provider, Handlers::conditionalReferencesReplacementHandler));
 
-    // Handler that generates tID for date, adds extension, and nulls the value
-    registry.addHander(
-        "shiftDateHandler",
-        (Function4<Seq<String>, BaseDateTimeType, Seq<Base>, Map<String, String>, BaseDateTimeType>)
-            (path, date, parents, context) -> shiftDate(date, provider));
+    // Keeps the date during the engine pass and collects the element. The date is shifted after the
+    // engine pass, see ShiftDateHandler.
+    registry.addHander(SHIFT_DATE_HANDLER, new ShiftDateHandler(provider));
 
     return registry;
   }
@@ -88,8 +90,43 @@ public interface DeidentifhirUtils {
     Map<String, String> staticContext =
         new Map.Map1<>(Handlers.patientIdentifierKey(), patientIdentifier);
     Deidentifhir deidentifhir = Deidentifhir.apply(config, registry);
+    var shiftDateHandler = (ShiftDateHandler) registry.getHandler(SHIFT_DATE_HANDLER).get();
     var deidentified = (Bundle) deidentifhir.deidentify(bundle, staticContext);
+    shiftDateHandler.shiftCollectedDates();
     sample.stop(meterRegistry.timer("deidentify"));
     return deidentified;
+  }
+
+  /**
+   * Handler for dates that are shifted by the TCA.
+   *
+   * <p>The engine replaces the extension list of a primitive element after the handler ran, so an
+   * extension that the handler adds is lost. The engine does keep the element instance that the
+   * handler returns and writes that instance into the output resource. So during the engine pass
+   * this handler keeps the date unchanged and only collects the element. After the engine pass,
+   * {@link #deidentify} applies {@link DeidentifhirUtils#shiftDate} to every collected element.
+   */
+  final class ShiftDateHandler
+      implements Function4<
+          Seq<String>, BaseDateTimeType, Seq<Base>, Map<String, String>, BaseDateTimeType> {
+
+    private final GeneratingReplacementProvider provider;
+    private final List<BaseDateTimeType> dates = new ArrayList<>();
+
+    ShiftDateHandler(GeneratingReplacementProvider provider) {
+      this.provider = provider;
+    }
+
+    @Override
+    public BaseDateTimeType apply(
+        Seq<String> path, BaseDateTimeType date, Seq<Base> parents, Map<String, String> context) {
+      dates.add(date);
+      return date;
+    }
+
+    void shiftCollectedDates() {
+      dates.forEach(date -> shiftDate(date, provider));
+      dates.clear();
+    }
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
@@ -5,6 +5,7 @@ import static care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils.deident
 import static care.smith.fts.cda.services.deidentifhir.DeidentifhirUtils.shiftDate;
 import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
 import static com.typesafe.config.ConfigFactory.parseResources;
+import static com.typesafe.config.ConfigFactory.parseString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.fts.api.ConsentedPatient;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +54,31 @@ class DeidentifhirUtilsTest {
     // Verify the identifier value was replaced with a generated tID
     assertThat(p.getIdentifierFirstRep().getValue()).isNotEqualTo("identifier1");
     assertThat(p.getIdentifierFirstRep().getValue()).hasSize(21); // NanoId length
+  }
+
+  @Test
+  void deidentifyKeepsDateShiftExtensionOnBirthDate() throws IOException {
+    ConsentedPatient patient = new ConsentedPatient("id1", "system");
+    var registry = buildRegistry(provider);
+    var config = parseResources(DeidentifhirUtilsTest.class, "CDtoTransport.profile");
+
+    var bundle =
+        TestPatientGenerator.generateOnePatient("id1", "2023", "identifierSystem1", "identifier1");
+    Bundle deidentifiedBundle =
+        deidentify(config, registry, bundle, patient.identifier(), meterRegistry);
+    Bundle b = (Bundle) deidentifiedBundle.getEntryFirstRep().getResource();
+
+    Patient p = (Patient) b.getEntryFirstRep().getResource();
+    var birthDate = p.getBirthDateElement();
+
+    // shiftDateHandler nulls the value and hangs the tID on the element as an extension
+    assertThat(birthDate.getValue()).isNull();
+
+    // without the extension the RDA cannot restore the shifted date, and the date is lost
+    var extension = birthDate.getExtensionByUrl(DATE_SHIFT_EXTENSION_URL);
+    assertThat(extension).isNotNull();
+    var tId = ((StringType) extension.getValue()).getValue();
+    assertThat(provider.getDateMappings()).containsKey(tId);
   }
 
   @Test
@@ -111,5 +138,78 @@ class DeidentifhirUtilsTest {
     // Only one mapping should exist for the same date value
     assertThat(provider.getDateMappings()).hasSize(1);
     assertThat(provider.getDateMappings()).containsValue("1950-01-01");
+  }
+
+  @Test
+  void deidentifyRemovesResourcesWithoutModule() throws IOException {
+    var registry = buildRegistry(provider);
+    var config = parseResources(DeidentifhirUtilsTest.class, "CDtoTransport.profile");
+    var bundle =
+        TestPatientGenerator.generateOnePatient("id1", "2023", "identifierSystem1", "identifier1");
+    var innerBundle = (Bundle) bundle.getEntryFirstRep().getResource();
+    innerBundle.addEntry().setResource(new Observation().setId("obs1"));
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Bundle b = (Bundle) deidentifiedBundle.getEntryFirstRep().getResource();
+    assertThat(b.getEntry()).hasSize(1);
+    assertThat(b.getEntryFirstRep().getResource()).isInstanceOf(Patient.class);
+  }
+
+  @Test
+  void deidentifyWithoutShiftDateHandlerKeepsDateValue() throws IOException {
+    var registry = buildRegistry(provider);
+    var config =
+        parseResources(
+            DeidentifhirUtilsTest.class, "CDtoTransportWithGeneralizeDateHandler.profile");
+    var bundle =
+        TestPatientGenerator.generateOnePatient("id1", "2023", "identifierSystem1", "identifier1");
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Bundle b = (Bundle) deidentifiedBundle.getEntryFirstRep().getResource();
+    Patient p = (Patient) b.getEntryFirstRep().getResource();
+    assertThat(p.getBirthDateElement().getValue()).isNotNull();
+    assertThat(p.getBirthDateElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNull();
+    assertThat(provider.getDateMappings()).isEmpty();
+  }
+
+  @Test
+  void deidentifyShiftsOnlyConfiguredDates() {
+    var registry = buildRegistry(provider);
+    var config =
+        parseString(
+            """
+            {
+              deidentiFHIR.profile.version=0.2
+              modules {
+                test_patient {
+                  base = ["Patient.id", "Patient.birthDate", "Patient.deceased[dateTime]", "Patient.meta.profile"]
+                  paths { "Patient.birthDate" { handler = shiftDateHandler } }
+                  pattern = "Patient.meta.profile contains 'https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient'"
+                }
+              }
+            }
+            """);
+    var patient = new Patient();
+    patient.setId("id1");
+    patient
+        .getMeta()
+        .addProfile(
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient");
+    patient.setBirthDateElement(new DateType("1990-01-01"));
+    patient.setDeceased(new DateTimeType("2020-05-05T00:00:00Z"));
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(patient);
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Patient p = (Patient) deidentifiedBundle.getEntryFirstRep().getResource();
+    assertThat(p.getBirthDateElement().getValue()).isNull();
+    assertThat(p.getBirthDateElement().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNotNull();
+    assertThat(p.getDeceasedDateTimeType().getValueAsString()).isEqualTo("2020-05-05T00:00:00Z");
+    assertThat(p.getDeceasedDateTimeType().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNull();
+    assertThat(provider.getDateMappings()).containsValues("1990-01-01");
+    assertThat(provider.getDateMappings()).hasSize(1);
   }
 }


### PR DESCRIPTION
## Summary

The CDA `shiftDateHandler` nulls a configured date and adds a transport ID extension to the element. DeidentiFHIR 0.2.11 rebuilds the extensions of a primitive element from the input element, not from the handler output, so the extension was lost. The RDA could not restore the date, and RD-HDS held no date at all. See #1936.

## Tests

- Unit: `DeidentifhirUtilsTest.deidentifyKeepsDateShiftExtensionOnBirthDate` runs the real engine over the test profile and asserts the extension and the date mapping in the provider.
- E2E: a check that the shifted date arrives in RD-HDS.

## Fix

Option O1 from #1936. The registry handler keeps the date during the engine pass and records the path per input resource. The engine runs per resource, so each output resource is paired with its input. A post-pass walks the output along the recorded paths and shifts the dates there, where the engine cannot prune the extension. The public interface of `DeidentifhirUtils` is unchanged.

Closes #1936

