### PR TITLE
Track Alpine 3.24 Packages in Agent Images

### DIFF
--- a/clinical-domain-agent/Dockerfile
+++ b/clinical-domain-agent/Dockerfile
@@ -3,9 +3,9 @@ FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
-# renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,

--- a/research-domain-agent/Dockerfile
+++ b/research-domain-agent/Dockerfile
@@ -3,9 +3,9 @@ FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
-# renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,

--- a/trust-center-agent/Dockerfile
+++ b/trust-center-agent/Dockerfile
@@ -3,9 +3,9 @@ FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
 # Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
 # share one version and must upgrade in lockstep.
-# renovate: datasource=repology depName=alpine_3_23/libexpat versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_23/p11-kit versioning=loose
+# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
 ARG P11_KIT_VERSION="0.26.2-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,


### PR DESCRIPTION
Base image moved to Alpine 3.24 in e47ba571; the Renovate annotations still pointed at the 3.23 package branch.

Fixes #1944