### PR TITLE
Add PIT mutation testing and exclude untestable mutants

### DIFF
--- a/.github/scripts/mutation-pr.sh
+++ b/.github/scripts/mutation-pr.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run PIT mutation testing only on the production classes that changed on this
+# branch compared with a base ref (default: origin/main).
+#
+# Usage: .github/scripts/mutation-pr.sh [BASE_REF] [extra mvn args...]
+set -euo pipefail
+
+base="${1:-origin/main}"
+shift || true
+
+mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${base}...HEAD" -- '*/src/main/java/*.java')
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No production Java files changed against ${base}; nothing to mutate."
+  exit 0
+fi
+
+declare -A modules
+classes=()
+for f in "${files[@]}"; do
+  module="${f%%/src/main/java/*}"
+  [[ "${module}" == "test-util" ]] && continue
+  modules["${module}"]=1
+  cls="${f#*/src/main/java/}"
+  cls="${cls%.java}"
+  classes+=("${cls//\//.}*")
+done
+
+if [[ ${#classes[@]} -eq 0 ]]; then
+  echo "Only test-util changed; nothing to mutate."
+  exit 0
+fi
+
+target_classes=$(IFS=,; echo "${classes[*]}")
+projects=$(IFS=,; echo "${!modules[*]}")
+
+echo "Modules:  ${projects}"
+echo "Classes:  ${target_classes}"
+
+[[ -n "${PIT_DRY_RUN:-}" ]] && exit 0
+
+mvn -B -Pmutation --also-make --projects "${projects}" \
+  -DskipUnitTests=true -DskipITs -Dcheckstyle.skip -Djacoco.skip -Dcyclonedx.skip -Dspring-boot.repackage.skip=true \
+  -DtargetClasses="${target_classes}" \
+  "$@" verify

--- a/.github/scripts/mutation-survived.sh
+++ b/.github/scripts/mutation-survived.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Print every mutant that survived, from all <module>/target/pit-reports/mutations.xml files.
+#
+# PIT has no JSON report format, so xq reads mutations.xml and applies a jq program
+# to it. xq comes from the python yq package: `pipx install yq`. It writes XML
+# attributes with an "@" prefix, and it needs the jq binary on the PATH.
+#
+# Usage: .github/scripts/mutation-survived.sh [--json] [module...]
+set -euo pipefail
+
+command -v xq >/dev/null || { echo "Needs xq: pipx install yq" >&2; exit 1; }
+
+json=false
+if [[ "${1:-}" == "--json" ]]; then
+  json=true
+  shift
+fi
+
+modules=("$@")
+[[ ${#modules[@]} -eq 0 ]] && modules=(api util clinical-domain-agent trust-center-agent research-domain-agent)
+
+# Keep the survivors, and add the path of the source file.
+program='
+  .mutations.mutation
+| (if . == null then [] elif type == "array" then . else [.] end)
+| map(select(."@status" == "SURVIVED" or ."@status" == "NO_COVERAGE"))
+| .[]
+| {
+    status: ."@status",
+    sourceFile: .sourceFile,
+    class: .mutatedClass,
+    method: .mutatedMethod,
+    line: (.lineNumber | tonumber),
+    mutator: (.mutator | split(".") | last),
+    description: .description,
+    module: $module,
+    file: ($module + "/src/main/java/" + (.mutatedClass | split("$") | .[0] | gsub("\\."; "/")) + ".java")
+  }
+'
+
+total=0
+for m in "${modules[@]}"; do
+  f="${m}/target/pit-reports/mutations.xml"
+  [[ -s "${f}" ]] || continue
+
+  if "${json}"; then
+    out=$(xq -c --arg module "${m}" "${program}" "${f}")
+  else
+    out=$(xq -r --arg module "${m}" \
+      "${program} | \"\(.file):\(.line)  \(.status)  \(.method)  \(.description)\"" "${f}")
+  fi
+
+  count=0
+  if [[ -n "${out}" ]]; then
+    printf '%s\n' "${out}"
+    count=$(printf '%s\n' "${out}" | wc -l)
+  fi
+
+  total=$((total + count))
+  echo "# ${m}: ${count} surviving" >&2
+done
+
+echo "# total: ${total} surviving" >&2

--- a/.github/scripts/mutation.sh
+++ b/.github/scripts/mutation.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run PIT mutation testing over all modules.
+#
+# Reports land in <module>/target/pit-reports. List the survivors with
+# .github/scripts/mutation-survived.sh.
+#
+# Usage: .github/scripts/mutation.sh [extra mvn args...]
+# To run one module: MAVEN_ARGS="-pl util" .github/scripts/mutation.sh
+set -euo pipefail
+
+# shellcheck disable=SC2086
+mvn ${MAVEN_ARGS:-} -B -Pmutation \
+  -DskipUnitTests=true -DskipITs -Dcheckstyle.skip -Djacoco.skip -Dcyclonedx.skip \
+  -Dspring-boot.repackage.skip=true \
+  "$@" verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	compile test build coverage clinical-domain-agent trust-center-agent research-domain-agent all
+.PHONY:	compile test build coverage mutation clinical-domain-agent trust-center-agent research-domain-agent all
 
 AGENTS := $(wildcard *-agent)
 all: build
@@ -20,6 +20,11 @@ build:
 
 coverage:
 	mvn ${MAVEN_ARGS} jacoco:report-aggregate@report
+
+# Reports land in <module>/target/pit-reports. List the survivors with
+# .github/scripts/mutation-survived.sh. To run one module: MAVEN_ARGS="-pl util" make mutation
+mutation:
+	.github/scripts/mutation.sh
 
 $(AGENTS):
 	mvn ${MAVEN_ARGS} clean package -DskipTests --projects $@ --also-make

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
     <!-- Corresponds to version defined via spring-boot-dependencies/junit-bom -->
     <junit-platform.version>6.0.3</junit-platform.version>
     <skipUnitTests>false</skipUnitTests>
+    <pit.skip>false</pit.skip>
+    <pit.threads>4</pit.threads>
   </properties>
 
   <dependencyManagement>
@@ -128,6 +130,75 @@
             <configLocation>google_checks.xml</configLocation>
             <consoleOutput>false</consoleOutput>
             <failsOnError>true</failsOnError>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.pitest</groupId>
+          <artifactId>pitest-maven</artifactId>
+          <version>1.19.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.pitest</groupId>
+              <artifactId>pitest-junit5-plugin</artifactId>
+              <version>1.2.3</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <targetClasses>
+              <param>care.smith.fts.*</param>
+            </targetClasses>
+            <excludedClasses>
+              <!--
+                Spring calls @Bean and @Configuration methods once at context start, before any
+                test runs, so PIT finds no covering test and cannot kill these mutants. A test
+                for a null @Bean adds nothing, because a null bean already fails every IT.
+                Named one by one on purpose: a *Configuration glob misses MetricsConfig and
+                swallows every class added later whose name ends in Configuration.
+                MetricsConfig$1 and OAuth2ConfigurationExistsCondition stay in scope. They
+                rewrite data or select a backend at runtime.
+              -->
+              <param>care.smith.fts.util.AgentConfiguration</param>
+              <param>care.smith.fts.util.MetricsConfig</param>
+              <param>care.smith.fts.util.fhir.FhirCodecConfiguration</param>
+              <param>care.smith.fts.util.fhir.FhirCodecConfiguration$*</param>
+              <param>care.smith.fts.util.auth.HttpServer*</param>
+              <param>care.smith.fts.util.error.*ResponseUtil</param>
+              <param>care.smith.fts.cda.ClinicalDomainAgent</param>
+              <param>care.smith.fts.rda.ResearchDomainAgent</param>
+              <param>care.smith.fts.tca.consent.configuration.GicsConfiguration</param>
+              <param>care.smith.fts.tca.deidentification.configuration.DeIdentificationConfiguration</param>
+              <param>care.smith.fts.tca.deidentification.configuration.GpasDeIdentificationConfiguration</param>
+              <!-- Cosmetic. No test asserts on these. -->
+              <param>care.smith.fts.util.CustomErrorHandler</param>
+              <param>care.smith.fts.util.NanoIdUtils</param>
+            </excludedClasses>
+            <!-- Cosmetic. requestName returns a constant label for the retry strategy. -->
+            <excludedMethods>
+              <param>toString</param>
+              <param>requestName</param>
+            </excludedMethods>
+            <excludedTestClasses>
+              <param>care.smith.fts.*E2E</param>
+            </excludedTestClasses>
+            <!-- Removed log and meter calls. No test should assert on those. -->
+            <avoidCallsTo>
+              <avoidCallsTo>org.slf4j</avoidCallsTo>
+              <avoidCallsTo>io.micrometer</avoidCallsTo>
+            </avoidCallsTo>
+            <mutators>
+              <mutator>STRONGER</mutator>
+            </mutators>
+            <outputFormats>
+              <format>XML</format>
+              <format>HTML</format>
+            </outputFormats>
+            <timestampedReports>false</timestampedReports>
+            <threads>${pit.threads}</threads>
+            <timeoutConstant>8000</timeoutConstant>
+            <failWhenNoMutations>false</failWhenNoMutations>
+            <skipFailingTests>true</skipFailingTests>
+            <skip>${pit.skip}</skip>
           </configuration>
         </plugin>
 
@@ -287,4 +358,27 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>mutation</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <executions>
+              <execution>
+                <id>mutation</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>mutationCoverage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -12,6 +12,10 @@
 
   <artifactId>test-util</artifactId>
 
+  <properties>
+    <pit.skip>true</pit.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
Sets up PIT and takes the mutants that no test can kill out of scope.

## What

- `pitest-maven` 1.19.1 with the `STRONGER` mutator set, in `pluginManagement`.
- A `mutation` profile that binds `mutationCoverage` to `verify`, and a `make mutation` target.
- `pit.skip=true` in `test-util`, which ships no production code.
- `tools/mutation/survived.sh` lists the survivors. `tools/mutation/pr.sh` mutates only the classes changed on a branch.
- The C4 and C5 exclusions from the mutation testing findings of 2026-09-07.

## Why the exclusions

Spring calls `@Bean` and `@Configuration` methods once at context start, before any test runs.
PIT attributes a line to a test only when the test's own execution runs it, so it finds no
covering test and cannot kill these mutants. A test for a null `@Bean` adds nothing, because a
null bean already fails the context start in every IT.

The cosmetic group is `toString`, `requestName`, `NanoIdUtils`, `CustomErrorHandler`, and the
`log.*` and `meter.*` calls. No test should assert on those.

## Three corrections to the proposed configuration

The findings proposed `care.smith.fts.*Configuration` and `*Configuration$*`. Applying
it showed three problems, so the list now names classes one by one.

1. `MetricsConfig` does not end in `Configuration`. The glob missed it.
2. The glob also matched `TransportMappingConfiguration`, which was not on the list, and it
   swallows every class added later whose name ends in `Configuration`.
3. Only `FhirCodecConfiguration` needs a `$*` entry. Its `@Bean` returns an anonymous
   `WebFluxConfigurer` that PIT reports as `FhirCodecConfiguration$1`.

## Verified in scope

A full run confirms these still report mutants, so issue 4.2 has targets:

| Class | Surviving mutants |
|---|---|
| `MetricsConfig$1.map` | 5, including the return-value one |
| `OAuth2ConfigurationExistsCondition` | 8 |
| `GicsConfigured` | 5 |

`avoidCallsTo io.micrometer` does not swallow the `MetricsConfig$1.map` mutants.
`WebClientFactory` is not excluded: `sslBundle` is real logic and a test can kill its mutant.

## Baseline

| Module | Mutants | Score | Survived | No coverage |
|---|---|---|---|---|
| api | 46 | 89% | 4 | 1 |
| util | 227 | 83% | 37 | 2 |
| clinical-domain-agent | 342 | 87% | 46 | 0 |
| research-domain-agent | 205 | 85% | 30 | 1 |
| trust-center-agent | 144 | 83% | 24 | 1 |

209 mutants survived before, 146 after. The mutant counts are not comparable with the first run,
because the default branch moved on between the two runs.

## Open points for issue 5

- `NanoIdUtils` is excluded, but its mutants are not untestable. A test that asserts the length
  and the alphabet kills them, and `nanoId` generates the tIDs that carry the pseudonym
  contract.
- `excludedMethods` applies to every class. `requestName` is safe today, because both
  implementations return a constant.
- Three mutants report `RUN_ERROR`, two in `util` and one in `clinical-domain-agent`. PIT counts
  them as detected. Check them before setting `mutationThreshold`.

No `mutationThreshold` yet. That is issue 5.

Closes #1947
