### PR TITLE
Patch OpenSSL in Agent Images

### DIFF
--- a/clinical-domain-agent/Dockerfile
+++ b/clinical-domain-agent/Dockerfile
@@ -1,19 +1,20 @@
 FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0d6a34312f858bd2c67dd01e732e6b682
 
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
-# Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
-# share one version and must upgrade in lockstep.
+# Renovate tracks updates (see renovate.json5). openssl, libssl3 and
+# libcrypto3 share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
-ARG P11_KIT_VERSION="0.26.2-r0"
+# renovate: datasource=repology depName=alpine_3_24/openssl versioning=loose
+ARG OPENSSL_VERSION="3.5.8-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
 # --private-key, and --ca-certificate.
 RUN apk add --no-cache -q \
       "libexpat=${LIBEXPAT_VERSION}" \
-      "p11-kit=${P11_KIT_VERSION}" \
-      "p11-kit-trust=${P11_KIT_VERSION}" \
+      "libcrypto3=${OPENSSL_VERSION}" \
+      "libssl3=${OPENSSL_VERSION}" \
+      "openssl=${OPENSSL_VERSION}" \
       wget
 
 COPY --chown=nobody:nobody target/clinical-domain-agent.jar /app/clinical-domain-agent.jar

--- a/research-domain-agent/Dockerfile
+++ b/research-domain-agent/Dockerfile
@@ -1,19 +1,20 @@
 FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0d6a34312f858bd2c67dd01e732e6b682
 
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
-# Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
-# share one version and must upgrade in lockstep.
+# Renovate tracks updates (see renovate.json5). openssl, libssl3 and
+# libcrypto3 share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
-ARG P11_KIT_VERSION="0.26.2-r0"
+# renovate: datasource=repology depName=alpine_3_24/openssl versioning=loose
+ARG OPENSSL_VERSION="3.5.8-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
 # --private-key, and --ca-certificate.
 RUN apk add --no-cache -q \
       "libexpat=${LIBEXPAT_VERSION}" \
-      "p11-kit=${P11_KIT_VERSION}" \
-      "p11-kit-trust=${P11_KIT_VERSION}" \
+      "libcrypto3=${OPENSSL_VERSION}" \
+      "libssl3=${OPENSSL_VERSION}" \
+      "openssl=${OPENSSL_VERSION}" \
       wget
 
 COPY --chown=nobody:nobody target/research-domain-agent.jar /app/research-domain-agent.jar

--- a/trust-center-agent/Dockerfile
+++ b/trust-center-agent/Dockerfile
@@ -1,19 +1,20 @@
 FROM eclipse-temurin:25.0.4_7-jre-alpine@sha256:3137541deb3cac6626b5d9a4a2187bc0d6a34312f858bd2c67dd01e732e6b682
 
 # Patch stale Alpine OS packages flagged by Trivy. Versions are pinned so
-# Renovate tracks updates (see renovate.json5). p11-kit and p11-kit-trust
-# share one version and must upgrade in lockstep.
+# Renovate tracks updates (see renovate.json5). openssl, libssl3 and
+# libcrypto3 share one version and must upgrade in lockstep.
 # renovate: datasource=repology depName=alpine_3_24/libexpat versioning=loose
 ARG LIBEXPAT_VERSION="2.8.4-r0"
-# renovate: datasource=repology depName=alpine_3_24/p11-kit versioning=loose
-ARG P11_KIT_VERSION="0.26.2-r0"
+# renovate: datasource=repology depName=alpine_3_24/openssl versioning=loose
+ARG OPENSSL_VERSION="3.5.8-r0"
 
 # GNU wget for mTLS-aware healthchecks; BusyBox wget lacks --certificate,
 # --private-key, and --ca-certificate.
 RUN apk add --no-cache -q \
       "libexpat=${LIBEXPAT_VERSION}" \
-      "p11-kit=${P11_KIT_VERSION}" \
-      "p11-kit-trust=${P11_KIT_VERSION}" \
+      "libcrypto3=${OPENSSL_VERSION}" \
+      "libssl3=${OPENSSL_VERSION}" \
+      "openssl=${OPENSSL_VERSION}" \
       wget
 
 COPY --chown=nobody:nobody target/trust-center-agent.jar /app/trust-center-agent.jar


### PR DESCRIPTION
Base image ships openssl 3.5.7-r0 and has not been rebuilt since the fix landed in Alpine. Drop the p11-kit pins, which the base image now satisfies on its own.

Fixes #1949