### PR TITLE
Restore Shifted Dates Before the Engine Pass

### DIFF
--- a/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStep.java
+++ b/research-domain-agent/src/main/java/care/smith/fts/rda/impl/DeidentifhirStep.java
@@ -38,16 +38,13 @@ class DeidentifhirStep implements Deidentificator {
     return fetchSecureMapping(bundle.transferId())
         .map(
             response -> {
+              // Restore shifted dates from TCA using tID extensions
+              DeidentifhirUtil.restoreShiftedDates(bundle.bundle(), response.dateShiftMap());
+
               // Apply ID replacement via deidentifhir
               var registry = generateRegistry(response.tidPidMap());
-              var deidentified =
-                  DeidentifhirUtil.deidentify(
-                      deidentifhirConfig, registry, bundle.bundle(), meterRegistry);
-
-              // Restore shifted dates from TCA using tID extensions
-              DeidentifhirUtil.restoreShiftedDates(deidentified, response.dateShiftMap());
-
-              return deidentified;
+              return DeidentifhirUtil.deidentify(
+                  deidentifhirConfig, registry, bundle.bundle(), meterRegistry);
             })
         .doOnNext(b -> log.trace("Total bundle entries: {}", b.getEntry().size()));
   }

--- a/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepIT.java
+++ b/research-domain-agent/src/test/java/care/smith/fts/rda/impl/DeidentifhirStepIT.java
@@ -4,6 +4,7 @@ import static care.smith.fts.test.MockServerUtil.APPLICATION_FHIR_JSON;
 import static care.smith.fts.test.MockServerUtil.clientConfig;
 import static care.smith.fts.test.MockServerUtil.jsonResponse;
 import static care.smith.fts.test.TestPatientGenerator.generateOnePatient;
+import static care.smith.fts.util.deidentifhir.DateShiftConstants.DATE_SHIFT_EXTENSION_URL;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -26,7 +27,10 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +41,9 @@ import reactor.core.publisher.Mono;
 @SpringBootTest
 @WireMockTest
 class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
+
+  private static final String MII_PATIENT_PROFILE =
+      "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient";
 
   @Autowired MeterRegistry meterRegistry;
   private WireMock wireMock;
@@ -104,6 +111,36 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
   }
 
   @Test
+  void deidentifyRestoresShiftedDates() {
+    var patient = new Patient();
+    patient.getMeta().addProfile(MII_PATIENT_PROFILE);
+    // The CDA nulls the date value and puts the tID in the extension, see DeidentifhirUtils.
+    var birthDate = new DateType();
+    birthDate.addExtension(DATE_SHIFT_EXTENSION_URL, new StringType("tId-birthDate"));
+    patient.setBirthDateElement(birthDate);
+
+    wireMock.register(
+        WireMock.post(urlPathEqualTo("/api/v2/rd/secure-mapping"))
+            .willReturn(
+                jsonResponse(
+                    """
+                    {
+                      "tidPidMap": {},
+                      "dateShiftMap": {"tId-birthDate": "2000-01-15"}
+                    }
+                    """)));
+
+    create(step.deidentify(new TransportBundle(wrapInOuterBundle(patient), "transferId")))
+        .assertNext(
+            b -> {
+              var inner = (Bundle) b.getEntryFirstRep().getResource();
+              var p = (Patient) inner.getEntryFirstRep().getResource();
+              assertThat(p.getBirthDateElement().getValueAsString()).isEqualTo("2000-01-15");
+            })
+        .verifyComplete();
+  }
+
+  @Test
   void deidentifySucceeds() {
     wireMock.register(
         WireMock.post(urlPathEqualTo("/api/v2/rd/secure-mapping"))
@@ -128,5 +165,15 @@ class DeidentifhirStepIT extends AbstractConnectionScenarioIT {
               assertThat(resource.getIdPart()).isEqualTo("pid1");
             })
         .verifyComplete();
+  }
+
+  private static Bundle wrapInOuterBundle(Resource... resources) {
+    var innerBundle = new Bundle();
+    for (var resource : resources) {
+      innerBundle.addEntry().setResource(resource);
+    }
+    var outerBundle = new Bundle();
+    outerBundle.addEntry().setResource(innerBundle);
+    return outerBundle;
   }
 }


### PR DESCRIPTION
Closes #1967

## What

`DeidentifhirStep` of the RDA called `restoreShiftedDates` after the Deidentifhir
engine pass. The engine drops the tID extension from date primitives, because the
profile lists `Patient.birthDate` but no extension path below it. The restore
therefore found no extension and never restored a date. The same mechanism forced
the CDA to add its tID extensions after its own engine pass, see `ShiftDateHandler`.

This moves the restore before the engine pass. The engine then carries the restored
value through.

## Mutation testing

`DeidentifhirStep`: 1 survivor before, 0 after.

`IdMapperStep` keeps 3 survivors, all of them equivalent mutants:

| Line | Mutant |
|------|--------|
| 150 | `RemoveConditional` on the ternary inside a `log.warn` argument |
| 155 | `RemoveConditional` on `if (shiftedDate == null)`, whose body is only a `log.warn` |

Both branches of each conditional return `Optional.ofNullable(shiftedDate)`. The only
difference is a log message, and the POM already lists `org.slf4j` under `avoidCallsTo`.
No test can observe the difference. An `Optional` chain was measured and only moves the
mutants: `.map(v -> v.getClass().getSimpleName())` gains an `EmptyObjectReturnVals`
survivor and `ifPresentOrElse` gains a `VoidMethodCall` survivor. Extraction into a
method named in `excludedMethods` does not help either, because PIT still mutates the
call site.

The `instanceof StringType` guard named in the issue is already killed by
`IdMapperStepIT.deidentifyHandlesNonStringTypeDateShiftExtension`.

Part of #1946