### PR TITLE
Test Deidentifhir Handlers Through the Registry

### DIFF
--- a/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
+++ b/clinical-domain-agent/src/main/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtils.java
@@ -126,7 +126,6 @@ public interface DeidentifhirUtils {
 
     void shiftCollectedDates() {
       dates.forEach(date -> shiftDate(date, provider));
-      dates.clear();
     }
   }
 }

--- a/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
+++ b/clinical-domain-agent/src/test/java/care/smith/fts/cda/services/deidentifhir/DeidentifhirUtilsTest.java
@@ -17,8 +17,10 @@ import java.io.IOException;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -191,12 +193,7 @@ class DeidentifhirUtilsTest {
               }
             }
             """);
-    var patient = new Patient();
-    patient.setId("id1");
-    patient
-        .getMeta()
-        .addProfile(
-            "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient");
+    var patient = patientWithProfile();
     patient.setBirthDateElement(new DateType("1990-01-01"));
     patient.setDeceased(new DateTimeType("2020-05-05T00:00:00Z"));
     var bundle = new Bundle();
@@ -211,5 +208,86 @@ class DeidentifhirUtilsTest {
     assertThat(p.getDeceasedDateTimeType().getExtensionByUrl(DATE_SHIFT_EXTENSION_URL)).isNull();
     assertThat(provider.getDateMappings()).containsValues("1990-01-01");
     assertThat(provider.getDateMappings()).hasSize(1);
+  }
+
+  @Test
+  void deidentifyGeneralizesBirthDateToMidMonth() {
+    var registry = buildRegistry(provider);
+    var config =
+        parseResources(
+            DeidentifhirUtilsTest.class, "CDtoTransportWithGeneralizeDateHandler.profile");
+    var bundle = new Bundle();
+    bundle
+        .addEntry()
+        .setResource(patientWithProfile().setBirthDateElement(new DateType("1980-05-17")));
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Patient p = (Patient) deidentifiedBundle.getEntryFirstRep().getResource();
+    assertThat(p.getBirthDateElement().getValueAsString()).isEqualTo("1980-05-15");
+  }
+
+  @Test
+  void deidentifyGeneralizesPostalCodeToThreeDigits() {
+    var registry = buildRegistry(provider);
+    var config =
+        parseResources(
+            DeidentifhirUtilsTest.class, "CDtoTransportWithGeneralizeDateHandler.profile");
+    var patient = patientWithProfile();
+    patient.addAddress().setPostalCode("12345");
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(patient);
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Patient p = (Patient) deidentifiedBundle.getEntryFirstRep().getResource();
+    assertThat(p.getAddressFirstRep().getPostalCode()).isEqualTo("123");
+  }
+
+  @Test
+  void deidentifyReplacesIdentifierOfConditionalReference() {
+    var registry = buildRegistry(provider);
+    var config =
+        parseString(
+            """
+            {
+              deidentiFHIR.profile.version=0.2
+              modules {
+                test_encounter {
+                  base = ["Encounter.id", "Encounter.subject.reference", "Encounter.meta.profile"]
+                  paths { "Encounter.subject.reference" { handler = conditionalReferencesReplacementHandler } }
+                  pattern = "Encounter.meta.profile contains 'https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung'"
+                }
+              }
+            }
+            """);
+    var encounter = new Encounter();
+    encounter.setId("enc1");
+    encounter
+        .getMeta()
+        .addProfile(
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung");
+    encounter.setSubject(new Reference("Patient?identifier=identifierSystem1|identifier1"));
+    var bundle = new Bundle();
+    bundle.addEntry().setResource(encounter);
+
+    Bundle deidentifiedBundle = deidentify(config, registry, bundle, "id1", meterRegistry);
+
+    Encounter e = (Encounter) deidentifiedBundle.getEntryFirstRep().getResource();
+    var reference = e.getSubject().getReference();
+    assertThat(reference).startsWith("Patient?identifier=identifierSystem1|");
+    var tId = reference.substring(reference.indexOf('|') + 1);
+    assertThat(tId).hasSize(21); // NanoId length
+    assertThat(provider.getIdMappings()).containsValue(tId);
+  }
+
+  private static Patient patientWithProfile() {
+    var patient = new Patient();
+    patient.setId("id1");
+    patient
+        .getMeta()
+        .addProfile(
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient");
+    return patient;
   }
 }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/services/deidentifhir/DeidentifhirUtilTest.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/services/deidentifhir/DeidentifhirUtilTest.java
@@ -5,6 +5,7 @@ import static care.smith.fts.rda.services.deidentifhir.DeidentifhirUtil.restoreS
 import static care.smith.fts.test.TestPatientGenerator.generateOnePatient;
 import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
 import static com.typesafe.config.ConfigFactory.parseResources;
+import static com.typesafe.config.ConfigFactory.parseString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.ume.deidentifhir.Registry;
@@ -21,6 +22,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +48,41 @@ class DeidentifhirUtilTest {
     assertThat(b.getEntry()).hasSize(1);
     assertThat(p.getId()).isEqualTo("Patient/pid1");
     assertThat(p.getIdentifierFirstRep().getValue()).isEqualTo("pidentifier1");
+  }
+
+  @Test
+  void deidentifyReplacesIdentifierOfConditionalReference() {
+    Registry registry = generateRegistry(Map.of("tidentifier1", "pidentifier1"));
+    var config =
+        parseString(
+            """
+            {
+              deidentiFHIR.profile.version=0.2
+              modules {
+                test_encounter {
+                  base = ["Encounter.id", "Encounter.subject.reference", "Encounter.meta.profile"]
+                  paths { "Encounter.subject.reference" { handler = conditionalReferencesReplacementHandler } }
+                  pattern = "Encounter.meta.profile contains 'https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung'"
+                }
+              }
+            }
+            """);
+    var encounter = new Encounter();
+    encounter.setId("enc1");
+    encounter
+        .getMeta()
+        .addProfile(
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-fall/StructureDefinition/KontaktGesundheitseinrichtung");
+    encounter.setSubject(new Reference("Patient?identifier=identifierSystem1|tidentifier1"));
+    var transportBundle = new Bundle();
+    transportBundle.addEntry().setResource(encounter);
+
+    var pseudomizedBundle =
+        DeidentifhirUtil.deidentify(config, registry, transportBundle, meterRegistry);
+
+    Encounter e = (Encounter) pseudomizedBundle.getEntryFirstRep().getResource();
+    assertThat(e.getSubject().getReference())
+        .isEqualTo("Patient?identifier=identifierSystem1|pidentifier1");
   }
 
   @Test


### PR DESCRIPTION
Closes #1961

`DeidentifhirUtilsTest.deidentifySucceeds` sent a bundle through the registry and
asserted that the output exists. A missing handler registration passed. This PR adds
tests that assert what each handler changes.

## Correction to the issue

The line numbers and the mutant list in the issue are stale. A fresh PIT run on
`care.smith.fts.cda.services.deidentifhir.*` and `care.smith.fts.rda.services.deidentifhir.*`
gave three surviving mutants, and none of them is the one the issue names:

| File:line | Mutant |
| --- | --- |
| `DeidentifhirUtils.java:53` | `addHander("conditionalReferencesReplacementHandler", ...)` removed |
| `DeidentifhirUtils.java:129` | `dates.clear()` removed |
| `DeidentifhirUtil.java:39` | `addHander("conditionalReferencesReplacementHandler", ...)` removed |

`generalizeDateHandler`, `shiftDateHandler` and `postalCodeHandler` already had no
surviving mutants. No profile in this repository maps a path to
`conditionalReferencesReplacementHandler`, so nothing exercised it.

The issue also expects `generalizeDateHandler` to turn `1980-05-17` into `1980`. The
handler does not truncate to the year. For DAY precision it calls `setDay(15)`, so the
value becomes `1980-05-15`. The test asserts the real behaviour.

## Changes

CDA `DeidentifhirUtilsTest`:

- `deidentifyGeneralizesBirthDateToMidMonth` — `1980-05-17` becomes `1980-05-15`.
- `deidentifyGeneralizesPostalCodeToThreeDigits` — `12345` becomes `123`.
- `deidentifyReplacesIdentifierOfConditionalReference` — `Patient?identifier=system|value`
  keeps the system and gets a generated tID as the value, and that tID appears in the
  ID mappings the CDA sends onward.

RDA `DeidentifhirUtilTest`:

- `deidentifyReplacesIdentifierOfConditionalReference` — `generateRegistry` maps the tID
  in a conditional reference back to the pseudonym.

The `shiftDateHandler` assertion through `deidentify` that the issue asks for already
exists, in `deidentifyKeepsDateShiftExtensionOnBirthDate` and
`deidentifyShiftsOnlyConfiguredDates`.

`DeidentifhirUtils`: removed the dead `dates.clear()` call. `buildRegistry` builds a new
`Registry` and a new `ShiftDateHandler` on every call, and `DeidentifhirStep` builds one
registry per patient bundle, so the collected list never outlives a single `deidentify`
pass. No test can kill that mutant.

## Result

PIT reports 0 surviving mutants in both target packages, down from 3.
